### PR TITLE
Fix CSS

### DIFF
--- a/primary.css
+++ b/primary.css
@@ -1,1 +1,17307 @@
-@media (prefers-color-scheme:dark){}@media (prefers-color-scheme:dark){}body{--theme-base-primary-color-h:27;--theme-base-primary-color-s:90%;--theme-base-primary-color-l:55%;--theme-base-primary-color-r:243.525;--theme-base-primary-color-g:129.9225;--theme-base-primary-color-b:36.975;--theme-button-color:var(--blue-600);--theme-button-hover-color:var(--blue-700);--theme-button-hover-background-color:var(--blue-050);--theme-button-active-background-color:var(--blue-100);--theme-button-selected-color:var(--blue-900);--theme-button-selected-background-color:var(--blue-200);--theme-button-filled-color:var(--powder-700);--theme-button-filled-background-color:var(--powder-100);--theme-button-filled-border-color:var(--powder-500);--theme-button-filled-hover-color:var(--powder-800);--theme-button-filled-hover-background-color:var(--powder-300);--theme-button-filled-active-background-color:var(--powder-400);--theme-button-filled-active-border-color:var(--powder-600);--theme-button-filled-selected-color:var(--powder-900);--theme-button-filled-selected-background-color:var(--powder-500);--theme-button-filled-selected-border-color:var(--powder-700);--theme-button-outlined-border-color:var(--blue-400);--theme-button-outlined-selected-border-color:var(--blue-600);--theme-button-primary-background-color:var(--blue-500);--theme-button-primary-hover-background-color:var(--blue-600);--theme-button-primary-active-background-color:var(--blue-700);--theme-button-primary-selected-background-color:var(--blue-800);--theme-background-color:var(--white);--theme-background-position:top left;--theme-background-repeat:repeat;--theme-background-size:auto;--theme-background-attachment:auto;--theme-content-background-color:var(--white);--theme-content-border-color:var(--black-100);--theme-header-background-color:var(--theme-primary-color);--theme-header-background-position:center left;--theme-header-background-repeat:repeat;--theme-header-background-size:auto;--theme-header-background-border-bottom:0;--theme-header-link-color:var(--theme-primary-color);--theme-header-sponsored-color:hsla(0,0%,100%,0.4);--theme-header-foreground-color:transparent;--theme-header-foreground-position:bottom right;--theme-header-foreground-repeat:no-repeat;--theme-header-foreground-size:auto;--theme-footer-background-color:hsl(210,8%,15%);--theme-footer-background-position:top left;--theme-footer-background-repeat:no-repeat;--theme-footer-background-size:auto;--theme-footer-background-border-top:0;--theme-footer-title-color:hsl(210,8%,75%);--theme-footer-text-color:hsl(210,8%,45%);--theme-footer-link-color:hsl(210,8%,55%);--theme-footer-link-color-hover:hsl(210,8%,65%);--theme-footer-link-color-active:hsl(27,90%,55%);--theme-footer-link-caret-color:var(--theme-footer-background-color);--theme-footer-divider-color:hsl(210,8%,25%);--theme-footer-padding-top:0;--theme-footer-padding-bottom:0;--theme-link-color:var(--blue-600);--theme-link-color-hover:var(--blue-500);--theme-link-color-visited:var(--blue-700);--theme-tag-color:var(--powder-700);--theme-tag-background-color:var(--powder-100);--theme-tag-border-color:transparent;--theme-tag-hover-color:var(--powder-800);--theme-tag-hover-background-color:var(--powder-200);--theme-tag-hover-border-color:transparent;--theme-body-font-family:var(--ff-sans);--theme-body-font-color:var(--black-800);--theme-post-title-font-family:var(--ff-sans);--theme-post-title-color:var(--theme-link-color);--theme-post-title-color-hover:var(--theme-link-color-hover);--theme-post-title-color-visited:var(--theme-link-color-visited);--theme-post-body-font-family:var(--ff-sans);--theme-post-owner-background-color:var(--theme-secondary-075);--theme-post-owner-new-background-color:var(--powder-200)}html,body{color:var(--theme-body-font-color);font-family:var(--theme-body-font-family);font-size:13px;line-height:1.30769231}@media (max-width:640px){html.html__responsive:not(.html__unpinned-leftnav) ,html.html__responsive:not(.html__unpinned-leftnav)  body{font-size:11px}}@media (max-width:640px){html.html__responsive.html__unpinned-leftnav ,html.html__responsive.html__unpinned-leftnav  body{font-size:11px}}body{box-sizing:border-box;min-height:100%;background-color:var(--white)}body *,body *:before,body *:after{box-sizing:inherit}.s-banner__body-pt{padding-top:93px}.s-banner{position:fixed;z-index:5049;top:0;right:0;left:0;width:100%;padding:12px;border-top:1px solid transparent;border-bottom:1px solid transparent;border-radius:0;box-shadow:none;color:var(--fc-medium);font-size:13px}.s-banner[aria-hidden="true"]{visibility:hidden;opacity:0;-webkit-transform:translate3d(0, -50px, 0);transform:translate3d(0, -50px, 0)}.s-banner[aria-hidden="false"]{visibility:visible;opacity:1;-webkit-transform:translate3d(0, 49px, 0);transform:translate3d(0, 49px, 0)}.s-banner.is-pinned{z-index:5051;-webkit-transform:translate3d(0, 0, 0);transform:translate3d(0, 0, 0)}.s-banner.s-banner__important{border-color:transparent;color:var(--white)}.s-banner--container{position:relative;width:100%;max-width:1060px;margin:0 auto}.s-btn{position:relative;display:inline-block;padding:.8em;color:var(--theme-button-color);border:1px solid transparent;border-radius:3px;background-color:transparent;outline:none;font-family:inherit;font-size:13px;font-weight:normal;line-height:1.15384615;text-align:center;text-decoration:none;cursor:pointer;user-select:none}body.theme-highcontrast .s-btn{border-color:currentColor}body.theme-highcontrast .s-btn:not(.s-btn__link):not(.s-btn__unset){text-decoration:none}button .s-btn,button[type="submit"] .s-btn,button[type="reset"] .s-btn{-webkit-appearance:button}.s-btn.grid{display:flex}.s-btn:hover,.s-btn:focus,.s-btn:active{color:var(--theme-button-hover-color);background:var(--theme-button-hover-background-color);text-decoration:none}.s-btn:active{background:var(--theme-button-active-background-color)}.s-btn:focus{outline:none;box-shadow:0 0 0 4px var(--focus-ring)}.s-btn[disabled]{opacity:.5;pointer-events:none;box-shadow:none !important}.s-btn.is-selected{color:var(--theme-button-selected-color);background:var(--theme-button-selected-background-color);box-shadow:none}.s-btn.is-selected:focus{box-shadow:0 0 0 4px var(--focus-ring)}.s-btn.s-btn__dropdown{padding-right:2em}.s-btn.s-btn__dropdown:after{content:"";position:absolute;z-index:30;top:calc(50% - 2px);right:.8em;border-style:solid;border-width:4px;border-top-width:4px;border-bottom-width:0;border-color:currentColor transparent;pointer-events:none}.s-btn.s-btn__xs{padding:.6em;font-size:11px}.s-btn.s-btn__xs.s-btn__dropdown{padding-right:1.5em}.s-btn.s-btn__xs.s-btn__dropdown:after{top:calc(50% - 2px);right:.6em;border-width:3px;border-top-width:3px;border-bottom-width:0}.s-btn.s-btn__sm{font-size:12px}.s-btn.s-btn__sm.s-btn__dropdown{padding-right:2.05em}.s-btn.s-btn__md{padding:.7em;border-radius:4px;font-size:1.30769231rem}.s-btn.s-btn__md.s-btn__dropdown{padding-right:1.8em}.s-btn.s-btn__md.s-btn__dropdown:after{top:calc(50% - 2px);right:.7em;border-width:5px;border-top-width:5px;border-bottom-width:0}.s-btn .s-btn--badge{opacity:.5;display:inline-block;border-radius:3px;padding:2px 3px;font-size:12px;line-height:1;background-color:currentColor}body.theme-highcontrast .s-btn .s-btn--badge{opacity:.8}.s-btn .s-btn--number{color:var(--white)}@media (prefers-color-scheme:dark){body.theme-system .s-btn__primary:not(.is-selected) .s-btn--number,body.theme-system .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number{color:var(--white)}}body.theme-dark .s-btn__primary:not(.is-selected) .s-btn--number,body.theme-dark .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number,.theme-dark__forced .s-btn__primary:not(.is-selected) .s-btn--number,.theme-dark__forced .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number{color:var(--white)}body.theme-highcontrast .s-btn__primary:not(.is-selected) .s-btn--number,body.theme-highcontrast .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number{color:var(--black)}.s-btn__outlined{border-color:var(--theme-button-outlined-border-color)}.s-btn__outlined.is-selected{border-color:var(--theme-button-outlined-selected-border-color)}.s-btn__filled{color:var(--theme-button-filled-color);background-color:var(--theme-button-filled-background-color);border-color:var(--theme-button-filled-border-color);box-shadow:inset 0 1px 0 0 hsla(0,0%,100%,0.7)}@media (prefers-color-scheme:dark){body.theme-system .s-btn__filled{box-shadow:none}}body.theme-dark .s-btn__filled,.theme-dark__forced .s-btn__filled{box-shadow:none}.s-btn__filled:hover,.s-btn__filled:focus,.s-btn__filled:active{color:var(--theme-button-filled-hover-color);background-color:var(--theme-button-filled-hover-background-color)}.s-btn__filled:active{background-color:var(--theme-button-filled-active-background-color);border-color:var(--theme-button-filled-active-border-color);box-shadow:none}body.theme-highcontrast .s-btn__filled:focus{box-shadow:0 0 0 4px var(--focus-ring)}.s-btn__filled.is-selected{color:var(--theme-button-filled-selected-color);background-color:var(--theme-button-filled-selected-background-color);border-color:var(--theme-button-filled-selected-border-color);box-shadow:none}.s-btn__muted{color:var(--black-500)}body.theme-highcontrast .s-btn__muted.s-btn__filled{border-color:transparent}.s-btn__muted:hover,.s-btn__muted:focus,.s-btn__muted:active{color:var(--black-600);background-color:var(--black-025)}.s-btn__muted:active{background:var(--black-050)}.s-btn__muted:focus{box-shadow:0 0 0 4px var(--focus-ring-muted)}.s-btn__muted.is-selected{color:var(--black-700);background-color:var(--black-075)}.s-btn__muted.is-selected:focus{box-shadow:0 0 0 4px var(--focus-ring-muted)}.s-btn__muted.s-btn__outlined{border-color:var(--black-300)}.s-btn__muted.s-btn__outlined.is-selected{border-color:var(--black-400)}.s-btn__muted.s-btn__filled{color:var(--black-700);background-color:var(--black-100);border-color:transparent;box-shadow:inset 0 1px 0 0 hsla(0,0%,100%,0.4)}@media (prefers-color-scheme:dark){body.theme-system .s-btn__muted.s-btn__filled{box-shadow:none}}body.theme-dark .s-btn__muted.s-btn__filled,.theme-dark__forced .s-btn__muted.s-btn__filled{box-shadow:none}body.theme-highcontrast .s-btn__muted.s-btn__filled{background-color:var(--black-400);border-color:transparent;color:var(--white)}body.theme-highcontrast .s-btn__muted.s-btn__filled .s-btn--number{color:var(--black)}.s-btn__muted.s-btn__filled:hover,.s-btn__muted.s-btn__filled:focus,.s-btn__muted.s-btn__filled:active{color:var(--black-700);background-color:var(--black-150)}.s-btn__muted.s-btn__filled:active{background-color:var(--black-200);box-shadow:none}.s-btn__muted.s-btn__filled:focus{box-shadow:0 0 0 4px var(--focus-ring-muted)}body.theme-highcontrast .s-btn__muted.s-btn__filled:focus{box-shadow:0 0 0 4px var(--focus-ring-muted)}.s-btn__muted.s-btn__filled.is-selected{color:var(--black-800);background-color:var(--black-350);box-shadow:none}body.theme-highcontrast .s-btn__muted.s-btn__filled.is-selected{background-color:var(--black-700)}body.theme-highcontrast .s-btn__muted.s-btn__filled.is-selected .s-btn--number{color:var(--black)}.s-btn__muted.s-btn__filled.is-selected:focus{box-shadow:0 0 0 4px var(--focus-ring-muted)}.s-btn__danger{color:var(--red-600)}body.theme-highcontrast .s-btn__danger.s-btn__filled{border-color:transparent}.s-btn__danger:hover,.s-btn__danger:focus,.s-btn__danger:active{color:var(--red-700);background-color:var(--red-050)}.s-btn__danger:active{background-color:var(--red-100)}.s-btn__danger:focus{box-shadow:0 0 0 4px var(--focus-ring-error)}body.theme-highcontrast .s-btn__danger:focus{box-shadow:0 0 0 4px var(--focus-ring-error)}.s-btn__danger.is-selected{color:var(--red-900);background-color:var(--red-200)}.s-btn__danger.is-selected:focus{box-shadow:0 0 0 4px var(--focus-ring-error)}.s-btn__danger.s-btn__outlined{border-color:var(--red-500)}.s-btn__danger.s-btn__outlined.is-selected{border-color:var(--red-600)}.s-btn__danger.s-btn__filled{color:hsl(0,0%,100%);background-color:var(--red-500);border-color:transparent;box-shadow:inset 0 1px 0 0 hsla(0,0%,100%,0.4)}@media (prefers-color-scheme:dark){body.theme-system .s-btn__danger.s-btn__filled{box-shadow:none}}body.theme-dark .s-btn__danger.s-btn__filled,.theme-dark__forced .s-btn__danger.s-btn__filled{box-shadow:none}body.theme-highcontrast .s-btn__danger.s-btn__filled{color:var(--white)}body.theme-highcontrast .s-btn__danger.s-btn__filled:focus{box-shadow:0 0 0 4px var(--focus-ring-error)}body.theme-highcontrast .s-btn__danger.s-btn__filled .s-btn--number{color:var(--black)}.s-btn__danger.s-btn__filled:hover,.s-btn__danger.s-btn__filled:focus,.s-btn__danger.s-btn__filled:active{color:hsl(0,0%,100%);background-color:var(--red-600)}.s-btn__danger.s-btn__filled:active{background-color:var(--red-700);box-shadow:none}.s-btn__danger.s-btn__filled:focus{box-shadow:0 0 0 4px var(--focus-ring-error)}.s-btn__danger.s-btn__filled.is-selected{color:var(--white);background-color:var(--red-800);box-shadow:none}.s-btn__danger.s-btn__filled.is-selected:focus{box-shadow:0 0 0 4px var(--focus-ring-error)}body.theme-highcontrast .s-btn__danger.s-btn__filled.is-selected .s-btn--number{color:var(--black)}.s-btn__danger.s-btn__filled .s-btn--number{color:var(--black-900)}.s-btn__primary{color:var(--theme-button-primary-color);background-color:var(--theme-button-primary-background-color);box-shadow:inset 0 1px 0 0 hsla(0,0%,100%,0.4)}@media (prefers-color-scheme:dark){body.theme-system .s-btn__primary{box-shadow:none}body.theme-system .s-btn__primary:not(.is-selected){color:var(--black)}}body.theme-dark .s-btn__primary,.theme-dark__forced .s-btn__primary{box-shadow:none}body.theme-dark .s-btn__primary:not(.is-selected),.theme-dark__forced .s-btn__primary:not(.is-selected){color:var(--black)}body.theme-highcontrast .s-btn__primary:not(.is-selected){border-color:transparent;color:var(--white)}.s-btn__primary:hover,.s-btn__primary:focus,.s-btn__primary:active{color:var(--theme-button-primary-hover-color);background-color:var(--theme-button-primary-hover-background-color)}.s-btn__primary:active{background-color:var(--theme-button-primary-active-background-color);box-shadow:none}body.theme-highcontrast .s-btn__primary:focus{box-shadow:0 0 0 4px var(--focus-ring)}.s-btn__primary.is-selected{color:var(--theme-button-primary-selected-color);background-color:var(--theme-button-primary-selected-background-color)}.s-btn__primary .s-btn--number{color:var(--theme-button-primary-number-color)}.s-btn__google{border-color:var(--bc-medium);background-color:var(--white);color:var(--black-700)}.s-btn__google:hover,.s-btn__google:focus{border-color:var(--bc-darker);background-color:var(--black-025);color:var(--black-800)}.s-btn__google:active{background-color:var(--black-050);color:var(--black-900)}.s-btn__google:focus{box-shadow:0 0 0 4px var(--focus-ring-muted)}.s-btn__facebook{border-color:transparent;background-color:#385499;color:#fff}body.theme-highcontrast .s-btn__facebook{border-color:transparent}.s-btn__facebook:hover,.s-btn__facebook:focus{background-color:#314a86;color:#fff}.s-btn__facebook:active{background-color:#2a4074;color:#fff}.s-btn__github{background-color:var(--black-750);color:var(--white)}body.theme-highcontrast .s-btn__github{border-color:transparent}.s-btn__github:hover,.s-btn__github:focus{background-color:var(--black-800);color:var(--white)}.s-btn__github:active{background-color:var(--black-900);color:var(--white)}.s-btn__github:focus{box-shadow:0 0 0 4px var(--focus-ring-muted)}.s-btn__unset,.s-btn__unset:hover,.s-btn__unset:active,.s-btn__unset:focus{padding:0;border:none;outline:none;font:unset;border-radius:0;color:unset;background:none;box-shadow:none;cursor:default;user-select:auto}.s-btn__link{display:inline;padding:0;border:none;border-radius:0;outline:none;font:inherit;background:none;box-shadow:none;text-align:inherit;text-decoration:none;color:var(--theme-link-color);cursor:pointer;user-select:auto}body.theme-highcontrast .s-btn__link{text-decoration:underline}.s-btn__link.s-link__visited:visited{color:var(--theme-link-color-visited)}.s-btn__link:hover,.s-btn__link.s-link__visited:hover,.s-btn__link:active,.s-btn__link.s-link__visited:active{color:var(--theme-link-color-hover)}.s-btn__link.s-link__grayscale{color:var(--black-800)}.s-btn__link.s-link__grayscale.s-link__visited:visited{color:var(--black-700)}.s-btn__link.s-link__grayscale:hover,.s-btn__link.s-link__grayscale.s-link__visited:hover,.s-btn__link.s-link__grayscale:active,.s-btn__link.s-link__grayscale.s-link__visited:active{color:var(--black-900)}.s-btn__link.s-link__muted{color:var(--black-500)}.s-btn__link.s-link__muted.s-link__visited:visited{color:var(--black-700)}.s-btn__link.s-link__muted:hover,.s-btn__link.s-link__muted.s-link__visited:hover,.s-btn__link.s-link__muted:active,.s-btn__link.s-link__muted.s-link__visited:active{color:var(--black-600)}.s-btn__link.s-link__danger{color:var(--red-500)}.s-btn__link.s-link__danger.s-link__visited:visited{color:var(--red-600)}.s-btn__link.s-link__danger:hover,.s-btn__link.s-link__danger.s-link__visited:hover,.s-btn__link.s-link__danger:active,.s-btn__link.s-link__danger.s-link__visited:active{color:var(--red-400)}.s-btn__link.s-link__inherit{color:inherit !important}.s-btn__link.s-link__inherit:hover,.s-btn__link.s-link__inherit:active,.s-btn__link.s-link__inherit.s-link__visited:visited{color:inherit !important}.s-btn__link.s-link__underlined{text-decoration:underline !important}.s-btn__link.s-link__dropdown{position:relative;padding-right:.9em}.s-btn__link.s-link__dropdown:after{content:"";position:absolute;z-index:30;top:calc(50% - 2px);right:0;border-style:solid;border-width:4px;border-top-width:4px;border-bottom-width:0;border-color:currentColor transparent;pointer-events:none}.s-btn__link:hover,.s-btn__link:active,.s-btn__link:focus,.s-btn__link[disabled]{background:none;box-shadow:none}.s-btn__link.s-btn__dropdown{padding-right:.9em}.s-btn__link.s-btn__dropdown:after{right:0}.s-btn__icon .svg-icon{vertical-align:baseline;margin-top:-0.3em;margin-bottom:-0.3em;transition:opacity 200ms cubic-bezier(.165, .84, .44, 1)}.s-btn.is-loading{padding-left:2.2em}.s-btn.is-loading:before{content:"";position:absolute;opacity:.3;left:.6em;top:calc(50% - .6em);width:1.23076923em;height:1.23076923em;border-width:2px;border-style:solid;border-color:currentColor;border-radius:50%}.s-btn.is-loading:after{content:"";position:absolute;left:.6em;top:calc(50% - .6em);width:1.23076923em;height:1.23076923em;border-width:2px;border-style:solid;border-color:transparent;border-left-color:currentColor;border-radius:50%;animation:s-spinner-rotate .9s infinite cubic-bezier(.5, .1, .5, .9);filter:invert(0);transform-origin:50% 50% 1px}.s-btn.is-loading .svg-icon:first-child{margin-left:-23px;opacity:0}a,.s-link{text-decoration:none;color:var(--theme-link-color);cursor:pointer;user-select:auto}body.theme-highcontrast a,body.theme-highcontrast .s-link{text-decoration:underline}a.s-link__visited:visited,.s-link.s-link__visited:visited{color:var(--theme-link-color-visited)}a:hover,.s-link:hover,a.s-link__visited:hover,.s-link.s-link__visited:hover,a:active,.s-link:active,a.s-link__visited:active,.s-link.s-link__visited:active{color:var(--theme-link-color-hover)}a.s-link__grayscale,.s-link.s-link__grayscale{color:var(--black-800)}a.s-link__grayscale.s-link__visited:visited,.s-link.s-link__grayscale.s-link__visited:visited{color:var(--black-700)}a.s-link__grayscale:hover,.s-link.s-link__grayscale:hover,a.s-link__grayscale.s-link__visited:hover,.s-link.s-link__grayscale.s-link__visited:hover,a.s-link__grayscale:active,.s-link.s-link__grayscale:active,a.s-link__grayscale.s-link__visited:active,.s-link.s-link__grayscale.s-link__visited:active{color:var(--black-900)}a.s-link__muted,.s-link.s-link__muted{color:var(--black-500)}a.s-link__muted.s-link__visited:visited,.s-link.s-link__muted.s-link__visited:visited{color:var(--black-700)}a.s-link__muted:hover,.s-link.s-link__muted:hover,a.s-link__muted.s-link__visited:hover,.s-link.s-link__muted.s-link__visited:hover,a.s-link__muted:active,.s-link.s-link__muted:active,a.s-link__muted.s-link__visited:active,.s-link.s-link__muted.s-link__visited:active{color:var(--black-600)}a.s-link__danger,.s-link.s-link__danger{color:var(--red-500)}a.s-link__danger.s-link__visited:visited,.s-link.s-link__danger.s-link__visited:visited{color:var(--red-600)}a.s-link__danger:hover,.s-link.s-link__danger:hover,a.s-link__danger.s-link__visited:hover,.s-link.s-link__danger.s-link__visited:hover,a.s-link__danger:active,.s-link.s-link__danger:active,a.s-link__danger.s-link__visited:active,.s-link.s-link__danger.s-link__visited:active{color:var(--red-400)}a.s-link__inherit,.s-link.s-link__inherit{color:inherit !important}a.s-link__inherit:hover,.s-link.s-link__inherit:hover,a.s-link__inherit:active,.s-link.s-link__inherit:active,a.s-link__inherit.s-link__visited:visited,.s-link.s-link__inherit.s-link__visited:visited{color:inherit !important}a.s-link__underlined,.s-link.s-link__underlined{text-decoration:underline !important}a.s-link__dropdown,.s-link.s-link__dropdown{position:relative;padding-right:.9em}a.s-link__dropdown:after,.s-link.s-link__dropdown:after{content:"";position:absolute;z-index:30;top:calc(50% - 2px);right:0;border-style:solid;border-width:4px;border-top-width:4px;border-bottom-width:0;border-color:currentColor transparent;pointer-events:none}button.s-link{-webkit-appearance:none;-moz-appearance:none;background:transparent;border:0;padding:0;line-height:inherit;user-select:auto;font-family:inherit}button.s-link:focus{outline:none}.s-anchors.s-anchors__underlined a:not(.s-link),.s-anchors.s-anchors__underlined .s-btn.s-btn__link{text-decoration:underline}.s-anchors.s-anchors__default a:not(.s-link),.s-anchors .s-anchors.s-anchors__default a:not(.s-link),.s-anchors.s-anchors__default .s-btn.s-btn__link,.s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link{color:var(--theme-link-color)}.s-anchors.s-anchors__default a:not(.s-link):hover,.s-anchors .s-anchors.s-anchors__default a:not(.s-link):hover,.s-anchors.s-anchors__default .s-btn.s-btn__link:hover,.s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:hover,.s-anchors.s-anchors__default a:not(.s-link):active,.s-anchors .s-anchors.s-anchors__default a:not(.s-link):active,.s-anchors.s-anchors__default .s-btn.s-btn__link:active,.s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:active{color:var(--theme-link-color-hover)}.s-anchors.s-anchors__default a:not(.s-link):visited,.s-anchors .s-anchors.s-anchors__default a:not(.s-link):visited,.s-anchors.s-anchors__default .s-btn.s-btn__link:visited,.s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:visited{color:var(--theme-link-color)}.s-anchors.s-anchors__default a:not(.s-link):visited:hover,.s-anchors .s-anchors.s-anchors__default a:not(.s-link):visited:hover,.s-anchors.s-anchors__default .s-btn.s-btn__link:visited:hover,.s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:visited:hover,.s-anchors.s-anchors__default a:not(.s-link):visited:active,.s-anchors .s-anchors.s-anchors__default a:not(.s-link):visited:active,.s-anchors.s-anchors__default .s-btn.s-btn__link:visited:active,.s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:visited:active{color:var(--theme-link-color-hover)}.s-anchors.s-anchors__grayscale a:not(.s-link),.s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link),.s-anchors.s-anchors__grayscale .s-btn.s-btn__link,.s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link{color:var(--black-700)}.s-anchors.s-anchors__grayscale a:not(.s-link):hover,.s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):hover,.s-anchors.s-anchors__grayscale .s-btn.s-btn__link:hover,.s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:hover,.s-anchors.s-anchors__grayscale a:not(.s-link):active,.s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):active,.s-anchors.s-anchors__grayscale .s-btn.s-btn__link:active,.s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:active{color:var(--black-600)}.s-anchors.s-anchors__grayscale a:not(.s-link):visited,.s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):visited,.s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited,.s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited{color:var(--black-700)}.s-anchors.s-anchors__grayscale a:not(.s-link):visited:hover,.s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):visited:hover,.s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited:hover,.s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited:hover,.s-anchors.s-anchors__grayscale a:not(.s-link):visited:active,.s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):visited:active,.s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited:active,.s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited:active{color:var(--black-600)}.s-anchors.s-anchors__inherit a:not(.s-link),.s-anchors .s-anchors.s-anchors__inherit a:not(.s-link),.s-anchors.s-anchors__inherit .s-btn.s-btn__link,.s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link{color:inherit}.s-anchors.s-anchors__inherit a:not(.s-link):hover,.s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):hover,.s-anchors.s-anchors__inherit .s-btn.s-btn__link:hover,.s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:hover,.s-anchors.s-anchors__inherit a:not(.s-link):active,.s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):active,.s-anchors.s-anchors__inherit .s-btn.s-btn__link:active,.s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:active{color:inherit}.s-anchors.s-anchors__inherit a:not(.s-link):visited,.s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):visited,.s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited,.s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited{color:inherit}.s-anchors.s-anchors__inherit a:not(.s-link):visited:hover,.s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):visited:hover,.s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited:hover,.s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited:hover,.s-anchors.s-anchors__inherit a:not(.s-link):visited:active,.s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):visited:active,.s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited:active,.s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited:active{color:inherit}.s-anchors.s-anchors__muted a:not(.s-link),.s-anchors .s-anchors.s-anchors__muted a:not(.s-link),.s-anchors.s-anchors__muted .s-btn.s-btn__link,.s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link{color:var(--black-500)}.s-anchors.s-anchors__muted a:not(.s-link):hover,.s-anchors .s-anchors.s-anchors__muted a:not(.s-link):hover,.s-anchors.s-anchors__muted .s-btn.s-btn__link:hover,.s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:hover,.s-anchors.s-anchors__muted a:not(.s-link):active,.s-anchors .s-anchors.s-anchors__muted a:not(.s-link):active,.s-anchors.s-anchors__muted .s-btn.s-btn__link:active,.s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:active{color:var(--black-400)}.s-anchors.s-anchors__muted a:not(.s-link):visited,.s-anchors .s-anchors.s-anchors__muted a:not(.s-link):visited,.s-anchors.s-anchors__muted .s-btn.s-btn__link:visited,.s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited{color:var(--black-500)}.s-anchors.s-anchors__muted a:not(.s-link):visited:hover,.s-anchors .s-anchors.s-anchors__muted a:not(.s-link):visited:hover,.s-anchors.s-anchors__muted .s-btn.s-btn__link:visited:hover,.s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited:hover,.s-anchors.s-anchors__muted a:not(.s-link):visited:active,.s-anchors .s-anchors.s-anchors__muted a:not(.s-link):visited:active,.s-anchors.s-anchors__muted .s-btn.s-btn__link:visited:active,.s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited:active{color:var(--black-400)}.s-anchors.s-anchors__danger a:not(.s-link),.s-anchors .s-anchors.s-anchors__danger a:not(.s-link),.s-anchors.s-anchors__danger .s-btn.s-btn__link,.s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link{color:var(--red-500)}.s-anchors.s-anchors__danger a:not(.s-link):hover,.s-anchors .s-anchors.s-anchors__danger a:not(.s-link):hover,.s-anchors.s-anchors__danger .s-btn.s-btn__link:hover,.s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:hover,.s-anchors.s-anchors__danger a:not(.s-link):active,.s-anchors .s-anchors.s-anchors__danger a:not(.s-link):active,.s-anchors.s-anchors__danger .s-btn.s-btn__link:active,.s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:active{color:var(--red-400)}.s-anchors.s-anchors__danger a:not(.s-link):visited,.s-anchors .s-anchors.s-anchors__danger a:not(.s-link):visited,.s-anchors.s-anchors__danger .s-btn.s-btn__link:visited,.s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited{color:var(--red-500)}.s-anchors.s-anchors__danger a:not(.s-link):visited:hover,.s-anchors .s-anchors.s-anchors__danger a:not(.s-link):visited:hover,.s-anchors.s-anchors__danger .s-btn.s-btn__link:visited:hover,.s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited:hover,.s-anchors.s-anchors__danger a:not(.s-link):visited:active,.s-anchors .s-anchors.s-anchors__danger a:not(.s-link):visited:active,.s-anchors.s-anchors__danger .s-btn.s-btn__link:visited:active,.s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited:active{color:var(--red-400)}.s-block-link{display:block;width:100%;color:var(--black-600);padding:6px 12px;cursor:pointer;border:none;background:transparent;border-radius:0;text-align:left;line-height:inherit;font-family:inherit}.s-block-link:hover,.s-block-link:active{color:var(--black-800)}.s-block-link:focus:not(:focus-visible){outline:none;box-shadow:none}.s-block-link:focus-visible{outline:none;box-shadow:0 0 0 4px var(--focus-ring-muted)}.s-block-link.is-selected{color:var(--black-800);font-weight:bold;background-color:var(--black-050)}@media (prefers-color-scheme:dark){body.theme-system .s-block-link.is-selected{background-color:var(--black-025)}}body.theme-dark .s-block-link.is-selected,.theme-dark__forced .s-block-link.is-selected{background-color:var(--black-025)}.s-block-link.is-selected.s-block-link__right{box-shadow:inset -3px 0 0 var(--theme-primary-color)}.s-block-link.is-selected.s-block-link__left{box-shadow:inset 3px 0 0 var(--theme-primary-color)}.s-block-link.s-block-link__danger{color:var(--red-500)}.s-block-link.s-block-link__danger:hover,.s-block-link.s-block-link__danger:active{color:var(--red-700)}.s-link-preview{border:1px solid var(--bc-medium);border-radius:3px;text-align:left;box-shadow:var(--bs-sm)}.s-link-preview--header{display:flex;background:var(--black-025);border-top-left-radius:3px;border-top-right-radius:3px;border-bottom:1px solid var(--bc-medium);padding:12px 8px}.s-link-preview--icon{margin-right:8px;color:var(--black-800)}.s-link-preview--title{font-size:1.30769231rem;font-weight:bold;color:var(--black-900)}a.s-link-preview--title{text-decoration:none;color:var(--theme-link-color);cursor:pointer}a.s-link-preview--title.s-link__visited:visited{color:var(--theme-link-color);text-decoration:none}body.theme-highcontrast a.s-link-preview--title.s-link__visited:visited{text-decoration:underline}a.s-link-preview--title:hover,a.s-link-preview--title.s-link__visited:hover,a.s-link-preview--title:active,a.s-link-preview--title.s-link__visited:active{color:var(--theme-link-color-hover);text-decoration:none}body.theme-highcontrast a.s-link-preview--title:hover,body.theme-highcontrast a.s-link-preview--title.s-link__visited:hover,body.theme-highcontrast a.s-link-preview--title:active,body.theme-highcontrast a.s-link-preview--title.s-link__visited:active{text-decoration:underline}.s-link-preview--details{font-size:12px;color:var(--black-500);margin-top:2px}@media (max-width:640px){html.html__responsive:not(.html__unpinned-leftnav) .s-link-preview--details{margin-top:4px}}@media (max-width:640px){html.html__responsive.html__unpinned-leftnav .s-link-preview--details{margin-top:4px}}.s-link-preview--body{padding:12px;font-size:1.15384615rem}.s-link-preview--body *:last-child{margin-bottom:0}.s-link-preview--code pre{border-radius:0 !important;margin:0;max-height:400px}.s-link-preview--footer{display:flex;justify-content:space-between;background:var(--black-025);border-bottom-left-radius:3px;border-bottom-right-radius:3px;border-top:1px solid var(--bc-medium);padding:12px;font-size:12px}@media (max-width:640px){html.html__responsive:not(.html__unpinned-leftnav) .s-link-preview--footer{flex-direction:column}}@media (max-width:640px){html.html__responsive.html__unpinned-leftnav .s-link-preview--footer{flex-direction:column}}.s-link-preview--url{overflow:hidden;max-width:100%;text-overflow:ellipsis !important;white-space:nowrap}.s-link-preview--misc{color:var(--black-500);padding-left:4px}@media (max-width:640px){html.html__responsive:not(.html__unpinned-leftnav) .s-link-preview--misc{padding-left:0;padding-top:2px}}@media (max-width:640px){html.html__responsive.html__unpinned-leftnav .s-link-preview--misc{padding-left:0;padding-top:2px}}.s-link-preview--details a,.s-link-preview--footer a{text-decoration:none;cursor:pointer;color:var(--black-500)}.s-link-preview--details a:visited,.s-link-preview--footer a:visited{color:var(--black-700)}.s-link-preview--details a:hover,.s-link-preview--footer a:hover,.s-link-preview--details a:active,.s-link-preview--footer a:active,.s-link-preview--details a:focus,.s-link-preview--footer a:focus{color:var(--black-600)}.s-notice{padding:16px;border:1px solid transparent;border-radius:3px;color:var(--fc-medium);font-size:13px}.s-toast .s-notice{max-width:44rem;width:100%;padding-top:8px;padding-bottom:8px;box-shadow:var(--bs-sm);pointer-events:all}.s-notice .s-notice--btn{color:var(--fc-dark);padding:8px}.s-notice__info,.s-banner__info{border-color:var(--theme-secondary-150);background-color:var(--theme-secondary-050)}.s-notice__info.s-notice__important,.s-banner__info.s-notice__important,.s-notice__info.s-banner__important,.s-banner__info.s-banner__important{background-color:var(--theme-secondary-400)}.s-notice__info .s-notice--btn:focus,.s-banner__info .s-notice--btn:focus,.s-notice__info .s-notice--btn:hover,.s-banner__info .s-notice--btn:hover{background-color:var(--theme-secondary-300)}.s-notice__info .s-notice--btn:active,.s-banner__info .s-notice--btn:active{background-color:var(--theme-secondary-400)}.s-notice__info code,.s-banner__info code{background-color:var(--theme-secondary-150)}.s-notice__success,.s-banner__success{border-color:var(--green-200);background-color:var(--green-050)}body.theme-highcontrast .s-notice__success,body.theme-highcontrast .s-banner__success{background-color:var(--green-200);border-color:var(--green-400)}.s-notice__success.s-notice__important,.s-banner__success.s-notice__important,.s-notice__success.s-banner__important,.s-banner__success.s-banner__important{background-color:var(--green-400);color:var(--black-900)}body.theme-highcontrast .s-notice__success.s-notice__important,body.theme-highcontrast .s-banner__success.s-notice__important,body.theme-highcontrast .s-notice__success.s-banner__important,body.theme-highcontrast .s-banner__success.s-banner__important{background-color:var(--green-500);color:var(--white);border-color:transparent}.s-notice__success .s-notice--btn:focus,.s-banner__success .s-notice--btn:focus,.s-notice__success .s-notice--btn:hover,.s-banner__success .s-notice--btn:hover{background-color:var(--green-100)}.s-notice__success .s-notice--btn:active,.s-banner__success .s-notice--btn:active{background-color:var(--green-200)}.s-notice__warning,.s-banner__warning{border-color:var(--yellow-300);background-color:var(--yellow-050)}body.theme-highcontrast .s-notice__warning,body.theme-highcontrast .s-banner__warning{background-color:var(--yellow-200);border-color:var(--yellow-700)}.s-notice__warning.s-notice__important,.s-banner__warning.s-notice__important,.s-notice__warning.s-banner__important,.s-banner__warning.s-banner__important{background-color:var(--yellow-400);color:var(--black-900)}body.theme-highcontrast .s-notice__warning.s-notice__important,body.theme-highcontrast .s-banner__warning.s-notice__important,body.theme-highcontrast .s-notice__warning.s-banner__important,body.theme-highcontrast .s-banner__warning.s-banner__important{background-color:var(--yellow-500);color:var(--white);border-color:transparent}.s-notice__warning .s-notice--btn:focus,.s-banner__warning .s-notice--btn:focus,.s-notice__warning .s-notice--btn:hover,.s-banner__warning .s-notice--btn:hover{background-color:var(--yellow-200)}.s-notice__warning .s-notice--btn:active,.s-banner__warning .s-notice--btn:active{background-color:var(--yellow-300)}.s-notice__warning code,.s-banner__warning code{background-color:var(--yellow-200)}.s-notice__danger,.s-banner__danger{border-color:var(--red-200);background-color:var(--red-050)}body.theme-highcontrast .s-notice__danger,body.theme-highcontrast .s-banner__danger{background-color:var(--red-200);border-color:var(--red-500)}body.theme-highcontrast .s-notice__danger.s-notice__important,body.theme-highcontrast .s-banner__danger.s-notice__important,body.theme-highcontrast .s-notice__danger.s-banner__important,body.theme-highcontrast .s-banner__danger.s-banner__important{background-color:var(--red-500)}.s-notice__danger.s-notice__important,.s-banner__danger.s-notice__important,.s-notice__danger.s-banner__important,.s-banner__danger.s-banner__important{background-color:var(--red-400)}.s-notice__danger .s-notice--btn:focus,.s-banner__danger .s-notice--btn:focus,.s-notice__danger .s-notice--btn:hover,.s-banner__danger .s-notice--btn:hover{background-color:var(--red-100)}.s-notice__danger .s-notice--btn:active,.s-banner__danger .s-notice--btn:active{background-color:var(--red-200)}.s-notice__important{border-color:transparent;background-color:var(--black-700);color:var(--white)}@media (prefers-color-scheme:dark){body.theme-system .s-notice__info,body.theme-system .s-notice__success,body.theme-system .s-notice__warning,body.theme-system .s-notice__danger{border-color:transparent}}body.theme-dark .s-notice__info,body.theme-dark .s-notice__success,body.theme-dark .s-notice__warning,body.theme-dark .s-notice__danger,.theme-dark__forced .s-notice__info,.theme-dark__forced .s-notice__success,.theme-dark__forced .s-notice__warning,.theme-dark__forced .s-notice__danger{border-color:transparent}body.theme-highcontrast .s-notice__info,body.theme-highcontrast .s-notice__success,body.theme-highcontrast .s-notice__warning,body.theme-highcontrast .s-notice__danger{border-color:currentColor}.s-toast{visibility:hidden;position:fixed;display:flex;justify-content:center;top:16px;left:8px;right:8px;opacity:0;z-index:9001;transform:translate3d(0, -66px, 0);transition:transform 100ms cubic-bezier(.25, .46, .45, .94) 0s,opacity 60ms cubic-bezier(.25, .46, .45, .94) 0ms,visibility 0s 150ms;pointer-events:none}.s-toast[aria-hidden="false"]{visibility:visible;opacity:1;transform:translate3d(0, 0, 0);transition:visibility 0s 0s,opacity 100ms cubic-bezier(.165, .84, .44, 1) 0s,transform 100ms cubic-bezier(.165, .84, .44, 1) 0s}@media (prefers-reduced-motion){.s-toast{transform:none}}.s-tag{display:inline-flex;align-items:center;justify-content:center;min-width:0;padding-left:4px;padding-right:4px;border-style:solid;border-width:1px;border-radius:3px;font-size:12px;line-height:1.84615385;text-decoration:none;vertical-align:middle;white-space:nowrap;border-color:var(--theme-tag-border-color);background-color:var(--theme-tag-background-color);color:var(--theme-tag-color)}body.theme-highcontrast .s-tag{border-color:currentColor}.s-tag .s-tag--dismiss{color:inherit;background-color:transparent}.s-tag .s-tag--dismiss:hover{color:var(--theme-tag-background-color);background-color:var(--theme-tag-color)}body.theme-highcontrast .s-tag .s-tag--dismiss:hover{color:var(--white)}body.theme-highcontrast .s-tag{text-decoration:none}.s-tag.is-selected{border-color:transparent;background-color:var(--theme-secondary-200);color:var(--theme-secondary-900)}body.theme-highcontrast .s-tag.is-selected{border-color:currentColor}.s-tag.s-tag__xs{font-size:11px;line-height:1.4;padding-left:2px;padding-right:2px}.s-tag.s-tag__sm{font-size:12px;line-height:1.5}.s-tag.s-tag__md{padding-left:6px;padding-right:6px;font-size:1.15384615rem;line-height:1.73333333}.s-tag.s-tag__lg{padding-left:6px;padding-right:6px;border-radius:4px;font-size:1.46153846rem;line-height:1.68421053}a.s-tag:not(.is-selected):hover,a.s-tag:not(.is-selected):focus,a.s-tag:not(.is-selected):active,body.theme-custom .post-tag:not(.is-selected):hover,body.theme-custom .post-tag:not(.is-selected):focus,body.theme-custom .post-tag:not(.is-selected):active{border-color:var(--theme-tag-hover-border-color);background-color:var(--theme-tag-hover-background-color);color:var(--theme-tag-hover-color)}body.theme-highcontrast a.s-tag:not(.is-selected):hover,body.theme-highcontrast a.s-tag:not(.is-selected):focus,body.theme-highcontrast a.s-tag:not(.is-selected):active,body.theme-highcontrast body.theme-custom .post-tag:not(.is-selected):hover,body.theme-highcontrast body.theme-custom .post-tag:not(.is-selected):focus,body.theme-highcontrast body.theme-custom .post-tag:not(.is-selected):active{border-color:currentColor}.s-tag--dismiss{display:flex;align-content:center;align-self:center;justify-content:center;width:16px;height:16px;margin-left:4px;padding:1px;border-radius:3px;cursor:pointer}.s-tag--dismiss:hover{color:var(--white)}.s-tag--sponsor{display:inline-flex;align-self:center;margin:-3px 4px -2px -2px;max-width:18px;border-radius:2px}.s-tag--sponsor .svg-icon,.s-tag--sponsor img{width:100%;height:100%}.s-tag__required{border-color:var(--bc-darker);background-color:var(--black-075);color:var(--black-700)}body.theme-highcontrast .s-tag__required{border-color:currentColor}.s-tag__required .s-tag--dismiss{color:inherit;background-color:transparent}.s-tag__required .s-tag--dismiss:hover{color:var(--black-075);background-color:var(--black-700)}body.theme-highcontrast .s-tag__required .s-tag--dismiss:hover{color:var(--white)}.s-tag__required.is-selected{border-color:var(--black-500);background-color:var(--black-200);color:var(--black-900)}body.theme-highcontrast .s-tag__required.is-selected{border-color:currentColor}a.s-tag__required:not(.is-selected):hover,a.s-tag__required:not(.is-selected):focus,a.s-tag__required:not(.is-selected):active,body.theme-custom .required-tag:not(.is-selected):hover,body.theme-custom .required-tag:not(.is-selected):focus,body.theme-custom .required-tag:not(.is-selected):active{border-color:var(--black-300);background-color:var(--black-100);color:var(--black-800)}body.theme-highcontrast a.s-tag__required:not(.is-selected):hover,body.theme-highcontrast a.s-tag__required:not(.is-selected):focus,body.theme-highcontrast a.s-tag__required:not(.is-selected):active,body.theme-highcontrast body.theme-custom .required-tag:not(.is-selected):hover,body.theme-highcontrast body.theme-custom .required-tag:not(.is-selected):focus,body.theme-highcontrast body.theme-custom .required-tag:not(.is-selected):active{border-color:currentColor}.s-tag__moderator{border-color:var(--red-200);background-color:var(--red-050);color:var(--red-800)}body.theme-highcontrast .s-tag__moderator{border-color:currentColor}.s-tag__moderator .s-tag--dismiss{color:inherit;background-color:transparent}.s-tag__moderator .s-tag--dismiss:hover{color:var(--red-050);background-color:var(--red-800)}body.theme-highcontrast .s-tag__moderator .s-tag--dismiss:hover{color:var(--white)}.s-tag__moderator.is-selected{border-color:var(--red-400);background-color:var(--red-200);color:var(--red-800)}body.theme-highcontrast .s-tag__moderator.is-selected{border-color:currentColor}a.s-tag__moderator:not(.is-selected):hover,a.s-tag__moderator:not(.is-selected):focus,a.s-tag__moderator:not(.is-selected):active,body.theme-custom .moderator-tag:not(.is-selected):hover,body.theme-custom .moderator-tag:not(.is-selected):focus,body.theme-custom .moderator-tag:not(.is-selected):active{border-color:var(--red-300);background-color:var(--red-100);color:var(--red-900)}body.theme-highcontrast a.s-tag__moderator:not(.is-selected):hover,body.theme-highcontrast a.s-tag__moderator:not(.is-selected):focus,body.theme-highcontrast a.s-tag__moderator:not(.is-selected):active,body.theme-highcontrast body.theme-custom .moderator-tag:not(.is-selected):hover,body.theme-highcontrast body.theme-custom .moderator-tag:not(.is-selected):focus,body.theme-highcontrast body.theme-custom .moderator-tag:not(.is-selected):active{border-color:currentColor}.s-tag__muted{border-color:transparent;background-color:var(--black-075);color:var(--black-700)}body.theme-highcontrast .s-tag__muted{border-color:currentColor}.s-tag__muted .s-tag--dismiss{color:inherit;background-color:transparent}.s-tag__muted .s-tag--dismiss:hover{color:var(--black-075);background-color:var(--black-700)}body.theme-highcontrast .s-tag__muted .s-tag--dismiss:hover{color:var(--white)}.s-tag__muted.is-selected{border-color:transparent;background-color:var(--black-200);color:var(--black-900)}body.theme-highcontrast .s-tag__muted.is-selected{border-color:currentColor}a.s-tag__muted:not(.is-selected):hover,a.s-tag__muted:not(.is-selected):focus,a.s-tag__muted:not(.is-selected):active{border-color:transparent;background-color:var(--black-100);color:var(--black-800)}body.theme-highcontrast a.s-tag__muted:not(.is-selected):hover,body.theme-highcontrast a.s-tag__muted:not(.is-selected):focus,body.theme-highcontrast a.s-tag__muted:not(.is-selected):active{border-color:currentColor}.s-tag__watched,.s-tag__ignored{position:relative;padding-left:22px}.s-tag__watched:before,.s-tag__ignored:before{content:"";display:block;width:14px;height:14px;margin-right:2px;background-color:currentColor;position:absolute;left:4px;top:calc(50% - 7px);-webkit-mask:var(--s-tag-icon) no-repeat center;mask:var(--s-tag-icon) no-repeat center;-webkit-mask-size:contain;mask-size:contain}.s-tag__watched{--s-tag-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E")}.s-tag__ignored{--s-tag-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E")}.s-pagination{display:flex;flex-wrap:wrap;margin-left:-2px;margin-right:-2px}.s-pagination--item{margin-left:2px;margin-right:2px;padding:0 8px;background-color:transparent;border-radius:3px;border:1px solid var(--bc-medium);font-size:13px;line-height:1.92307692;color:var(--fc-medium)}body.theme-highcontrast .s-pagination--item{text-decoration:none}.s-pagination--item:hover{border-color:var(--bc-darker);background-color:var(--black-100);color:var(--fc-dark)}.s-pagination--item.is-selected{border-color:transparent;background-color:var(--theme-primary-color);color:var(--white)}.s-pagination--item.s-pagination--item__clear,.s-pagination--item.s-pagination--item__clear:hover{color:inherit;border-color:transparent;background-color:transparent}.s-sidebarwidget--item[aria-current="true"]:before,.s-sidebarwidget--item>:first-child[aria-current="true"]:before,.s-sidebarwidget--item[aria-current="page"]:before,.s-sidebarwidget--item>:first-child[aria-current="page"]:before{border-left-color:var(--theme-primary-color)}.s-sidebarwidget--subnav li[aria-current="true"],.s-sidebarwidget--subnav li[aria-current="page"]{background-image:url("data:image/svg+xml,%3C?xml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22?%3E%3Csvg%20version%3D%221.1%22%20viewBox%3D%220%200%207%2010%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m0.72153%200.68446%204.1336%204.3077-4.1336%204.3077%22%20fill%3D%22none%22%20stroke%3D%22var%28--theme-primary-color%29%22%20stroke-width%3D%222%22/%3E%3C/svg%3E")}.row{max-width:1080px;width:100%}.row::before,.row::after{display:table;content:" "}.row::after{clear:both}.col-1{width:8.33333333%;float:left}.col-1.with-padding{padding-left:10px;padding-right:10px}.col-1.with-padding:first-child{padding-left:0}.col-1.with-padding:last-child{padding-right:0}.col-2{width:16.66666667%;float:left}.col-2.with-padding{padding-left:10px;padding-right:10px}.col-2.with-padding:first-child{padding-left:0}.col-2.with-padding:last-child{padding-right:0}.col-3{width:25%;float:left}.col-3.with-padding{padding-left:10px;padding-right:10px}.col-3.with-padding:first-child{padding-left:0}.col-3.with-padding:last-child{padding-right:0}.col-4{width:33.33333333%;float:left}.col-4.with-padding{padding-left:10px;padding-right:10px}.col-4.with-padding:first-child{padding-left:0}.col-4.with-padding:last-child{padding-right:0}.col-5{width:41.66666667%;float:left}.col-5.with-padding{padding-left:10px;padding-right:10px}.col-5.with-padding:first-child{padding-left:0}.col-5.with-padding:last-child{padding-right:0}.col-6{width:50%;float:left}.col-6.with-padding{padding-left:10px;padding-right:10px}.col-6.with-padding:first-child{padding-left:0}.col-6.with-padding:last-child{padding-right:0}.col-7{width:58.33333333%;float:left}.col-7.with-padding{padding-left:10px;padding-right:10px}.col-7.with-padding:first-child{padding-left:0}.col-7.with-padding:last-child{padding-right:0}.col-8{width:66.66666667%;float:left}.col-8.with-padding{padding-left:10px;padding-right:10px}.col-8.with-padding:first-child{padding-left:0}.col-8.with-padding:last-child{padding-right:0}.col-9{width:75%;float:left}.col-9.with-padding{padding-left:10px;padding-right:10px}.col-9.with-padding:first-child{padding-left:0}.col-9.with-padding:last-child{padding-right:0}.col-10{width:83.33333333%;float:left}.col-10.with-padding{padding-left:10px;padding-right:10px}.col-10.with-padding:first-child{padding-left:0}.col-10.with-padding:last-child{padding-right:0}.col-11{width:91.66666667%;float:left}.col-11.with-padding{padding-left:10px;padding-right:10px}.col-11.with-padding:first-child{padding-left:0}.col-11.with-padding:last-child{padding-right:0}.col-12{width:100%;float:left}.col-12.with-padding{padding-left:10px;padding-right:10px}.col-12.with-padding:first-child{padding-left:0}.col-12.with-padding:last-child{padding-right:0}.svg-icon{vertical-align:bottom}.svg-icon:not(.native) *{fill:currentColor}.icon-site,.icon-location,.icon-github,.icon-twitter,.icon-external-link,.icon-settings-off{background-image:url("../../Img/user-profile-sprite.png?v=6829b895a42c");background-image:url("../../Img/user-profile-sprite.svg?v=d88bb7069e3d"),none;display:inline-block;width:12px;height:14px;vertical-align:middle}.icon-site{background-position:0 -80px}.icon-location{background-position:0 -97px}.icon-github{background-position:0 -114px}.icon-twitter{background-position:0 -131px}.icon-settings-off{height:12px;width:11px;background-position:0 -355px}.icon-settings-off.hover:hover{background-position:0 -370px}.icon-external-link{width:14px;height:14px;background-position:-49px -369px}.input-icon{position:relative}.input-icon .svg-icon{position:absolute;top:8px;left:8px;z-index:99;pointer-events:none}.input-icon .icon{position:absolute;z-index:99;pointer-events:none;top:50%;margin-top:-7px;left:12px}.input-icon input{padding-left:30px !important}.icon-check-on,.icon-check-off,.item-select-table .item input[type="checkbox"]:checked+.check,.item-select-table .item .check{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:16px;height:16px;display:inline-block}.icon-check-off,.item-select-table .item .check{background-position:-51px -58px}.icon-check-on,.item-select-table .item input[type="checkbox"]:checked+.check{background-position:-74px -58px}.icon-check-small-on,.icon-check-small-off{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:13px;height:10px;display:inline-block}.icon-check-small-on{background-position:-51px -40px}.icon-check-small-off{background-position:-74px -40px}.icon-privacy-public,.icon-privacy-private,.icon-privacy-public-btn,.icon-privacy-private-btn{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:11px;height:11px;display:inline-block}.icon-privacy-public{background-position:-52px 0}.icon-privacy-private{background-position:-76px 0}.icon-privacy-public-btn{background-position:-52px -20px}.icon-privacy-private-btn{background-position:-76px -20px}.icon-i,.icon-i-orange{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:14px;height:14px;display:inline-block;background-position:-54px -94px}.icon-i-orange{background-position:-54px -134px;width:12px;height:12px}.icon-warning-orange,.icon-warning-label:before{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:13px;height:11px;display:inline-block}.icon-warning-orange,.icon-warning-label:before{background-position:-55px -114px}.icon-warning-label{display:inline-block;background:#faeed6;border-radius:3px;padding:2px 4px;cursor:pointer}.icon-warning-label:before{content:''}#location-home-item,.needs-visa{position:relative;padding-left:1.8em !important}#location-home-item .visa-icon,.needs-visa .visa-icon,#location-home-item .home-icon,.needs-visa .home-icon{position:absolute;left:.4em;top:50%;transform:translate(0%, -50%)}.home-icon{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:12px;height:12px;display:inline-block;background-position:-76px -132px}.visa-icon{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:12px;height:12px;display:inline-block;background-position:-76px -114px}.geo-tag .visa-icon{display:none}.geo-tag.needs-visa .visa-icon{display:inline-block}.icon-image-upload{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:20px;height:19px;display:inline-block;background-position:0 -360px}.icon-external-link{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:12px;height:10px;display:inline-block;background-position:0 -430px}.icon-play-white{background-image:url('../../Img/share-sprite-new.png?v=e1b8bd67bc12');background-image:url('../../Img/share-sprite-new.svg?v=0e11bfd41fbc'),none;width:12px;height:12px;display:inline-block;background-position:0 -258px}.btn .icon-play-white{position:relative;top:1px}.icon-print{background-image:url('../../Img/developer-story/timeline.svg?v=d0477cf4f5f4'),none;width:12px;height:11px;display:inline-block;background-position:0 -488px}.badge,.badge-tag{padding:.4em .8em .4em .4em;margin:0 3px 3px 0;color:hsl(0,0%,100%);line-height:1;text-decoration:none;white-space:nowrap;font-size:12px;background-color:hsl(210,8%,25%);border:1px solid transparent;display:inline-block;border-radius:4px}@media (prefers-color-scheme:dark){body.theme-system .badge,body.theme-system .badge-tag{background-color:hsl(210,8%,5%)}}body.theme-dark .badge,body.theme-dark .badge-tag,.theme-dark__forced .badge,.theme-dark__forced .badge-tag{background-color:hsl(210,8%,5%)}.badge:hover,.badge-tag:hover{color:hsl(0,0%,100%);text-decoration:none;background-color:hsl(210,8%,5%)}@media (prefers-color-scheme:dark){body.theme-system .badge:hover,body.theme-system .badge-tag:hover{background-color:#000}}body.theme-dark .badge:hover,body.theme-dark .badge-tag:hover,.theme-dark__forced .badge:hover,.theme-dark__forced .badge-tag:hover{background-color:#000}body.theme-highcontrast .badge{border-color:hsl(210,8%,5%)}.badge-tag{color:var(--black-600);background-color:var(--black-050);border-color:var(--black-100)}body.theme-highcontrast .badge-tag{border-color:currentColor}.badge-tag:hover{color:var(--black-700);background-color:var(--black-075);border-color:var(--black-150)}.badgecount{font-size:12px;font-weight:bold;padding-left:2px;color:var(--black-400)}.badge1,.badge2,.badge3{display:inline-block;overflow:hidden;line-height:inherit;vertical-align:text-bottom;width:14px;height:14px}.badge1{background-position:-97px -398px}.badge2{background-position:-77px -398px}.badge3{background-position:-57px -398px}select,input,button,.button,a.button:link,.btn,[class*="btn-"]{font-size:100%}input[type="text"]:not(.s-input):not(.s-textarea),input[type="password"]:not(.s-input):not(.s-textarea),input[type="number"]:not(.s-input):not(.s-textarea),input[type="email"]:not(.s-input):not(.s-textarea),input[type="url"]:not(.s-input):not(.s-textarea),input[type="search"]:not(.s-input):not(.s-textarea),input[type="tel"]:not(.s-input):not(.s-textarea),input[type="datetime"]:not(.s-input):not(.s-textarea),input[type="datetime-local"]:not(.s-input):not(.s-textarea),input[type="date"]:not(.s-input):not(.s-textarea),textarea:not(.s-input):not(.s-textarea){padding:8px 10px;font-family:var(--theme-body-font-family);font-size:1.15384615rem;color:hsl(210,8%,25%);background:hsl(0,0%,100%);border:1px solid hsl(210,8%,80%)}input[type="text"]:not(.s-input):not(.s-textarea)[disabled],input[type="password"]:not(.s-input):not(.s-textarea)[disabled],input[type="number"]:not(.s-input):not(.s-textarea)[disabled],input[type="email"]:not(.s-input):not(.s-textarea)[disabled],input[type="url"]:not(.s-input):not(.s-textarea)[disabled],input[type="search"]:not(.s-input):not(.s-textarea)[disabled],input[type="tel"]:not(.s-input):not(.s-textarea)[disabled],input[type="datetime"]:not(.s-input):not(.s-textarea)[disabled],input[type="datetime-local"]:not(.s-input):not(.s-textarea)[disabled],input[type="date"]:not(.s-input):not(.s-textarea)[disabled],textarea:not(.s-input):not(.s-textarea)[disabled]{background:hsla(210,8%,65%,0.1);cursor:not-allowed}input[type="text"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="password"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="number"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="email"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="url"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="search"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="tel"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="datetime"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="datetime-local"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,input[type="date"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder,textarea:not(.s-input):not(.s-textarea)::-webkit-input-placeholder{color:hsl(210,8%,65%)}input[type="text"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="password"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="number"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="email"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="url"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="search"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="tel"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="datetime"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="datetime-local"]:not(.s-input):not(.s-textarea)::-moz-placeholder,input[type="date"]:not(.s-input):not(.s-textarea)::-moz-placeholder,textarea:not(.s-input):not(.s-textarea)::-moz-placeholder{color:hsl(210,8%,65%);opacity:1}input[type="text"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="password"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="number"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="email"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="url"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="search"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="tel"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="datetime"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="datetime-local"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,input[type="date"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder,textarea:not(.s-input):not(.s-textarea)::-ms-input-placeholder{color:hsl(210,8%,65%)}input[type="text"]:not(.s-input):not(.s-textarea)::placeholder,input[type="password"]:not(.s-input):not(.s-textarea)::placeholder,input[type="number"]:not(.s-input):not(.s-textarea)::placeholder,input[type="email"]:not(.s-input):not(.s-textarea)::placeholder,input[type="url"]:not(.s-input):not(.s-textarea)::placeholder,input[type="search"]:not(.s-input):not(.s-textarea)::placeholder,input[type="tel"]:not(.s-input):not(.s-textarea)::placeholder,input[type="datetime"]:not(.s-input):not(.s-textarea)::placeholder,input[type="datetime-local"]:not(.s-input):not(.s-textarea)::placeholder,input[type="date"]:not(.s-input):not(.s-textarea)::placeholder,textarea:not(.s-input):not(.s-textarea)::placeholder{color:hsl(210,8%,65%)}textarea.custom-reason-text{width:600px}input{margin:5px 0}input[type="checkbox"]:not(.s-checkbox),input[type="radio"]:not(.s-radio){border:none;margin-right:5px}.form-submit{display:block;padding:10px 0 15px 0}.form-submit input:hover{cursor:pointer}.form-submit input:active{position:relative;top:1px}.privacy-wrapper{position:relative}.privacy-wrapper .privacy-checkbox{display:none;width:auto;padding:3px 6px;border-radius:3px 3px 0px 0px;position:absolute;top:-8px;right:0;font-size:11px;color:white;background:hsl(206,100%,52%)}.privacy-wrapper .privacy-checkbox input[type="checkbox"]{position:relative;z-index:1;margin-right:8px}.privacy-wrapper .privacy-checkbox:focus{outline:0}.privacy-wrapper .privacy-checkbox:before{content:'';display:inline-block;position:absolute;left:0;top:0;bottom:0;width:24px;background:hsl(206,100%,40%);z-index:0;border-radius:3px 0px 0px 0px}.has-error .textarea-with-counter textarea:not(:focus){border-color:hsl(358,68%,59%);border-bottom:0}.has-error .textarea-with-counter textarea:not(:focus)+.-counter{border-color:hsl(358,68%,59%)}.textarea-with-counter{margin:5px 0}.textarea-with-counter+.help-text{display:block;margin-bottom:5px !important}.textarea-with-counter textarea{margin:0 !important;border-bottom:0;display:block}.textarea-with-counter textarea:focus{border-bottom:0}.textarea-with-counter textarea:focus+.-counter{border-color:hsl(206,100%,52%)}.textarea-with-counter .-counter{display:flex;align-items:center;background:hsl(205,47%,97%);padding:4px;color:hsl(210,8%,55%);font-size:11px;border-bottom:1px solid hsl(210,8%,80%);border-left:1px solid hsl(210,8%,80%);border-right:1px solid hsl(210,8%,80%)}.textarea-with-counter .-counter.-fail .-dot,.textarea-with-counter .-counter.-success .-dot{display:inline-block}.textarea-with-counter .-counter.-fail .-dot{background:hsl(27,90%,70%)}.textarea-with-counter .-counter.-success{color:var(--green-400)}.textarea-with-counter .-counter.-success .-dot{background:hsl(140,40%,65%)}.textarea-with-counter .-dot{display:none;width:8px;height:8px;margin-right:4px;border-radius:50%}.label-required{display:inline-block;margin-left:2px;color:hsl(210,8%,55%)}.double-input:before,.double-input:after{content:"";display:table}.double-input:after{clear:both}.double-input input[type="text"],.double-input input[type="password"],.double-input input[type="email"],.double-input .separator{float:left;display:inline-block;width:auto;max-width:155px}.double-input .separator{background:hsl(210,8%,95%);color:hsl(210,8%,55%);font-size:13px;padding:8px 10px;margin:5px 0 5px 0;border-top:1px solid hsl(210,8%,80%);border-bottom:1px solid hsl(210,8%,80%);min-width:12px;text-align:center}.double-input.disabled{pointer-events:none;cursor:not-allowed;opacity:.4}.double-input.flex{display:flex;margin-bottom:18px}.double-input.flex .separator{float:none;flex-shrink:0;margin:5px 0 0 0}.double-input.flex input[type="text"],.double-input.flex input[type="password"],.double-input.flex input[type="email"]{float:none;flex-grow:1;margin-bottom:0 !important;max-width:none}.switcher{margin:5px auto 8px auto;display:inline-block;border:1px solid hsl(210,8%,90%);border-radius:3px;overflow:hidden}.switcher:before,.switcher:after{content:"";display:table}.switcher:after{clear:both}.switcher input[type="radio"]{display:none}.switcher label{background:hsl(0,0%,100%);transition:background 300ms ease;text-align:center;color:hsl(210,8%,45%);display:inline-block;padding:10px 8px;min-width:98px;float:left;cursor:pointer;border-right:1px solid hsl(210,8%,90%);margin-top:0}.switcher label:last-of-type{border-right:0}.switcher label:hover{background:#F4F8FB}.switcher input[type="radio"]:checked+label{background:#E1ECF4;color:hsl(210,8%,25%);pointer-events:none}.switcher.three-choices label{width:30.5%}.switcher.flex{display:flex;overflow:inherit}.switcher.flex label{min-width:0;flex-grow:1}.switcher.flex.three label{width:34%}.switcher.flex .informative-tooltip{width:200px}.disabled-area{opacity:.5;pointer-events:none}label.block,input.block,textarea.block{display:block;width:100%}label>input[type="checkbox"]{vertical-align:middle;margin:0 3px 3px 0}label>input[type="radio"]{margin:0 3px 4px 0}input[type="radio"],input[type="checkbox"]{vertical-align:middle}.container .chosen-container .chosen-choices{border:1px solid hsl(210,8%,80%);box-shadow:inset 0 1px 2px hsla(210,8%,5%,0.1);background:hsl(0,0%,100%)}.input-loader{position:relative}.input-loader.loading:before{content:'';position:absolute !important;top:50%;margin-top:-7px;right:7px}.f-label,label.f-label{display:inline-flex;margin:0;font-size:13px;line-height:1.61538462;font-weight:700;color:var(--black-700);cursor:pointer}.f-label._muted,label.f-label._muted{color:var(--black-400)}.f-label._small,label.f-label._small{font-size:11px}.f-label._medium,label.f-label._medium{font-size:17px}.f-label._large,label.f-label._large{font-size:21px}.f-label._medium,label.f-label._medium,.f-label._large,label.f-label._large{font-weight:400}.f-label .is-required,label.f-label .is-required,.f-label .is-optional,label.f-label .is-optional{display:inline-flex;align-self:flex-end;margin-bottom:2px;margin-left:8px;font-size:86%;font-style:italic;font-weight:400}p.is-required,span.is-required{color:hsl(358,68%,59%)}p.is-optional,span.is-optional{color:hsl(210,8%,45%)}.t-help{margin-top:6px;margin-bottom:12px;color:hsl(210,8%,55%);font-size:11px;line-height:1.30769231}.t-help._medium{font-size:13px}.f-input,textarea.f-input,input[type="text"].f-input,input[type="password"].f-input,input[type="number"].f-input,input[type="email"].f-input,input[type="url"].f-input,input[type="search"].f-input,input[type="tel"].f-input,input[type="datetime"].f-input{box-sizing:border-box;flex:1 auto;margin:0;padding:8px 16px;min-height:auto;vertical-align:middle;border:1px solid hsl(210,8%,80%);border-radius:0;box-shadow:inset 0 0 1px hsla(210,8%,60%,0.2),0 0 0 hsla(0,0%,100%,0);font-size:13px;line-height:1.61538462;color:hsl(210,8%,25%);background-color:hsl(0,0%,100%);transition:all 600ms cubic-bezier(.165, .84, .44, 1)}.f-input::-webkit-input-placeholder,textarea.f-input::-webkit-input-placeholder,input[type="text"].f-input::-webkit-input-placeholder,input[type="password"].f-input::-webkit-input-placeholder,input[type="number"].f-input::-webkit-input-placeholder,input[type="email"].f-input::-webkit-input-placeholder,input[type="url"].f-input::-webkit-input-placeholder,input[type="search"].f-input::-webkit-input-placeholder,input[type="tel"].f-input::-webkit-input-placeholder,input[type="datetime"].f-input::-webkit-input-placeholder{color:hsl(210,8%,80%)}.f-input::-moz-placeholder,textarea.f-input::-moz-placeholder,input[type="text"].f-input::-moz-placeholder,input[type="password"].f-input::-moz-placeholder,input[type="number"].f-input::-moz-placeholder,input[type="email"].f-input::-moz-placeholder,input[type="url"].f-input::-moz-placeholder,input[type="search"].f-input::-moz-placeholder,input[type="tel"].f-input::-moz-placeholder,input[type="datetime"].f-input::-moz-placeholder{color:hsl(210,8%,80%);opacity:1}.f-input::-ms-input-placeholder,textarea.f-input::-ms-input-placeholder,input[type="text"].f-input::-ms-input-placeholder,input[type="password"].f-input::-ms-input-placeholder,input[type="number"].f-input::-ms-input-placeholder,input[type="email"].f-input::-ms-input-placeholder,input[type="url"].f-input::-ms-input-placeholder,input[type="search"].f-input::-ms-input-placeholder,input[type="tel"].f-input::-ms-input-placeholder,input[type="datetime"].f-input::-ms-input-placeholder{color:hsl(210,8%,80%)}.f-input::placeholder,textarea.f-input::placeholder,input[type="text"].f-input::placeholder,input[type="password"].f-input::placeholder,input[type="number"].f-input::placeholder,input[type="email"].f-input::placeholder,input[type="url"].f-input::placeholder,input[type="search"].f-input::placeholder,input[type="tel"].f-input::placeholder,input[type="datetime"].f-input::placeholder{color:hsl(210,8%,80%)}.f-input:hover,textarea.f-input:hover,input[type="text"].f-input:hover,input[type="password"].f-input:hover,input[type="number"].f-input:hover,input[type="email"].f-input:hover,input[type="url"].f-input:hover,input[type="search"].f-input:hover,input[type="tel"].f-input:hover,input[type="datetime"].f-input:hover{border-color:hsla(206,100%,52%,0.5);box-shadow:inset 0 0 2px hsl(210,8%,85%),0 0 2px hsla(206,100%,52%,0.2)}.f-input:focus,textarea.f-input:focus,input[type="text"].f-input:focus,input[type="password"].f-input:focus,input[type="number"].f-input:focus,input[type="email"].f-input:focus,input[type="url"].f-input:focus,input[type="search"].f-input:focus,input[type="tel"].f-input:focus,input[type="datetime"].f-input:focus{border-color:hsl(206,100%,52%);box-shadow:inset 0 0 4px hsl(210,8%,95%),0 0 5px hsla(206,100%,52%,0.5);outline:0}.f-input[disabled],textarea.f-input[disabled],input[type="text"].f-input[disabled],input[type="password"].f-input[disabled],input[type="number"].f-input[disabled],input[type="email"].f-input[disabled],input[type="url"].f-input[disabled],input[type="search"].f-input[disabled],input[type="tel"].f-input[disabled],input[type="datetime"].f-input[disabled],.f-input.is-disabled,textarea.f-input.is-disabled,input[type="text"].f-input.is-disabled,input[type="password"].f-input.is-disabled,input[type="number"].f-input.is-disabled,input[type="email"].f-input.is-disabled,input[type="url"].f-input.is-disabled,input[type="search"].f-input.is-disabled,input[type="tel"].f-input.is-disabled,input[type="datetime"].f-input.is-disabled,.f-input[read-only],textarea.f-input[read-only],input[type="text"].f-input[read-only],input[type="password"].f-input[read-only],input[type="number"].f-input[read-only],input[type="email"].f-input[read-only],input[type="url"].f-input[read-only],input[type="search"].f-input[read-only],input[type="tel"].f-input[read-only],input[type="datetime"].f-input[read-only],.f-input.is-readonly,textarea.f-input.is-readonly,input[type="text"].f-input.is-readonly,input[type="password"].f-input.is-readonly,input[type="number"].f-input.is-readonly,input[type="email"].f-input.is-readonly,input[type="url"].f-input.is-readonly,input[type="search"].f-input.is-readonly,input[type="tel"].f-input.is-readonly,input[type="datetime"].f-input.is-readonly{border-color:hsl(210,8%,90%);box-shadow:inset 0 0 3px hsla(210,8%,60%,0.1);background-color:hsl(210,8%,95%);color:hsl(210,8%,55%)}.f-input[disabled],textarea.f-input[disabled],input[type="text"].f-input[disabled],input[type="password"].f-input[disabled],input[type="number"].f-input[disabled],input[type="email"].f-input[disabled],input[type="url"].f-input[disabled],input[type="search"].f-input[disabled],input[type="tel"].f-input[disabled],input[type="datetime"].f-input[disabled],.f-input.is-disabled,textarea.f-input.is-disabled,input[type="text"].f-input.is-disabled,input[type="password"].f-input.is-disabled,input[type="number"].f-input.is-disabled,input[type="email"].f-input.is-disabled,input[type="url"].f-input.is-disabled,input[type="search"].f-input.is-disabled,input[type="tel"].f-input.is-disabled,input[type="datetime"].f-input.is-disabled{background-image:url("../../Img/forms/icon-disabled.svg?v=363cfdd5fd7d"),none;background-repeat:no-repeat;background-position:right 12px center;cursor:not-allowed}.f-input._large,textarea.f-input._large,input[type="text"].f-input._large,input[type="password"].f-input._large,input[type="number"].f-input._large,input[type="email"].f-input._large,input[type="url"].f-input._large,input[type="search"].f-input._large,input[type="tel"].f-input._large,input[type="datetime"].f-input._large{padding-top:16px;padding-bottom:16px;font-size:24px}.f-input._medium,textarea.f-input._medium,input[type="text"].f-input._medium,input[type="password"].f-input._medium,input[type="number"].f-input._medium,input[type="email"].f-input._medium,input[type="url"].f-input._medium,input[type="search"].f-input._medium,input[type="tel"].f-input._medium,input[type="datetime"].f-input._medium{font-size:17px}.f-input._small,textarea.f-input._small,input[type="text"].f-input._small,input[type="password"].f-input._small,input[type="number"].f-input._small,input[type="email"].f-input._small,input[type="url"].f-input._small,input[type="search"].f-input._small,input[type="tel"].f-input._small,input[type="datetime"].f-input._small{padding-left:12px;padding-right:12px;font-size:11px}textarea.f-input{padding:12px;height:auto;resize:vertical}.f-select{position:relative;color:hsl(210,8%,25%)}.f-select:before,.f-select:after{content:"";position:absolute;right:.75em;pointer-events:none;border-width:3px;border-style:solid;border-color:currentColor transparent}.f-select:before{top:calc(50% - 6px);border-top-width:0;border-bottom-width:5px}.f-select:after{top:calc(50% + 1px);border-top-width:5px;border-bottom-width:0}.f-select>select{-webkit-appearance:none;-moz-appearance:none;appearance:none;flex:1 auto;padding:8px 16px;padding-right:32px;font-size:13px;font-family:var(--theme-body-font-family);line-height:1.61538462;color:inherit;background-color:hsl(0,0%,100%);border:1px solid hsl(210,8%,80%);border-radius:3px;transition:color 600ms cubic-bezier(.165, .84, .44, 1),border-color 600ms cubic-bezier(.165, .84, .44, 1),box-shadow 600ms cubic-bezier(.165, .84, .44, 1),background-color 600ms cubic-bezier(.165, .84, .44, 1)}.f-select>select::-ms-expand{display:none}.f-select>select:hover{border-color:hsla(206,100%,52%,0.5);box-shadow:inset 0 0 2px hsl(210,8%,85%),0 0 2px hsla(206,100%,52%,0.2)}.f-select>select:focus{border-color:hsl(206,100%,52%);box-shadow:inset 0 0 4px hsl(210,8%,95%),0 0 5px hsla(206,100%,52%,0.5);outline:0}.f-select.is-disabled:before,.f-select.is-disabled:after{opacity:.3}.f-select.is-disabled select{color:hsl(210,8%,70%);background-color:hsl(210,8%,95%);border-color:hsl(210,8%,90%)}.f-select.is-disabled select:hover{border-color:hsl(210,8%,90%);box-shadow:none}.f-checkbox input[type="radio"],.f-radio input[type="radio"],.f-checkbox input[type="checkbox"],.f-radio input[type="checkbox"]{margin:0}.f-checkbox>.-input,.f-radio>.-input{flex:none;padding-right:8px}.f-checkbox>.-input>input,.f-radio>.-input>input{margin:0}.f-checkbox>.-input>input[type="checkbox"],.f-radio>.-input>input[type="checkbox"]{margin-top:2px}.f-checkbox>.-input>input:focus,.f-radio>.-input>input:focus{outline:0}.f-checkbox .f-label,.f-radio .f-label{font-weight:400}.f-checkbox .t-help,.f-radio .t-help{margin:2px 0;padding-right:1em}.f-checkbox+.f-checkbox,.f-checkbox+.f-radio,.f-radio+.f-checkbox,.f-radio+.f-radio{margin-top:8px}.f-checkbox.is-disabled,.f-radio.is-disabled{opacity:.5}.f-checkbox.is-disabled,.f-radio.is-disabled,.f-checkbox.is-disabled label,.f-radio.is-disabled label,.f-checkbox.is-disabled .label,.f-radio.is-disabled .label{cursor:not-allowed}.input-group{box-sizing:border-box}.input-group .message{display:block;margin-bottom:0;padding-top:8px;padding-bottom:8px}.input-group.has-warning .f-input,.input-group.has-error .f-input,.input-group.is-success .f-input,.input-group.has-warning .tag-editor,.input-group.has-error .tag-editor,.input-group.is-success .tag-editor,.input-group.has-warning .autocomplete input,.input-group.has-error .autocomplete input,.input-group.is-success .autocomplete input,.input-group.has-warning .f-select select,.input-group.has-error .f-select select,.input-group.is-success .f-select select{background-position:right 12px center;background-repeat:no-repeat}.input-group.has-warning .f-select select,.input-group.has-error .f-select select,.input-group.is-success .f-select select{background-position:right 24px center}.input-group.has-warning .f-input,.input-group.has-warning .f-select select{border-color:#db8e17;background-image:url("../../Img/forms/icon-warning.svg?v=982eba4202d6"),none}.input-group.has-warning .f-input:hover,.input-group.has-warning .f-select select:hover{border-color:#eaa63b;box-shadow:inset 0 0 1px hsl(210,8%,85%),0 0 2px hsl(47,65%,84%)}.input-group.has-warning .f-input:focus,.input-group.has-warning .f-select select:focus{border-color:#e7910b;box-shadow:inset 0 0 4px hsl(210,8%,95%),0 0 4px hsl(47,65%,84%)}.input-group.has-warning .message{color:#db8e17}.input-group.has-error .f-input,.input-group.has-error .tag-editor,.input-group.has-error .autocomplete input,.input-group.has-error .f-select select{border-color:hsl(358,68%,59%);background-image:url("../../Img/forms/icon-error.svg?v=7912aa2ddbe0"),none}.input-group.has-error .f-input:hover,.input-group.has-error .tag-editor:hover,.input-group.has-error .autocomplete input:hover,.input-group.has-error .f-select select:hover{border-color:hsl(358,70%,70%);box-shadow:inset 0 0 1px hsl(210,8%,85%),0 0 2px hsl(358,76%,90%)}.input-group.has-error .f-input:focus,.input-group.has-error .tag-editor:focus,.input-group.has-error .autocomplete input:focus,.input-group.has-error .f-select select:focus{border-color:hsl(358,62%,52%);box-shadow:inset 0 0 4px hsl(210,8%,95%),0 0 4px hsl(358,74%,83%)}.input-group.has-error .message{color:var(--red-500)}.input-group.is-success .f-input,.input-group.is-success .f-select select{border-color:var(--green-400);background-image:url("../../Img/forms/icon-success.svg?v=4012387047df"),none}.input-group.is-success .f-input:hover,.input-group.is-success .f-select select:hover{border-color:hsl(140,40%,65%);box-shadow:inset 0 0 1px hsl(210,8%,85%),0 0 2px hsl(140,40%,85%)}.input-group.is-success .f-input:focus,.input-group.is-success .f-select select:focus{border-color:var(--green-500);box-shadow:inset 0 0 4px hsl(210,8%,95%),0 0 4px hsl(140,40%,75%)}.input-group.is-success .message{color:hsl(140,40%,42%)}.input-group.is-disabled{opacity:.5;cursor:not-allowed}.input-group,.button-group{position:relative;display:flex}.input-group *,.button-group *,.input-group *:before,.button-group *:before,.input-group *:after,.button-group *:after{box-sizing:border-box}.input-group{flex-flow:column nowrap;margin-bottom:24px}.input-group>.input-group{margin-bottom:0}.input-group>.f-label+*{margin-top:6px}.input-group>.f-label+.t-help{margin-top:2px}.input-group>.f-label+.input-group{margin-top:16px}.input-group._clusters .input-group{margin-bottom:0}.input-group._clusters .input-group .f-label{font-weight:400}.input-group .-fill{flex:none;align-items:center;padding:8px 16px;color:hsl(210,8%,35%);background-color:hsl(210,8%,95%);border:1px solid hsl(210,8%,80%);border-left-width:0;border-right-width:0}.input-group .-fill>label{font-size:inherit;line-height:inherit}.input-group .-fill._clean{border-color:transparent;background-color:transparent}.input-group .-fill.is-first{order:-1;border-left-width:1px}.input-group .-fill.is-last{order:99;border-right-width:1px}.input-group [class^="btn"].is-last{order:100;margin-left:-1px;border-top-left-radius:0;border-bottom-left-radius:0}.button-group [class^="btn"]+[class^="btn"]{margin-left:2px}.button-group .t-help{margin-top:12px;margin-bottom:0}.button-group.has-border{padding-top:24px;border-top:1px solid hsl(210,8%,85%)}.f-radio-toggle .f-label{flex:1 auto;justify-content:center;padding:8px 16px;margin-left:-1px;margin-right:-1px;border:1px solid hsl(210,8%,80%);background-color:var(--white);font-weight:400;line-height:1.61538462;color:hsl(210,8%,25%);text-align:center;transition:all 600ms cubic-bezier(.165, .84, .44, 1);cursor:pointer}.f-radio-toggle .f-label:hover,.f-radio-toggle .f-label:focus,.f-radio-toggle .f-label:active{color:hsl(210,8%,15%);background-color:var(--blue-050);border-color:var(--blue-200);z-index:1}.f-radio-toggle input[type="radio"]{position:absolute;left:-9999em;opacity:0}.f-radio-toggle input[type="radio"]:checked+.f-label{color:var(--white);background-color:var(--blue-500);border-color:var(--blue-500);pointer-events:none;position:relative;z-index:2}.f-radio-toggle._muted .f-label{border:1px solid var(--black-150);background-color:var(--white);color:var(--black-400)}.f-radio-toggle._muted .f-label:hover,.f-radio-toggle._muted .f-label:focus,.f-radio-toggle._muted .f-label:active{color:var(--black-700);background-color:var(--black-050);border-color:var(--black-200)}.f-radio-toggle._muted input[type="radio"]:checked+.f-label{color:var(--white);background-color:var(--green-400);border-color:var(--green-400)}.f-radio-toggle._muted input[type="radio"]._off:checked+.f-label{color:var(--black-500);background-color:var(--black-100);border-color:var(--black-200)}.container .chosen-container{margin-top:0}.container .chosen-container.chosen-container-active{border-width:0}.container .chosen-container.chosen-container-active .chosen-choices{border-color:hsl(206,100%,52%);box-shadow:inset 0 0 4px hsl(210,8%,95%),0 0 5px hsla(206,100%,52%,0.5)}.container .chosen-container .chosen-choices{display:flex;padding:0 1px;min-height:38px;background-image:none;border-radius:3px;border-color:hsl(210,8%,80%)}.container .chosen-container .chosen-choices:hover{border-color:hsla(206,100%,52%,0.5);box-shadow:inset 0 0 2px hsl(210,8%,85%),0 0 2px hsla(206,100%,52%,0.2)}.container .chosen-container .chosen-choices li.search-choice,.container .chosen-container .chosen-choices li.search-field{display:inline-flex;align-items:center;margin:4px 1px;padding:2px 6px}.container .chosen-container .chosen-choices li.search-choice{float:none;box-shadow:none;background-image:none;font-family:var(--ff-sans);font-size:12px;color:var(--powder-600);background-color:var(--powder-100);border-color:transparent;border-radius:3px}.container .chosen-container .chosen-choices li.search-choice:first-child{margin-left:3px}.container .chosen-container .chosen-choices li.search-choice .search-choice-close{position:relative;top:0;right:-1px;margin-left:4px;transition:none}.container .chosen-container li.search-field>input[type="text"]{padding:0;margin:0}ul,ol,li{margin:0;padding:0}ul,ol{margin-left:30px;margin-bottom:1em}ul ul,ol ul,ul ol,ol ol{margin-bottom:0}ul{list-style-type:disc}ol{list-style-type:decimal}.caption{padding-top:13px;padding-bottom:13px;text-align:left}table{border-spacing:0;border-collapse:collapse}.table{margin-bottom:15px;width:100%;max-width:100%;background-color:transparent;border-width:0}.table th{text-align:left}.table>thead>tr>th,.table>tbody>tr>th,.table>tfoot>tr>th,.table>thead>tr>td,.table>tbody>tr>td,.table>tfoot>tr>td{padding:13px;padding-left:0;vertical-align:top}.table>thead>tr>th small,.table>tbody>tr>th small,.table>tfoot>tr>th small,.table>thead>tr>td small,.table>tbody>tr>td small,.table>tfoot>tr>td small{font-size:11px}.table>thead>tr>th{vertical-align:bottom}.table>tfoot>tr>td{vertical-align:top}.table>caption+thead>tr:first-child>th,.table>.caption+thead>tr:first-child>th,.table>colgroup+thead>tr:first-child>th,.table>.colgroup+thead>tr:first-child>th,.table>thead:first-child>tr:first-child>th,.table>caption+thead>tr:first-child>td,.table>.caption+thead>tr:first-child>td,.table>colgroup+thead>tr:first-child>td,.table>.colgroup+thead>tr:first-child>td,.table>thead:first-child>tr:first-child>td{border-top:0}.table ._textLeft{text-align:left}.table ._textCenter{text-align:center}.table ._textRight{text-align:right}.table col[class*="-col"]{position:static;float:none;display:table-column}.table td[class*="-col"],.table th[class*="-col"]{position:static;float:none;display:table-cell}.table td.-col1,.table th.-col1{width:8.33333333%}.table td.-col2,.table th.-col2{width:16.66666667%}.table td.-col3,.table th.-col3{width:25%}.table td.-col4,.table th.-col4{width:33.33333333%}.table td.-col5,.table th.-col5{width:41.66666667%}.table td.-col6,.table th.-col6{width:50%}.table td.-col7,.table th.-col7{width:58.33333333%}.table td.-col8,.table th.-col8{width:66.66666667%}.table td.-col9,.table th.-col9{width:75%}.table td.-col10,.table th.-col10{width:83.33333333%}.table td.-col11,.table th.-col11{width:91.66666667%}.table td.-col12,.table th.-col12{width:100%}.table._hover>tbody>tr:hover{background-color:hsl(0,0%,97%)}.table._hover>tbody>tr:hover>td{box-shadow:inset 0 2px 0 hsl(0,0%,100%),inset 0 -2px 0 hsl(0,0%,100%)}.table._condensed>thead>tr>th,.table._condensed>tbody>tr>th,.table._condensed>tfoot>tr>th,.table._condensed>thead>tr>td,.table._condensed>tbody>tr>td,.table._condensed>tfoot>tr>td{padding:7px;padding-left:0}.table._condensed input[type="radio"],.table._condensed input[type="checkbox"]{margin-top:0}.table._borders>thead>tr>th,.table._borders>tbody>tr>th,.table._borders>tfoot>tr>th,.table._borders>thead>tr>td,.table._borders>tbody>tr>td,.table._borders>tfoot>tr>td{border-top:1px solid var(--black-075)}.table._borders>thead>tr>th{border-bottom:1px solid var(--black-075)}.table._borders>tbody+tbody{border-top:2px solid var(--black-075)}.table tfoot.-totals>tr>td{font-size:1.46153846rem}.table tfoot.-totals:hover{background-color:transparent;transition:none}.table .js-tableToggle{display:none}.table._whiteBg{background:hsl(0,0%,100%)}.table._whiteBg>thead>tr>th,.table._whiteBg>tbody>tr>th,.table._whiteBg>tfoot>tr>th,.table._whiteBg>thead>tr>td,.table._whiteBg>tbody>tr>td,.table._whiteBg>tfoot>tr>td{padding:10px}.table._verticalCenter>thead>tr>th,.table._verticalCenter>tbody>tr>th,.table._verticalCenter>tfoot>tr>th,.table._verticalCenter>thead>tr>td,.table._verticalCenter>tbody>tr>td,.table._verticalCenter>tfoot>tr>td{vertical-align:middle}.table th.-checkbox,.table td.-checkbox{width:2em}.table td.empty{font-style:italic;opacity:.75}.edit-table{border:1px solid var(--black-100);margin-top:5px}.edit-table._short{max-height:150px;overflow-y:auto}.edit-table._medium{max-height:250px;overflow-y:auto}.edit-table>table,.edit-table>.table{margin-bottom:0}.item-select-table{display:flex;justify-content:flex-start;flex-wrap:wrap;background:var(--white);border-right:1px solid var(--black-100);border-bottom:1px solid var(--black-100);margin-bottom:20px}.item-select-table.limit-height-300{max-height:300px;overflow-y:auto;overflow-x:hidden}.item-select-table.columns-3 .item{width:33.3%}.item-select-table.tag-table .item{display:flex;align-items:center}.item-select-table.tag-table .post-tag{max-width:110px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-right:4px}.item-select-table label.item{cursor:pointer}.item-select-table .item{border:1px solid var(--black-100);padding:10px;position:relative;flex-grow:1;text-align:center;margin-right:-1px;margin-bottom:-1px}.item-select-table .item:hover{background:var(--black-050)}.item-select-table .item input[type="checkbox"]{display:none}.item-select-table .item .check{position:absolute;top:4px;right:4px}table.sorter{margin:10px 0pt 15px;text-align:left;border-bottom:solid 1px var(--black-100)}table.sorter>thead>tr .headerSortDown,table.sorter>thead>tr .headerSortUp{background-color:var(--orange-400);color:hsl(0,0%,100%)}table.sorter>thead>tr .headerSortUp span:after{content:"▴"}table.sorter>thead>tr .headerSortDown span:after{content:"▾"}table.sorter>thead>tr .header{background-repeat:no-repeat;background-position:center right;cursor:pointer}table.sorter>thead>tr span:after{padding-left:5px}table.sorter>thead>tr>th{text-align:center}table.sorter>thead>tr>th,table.sorter>tfoot>tr>td{background-color:var(--black-500);color:var(--white);border:1px solid var(--white);font-size:110%;padding:5px}table.sorter>tbody>tr>td{padding:5px 10px;background-color:var(--white);vertical-align:top}table.sorter>tbody>tr.odd>td{background-color:var(--black-050)}table.sorter>tbody>tr>td.mod-ip-banned{background-color:var(--red-100)}table.sorter>tbody>tr>td.mod-ip-hobbled{background-color:var(--orange-100)}table.sorter>tbody .row-data{text-align:right}.post-tag,.moderator-tag,.required-tag,.disliked-tag,.company-tag,.geo-tag,.geo-tag,.container .chosen-choices .search-choice,.container .chosen-container-multi .chosen-choices li.search-choice{display:inline-block;padding:.4em .5em;margin:2px 2px 2px 0;font-size:11px;line-height:1;white-space:nowrap;text-decoration:none;text-align:center;border-width:1px;border-style:solid;border-radius:3px}body.theme-highcontrast .post-tag,body.theme-highcontrast .moderator-tag,body.theme-highcontrast .required-tag,body.theme-highcontrast .disliked-tag,body.theme-highcontrast .company-tag,body.theme-highcontrast .geo-tag{border-color:currentColor}.post-tag:hover,.moderator-tag:hover,.required-tag:hover,.disliked-tag:hover,.company-tag:hover,.geo-tag:hover{text-decoration:none}.post-tag img,.moderator-tag img,.required-tag img,.disliked-tag img,.company-tag img,.geo-tag img{margin-bottom:0}.post-tag img.sponsor-tag-img,.moderator-tag img.sponsor-tag-img,.required-tag img.sponsor-tag-img,.disliked-tag img.sponsor-tag-img,.company-tag img.sponsor-tag-img,.geo-tag img.sponsor-tag-img{margin-top:-2px;margin-bottom:-2px}.post-tag,.geo-tag,.container .chosen-choices .search-choice,.container .chosen-container-multi .chosen-choices li.search-choice{color:var(--theme-tag-color);background-color:var(--theme-tag-background-color);border-color:var(--theme-tag-border-color)}.post-tag:hover{color:var(--theme-tag-hover-color);background-color:var(--theme-tag-hover-background-color);border-color:var(--theme-tag-hover-border-color)}.moderator-tag{color:var(--red-600);background-color:var(--red-050);border-color:var(--red-100)}.moderator-tag:hover{color:var(--red-700);background-color:var(--red-100);border-color:var(--red-200)}.required-tag{color:var(--black-700);background-color:var(--black-075);border-color:var(--black-200)}.required-tag:hover{color:var(--black-800);background-color:var(--black-100);border-color:var(--black-300)}.disliked-tag{color:hsl(210,8%,45%);background-color:hsl(210,8%,90%);border-color:transparent}.disliked-tag:hover{color:hsl(210,8%,40%);background-color:hsl(210,8%,85%);border-color:rgba(0,0,0,0)}.company-tag{color:hsl(210,8%,5%);font-size:12px;text-align:left;background-color:hsl(210,8%,95%);border-radius:0;border-color:transparent;border-left:2px solid hsl(27,90%,55%)}.company-tag:hover{background-color:#ECEAEA;color:hsl(210,8%,15%)}.company-tag img{margin-bottom:auto;padding-right:4px;max-height:20px;width:auto;vertical-align:middle}.autocomplete .company-tag{line-height:1.5em}.geo-tag .delete-location{margin:-2px 0 0 3px;vertical-align:middle;width:14px;height:13px;line-height:26px}.geo-tag .icon-visa-show[value="false"]~.icon-visa{display:none}.container .chosen-choices .search-choice,.container .chosen-container-multi .chosen-choices li.search-choice{background-image:none;box-shadow:none;border-color:var(--theme-tag-border-color);padding-right:1.75em;padding-top:.5em;margin:4px 4px 0 0 !important}.container .chosen-choices .search-choice .search-choice-close,.container .chosen-container-multi .chosen-choices li.search-choice .search-choice-close{margin:0 !important}.post-tag.s-tag__watched{display:inline-flex;align-items:center;position:relative;padding-left:22px;--s-tag-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E")}.post-tag.s-tag__watched:before{content:"";display:block;width:14px;height:14px;margin-right:2px;background-color:currentColor;position:absolute;left:4px;top:calc(50% - 7px);-webkit-mask:var(--s-tag-icon) no-repeat center;mask:var(--s-tag-icon) no-repeat center;-webkit-mask-size:contain;mask-size:contain}.post-tag.s-tag__ignored{display:inline-flex;align-items:center;position:relative;padding-left:22px;--s-tag-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E")}.post-tag.s-tag__ignored:before{content:"";display:block;width:14px;height:14px;margin-right:2px;background-color:currentColor;position:absolute;left:4px;top:calc(50% - 7px);-webkit-mask:var(--s-tag-icon) no-repeat center;mask:var(--s-tag-icon) no-repeat center;-webkit-mask-size:contain;mask-size:contain}a{color:var(--theme-link-color);text-decoration:none;cursor:pointer}a:hover,a:active{color:var(--theme-link-color-hover);text-decoration:none}a.comment-user{display:inline-block;white-space:nowrap;padding:0}a.comment-user.owner{padding:1px 5px}body.theme-highcontrast a.comment-user.owner{background-color:var(--theme-link-color);color:var(--theme-post-owner-background-color)}body.theme-highcontrast a.comment-user.owner:hover{color:var(--theme-post-owner-background-color)}.s-prose a:not(.post-tag):not(.s-tag):not(.badge-tag):not(.s-link__visited):not(.s-btn):not(.s-editor-btn),.comment-copy a{text-decoration:underline}.s-prose a:not(.post-tag):not(.s-tag):not(.badge-tag):not(.s-link__visited):not(.s-btn):not(.s-editor-btn):visited,.comment-copy a:visited{color:var(--theme-link-color-visited)}a .mathjax{width:115px;height:55px;background-image:url("../../Img/share-sprite.png?v=0734e5a54af0");background-position:-190px 5px}.external{position:relative;display:inline-block;padding-left:20px}.external>.-icon{position:relative;display:inline-block;width:9px;height:9px;overflow:hidden;background-image:url("../../Img/share-sprite-new.png?v=e1b8bd67bc12");background-image:url("../../Img/share-sprite-new.svg?v=0e11bfd41fbc"),none;background-position:0 -220px;background-repeat:no-repeat}.external:visited{color:var(--theme-link-color)}.external:hover,.external:active{text-decoration:none}.external:hover>.-icon,.external:active>.-icon{background-position:-13px -220px}.question-hyperlink{font-size:1.30769231rem;font-weight:400}.question-hyperlink,.answer-hyperlink{color:var(--theme-post-title-color);line-height:1.3;margin-bottom:1.2em}.question-hyperlink:hover,.answer-hyperlink:hover,.question-hyperlink:active,.answer-hyperlink:active{color:var(--theme-post-title-color-hover)}body.theme-highcontrast .question-hyperlink:hover,body.theme-highcontrast .answer-hyperlink:hover,body.theme-highcontrast .question-hyperlink:focus,body.theme-highcontrast .answer-hyperlink:focus{text-decoration:underline}.question-hyperlink:visited,.answer-hyperlink:visited{color:var(--theme-post-title-color-visited)}b,strong{font-weight:bold}i,em{font-style:italic}sup,sub{font-size:80%}ins{text-decoration:none}del,s{text-decoration:line-through}del .post-tag,s .post-tag,del .required-tag,s .required-tag,del .moderator-tag,s .moderator-tag{text-decoration:line-through !important}kbd{display:inline-block;margin:0 .1em;padding:.1em .6em;font-family:var(--theme-body-font-family);font-size:11px;line-height:1.4;color:var(--black-800);text-shadow:0 1px 0 var(--white);background-color:var(--black-075);border:1px solid var(--black-300);border-radius:3px;box-shadow:0 1px 1px hsla(210,8%,5%,0.15),inset 0 1px 0 0 var(--white);white-space:nowrap}@media (prefers-color-scheme:dark){body.theme-system kbd{box-shadow:0 1px 2px hsla(210,8%,5%,0.75)}}body.theme-dark kbd,.theme-dark__forced kbd{box-shadow:0 1px 2px hsla(210,8%,5%,0.75)}.placeholder-text{color:var(--black-300)}.help-text{color:var(--black-600);font-size:11px}p{clear:both;margin-bottom:1em;margin-top:0}p code{padding:1px 5px}code{font-family:var(--ff-mono);background-color:var(--black-075)}pre{margin-bottom:1em;padding:12px;width:auto;max-height:600px;overflow:auto;font-family:var(--ff-mono);font-size:13px;background-color:var(--black-050);border-radius:3px;scrollbar-color:var(--scrollbar) transparent}pre code{background-color:transparent}pre::-webkit-scrollbar{width:10px;height:10px;background-color:transparent}pre::-webkit-scrollbar-track{border-radius:10px;background-color:transparent}pre::-webkit-scrollbar-thumb{border-radius:10px;background-color:var(--scrollbar)}pre::-webkit-scrollbar-corner{background-color:transparent;border-color:transparent}li pre{margin:.5em 0 1em 0}h1,h2,h3{line-height:1.3;margin:0 0 1em}h1{font-size:1.61538462rem}h2{font-size:1.46153846rem}h3{font-size:1.15384615rem}.s-prose,.comment-copy,.question-status,.excerpt{font-family:var(--theme-post-body-font-family)}blockquote,q{quotes:none}blockquote{position:relative;margin-bottom:1em;padding:12px 12px 12px 16px}blockquote:before{content:"";display:block;position:absolute;top:0;bottom:0;left:0;width:4px;border-radius:8px;background:var(--black-150)}blockquote *:last-child{margin-bottom:0}li blockquote{margin:.5em 0 1em 0}.favicon{width:16px;height:16px;background-color:transparent;background-repeat:no-repeat;background-size:16px;background-image:url('../../Img/favicons-sprite16.png?v=986d639469b0')}body.theme-dark .favicon{background-image:url('../../Img/favicons-sprite16-dark.png?v=78243e15ed0e')}@media (prefers-color-scheme:dark){body.theme-system .favicon{background-image:url('../../Img/favicons-sprite16-dark.png?v=78243e15ed0e')}}div.favicon{display:inline-block}@media only screen and (min--moz-device-pixel-ratio:1.5),only screen and (-o-min-device-pixel-ratio:3/2),only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.favicon{background-image:url('../../Img/favicons-sprite32.png?v=85acf8076063')}body.theme-dark .favicon{background-image:url('../../Img/favicons-sprite32-dark.png?v=de2232974c99')}}@media only screen and (min--moz-device-pixel-ratio:1.5) and (prefers-color-scheme:dark),only screen and (-o-min-device-pixel-ratio:3/2) and (prefers-color-scheme:dark),only screen and (-webkit-min-device-pixel-ratio:1.5) and (prefers-color-scheme:dark),only screen and (min-device-pixel-ratio:1.5) and (prefers-color-scheme:dark){body.theme-system .favicon{background-image:url('../../Img/favicons-sprite32-dark.png?v=de2232974c99')}}@media only screen and (min--moz-device-pixel-ratio:1.5),only screen and (-o-min-device-pixel-ratio:3/2),only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.favicon{-moz-background-size:16px 6966px;-o-background-size:16px 6966px;-webkit-background-size:16px 6966px;background-size:16px 6966px}}.favicon-3dprinting{background-position:0 0}.favicon-3dprintingmeta{background-position:0 -18px}.favicon-academia{background-position:0 -36px}.favicon-academiameta{background-position:0 -54px}.favicon-ai{background-position:0 -72px}.favicon-aimeta{background-position:0 -90px}.favicon-alcohol{background-position:0 -108px}.favicon-alcoholmeta{background-position:0 -126px}.favicon-android{background-position:0 -144px}.favicon-androidmeta{background-position:0 -162px}.favicon-anime{background-position:0 -180px}.favicon-animemeta{background-position:0 -198px}.favicon-apple{background-position:0 -216px}.favicon-applemeta{background-position:0 -234px}.favicon-arabic{background-position:0 -252px}.favicon-arabicmeta{background-position:0 -270px}.favicon-arduino{background-position:0 -288px}.favicon-arduinometa{background-position:0 -306px}.favicon-area51{background-position:0 -324px}.favicon-area51discuss{background-position:0 -342px}.favicon-askubuntu{background-position:0 -360px}.favicon-askubuntumeta{background-position:0 -378px}.favicon-astronomy{background-position:0 -396px}.favicon-astronomymeta{background-position:0 -414px}.favicon-augur{background-position:0 -432px}.favicon-augurmeta{background-position:0 -450px}.favicon-aviation{background-position:0 -468px}.favicon-aviationmeta{background-position:0 -486px}.favicon-avp{background-position:0 -504px}.favicon-avpmeta{background-position:0 -522px}.favicon-beta{background-position:0 -540px}.favicon-betameta{background-position:0 -558px}.favicon-bicycles{background-position:0 -576px}.favicon-bicyclesmeta{background-position:0 -594px}.favicon-bioinformatics{background-position:0 -612px}.favicon-bioinformaticsmeta{background-position:0 -630px}.favicon-biology{background-position:0 -648px}.favicon-biologymeta{background-position:0 -666px}.favicon-bitcoin{background-position:0 -684px}.favicon-bitcoinmeta{background-position:0 -702px}.favicon-blender{background-position:0 -720px}.favicon-blendermeta{background-position:0 -738px}.favicon-boardgames{background-position:0 -756px}.favicon-boardgamesmeta{background-position:0 -774px}.favicon-br{background-position:0 -792px}.favicon-bricks{background-position:0 -810px}.favicon-bricksmeta{background-position:0 -828px}.favicon-brmeta{background-position:0 -846px}.favicon-buddhism{background-position:0 -864px}.favicon-buddhismmeta{background-position:0 -882px}.favicon-cardano{background-position:0 -900px}.favicon-cardanometa{background-position:0 -918px}.favicon-careers{background-position:0 -936px}.favicon-channels{background-position:0 -954px}.favicon-chemistry{background-position:0 -972px}.favicon-chemistrymeta{background-position:0 -990px}.favicon-chess{background-position:0 -1008px}.favicon-chessmeta{background-position:0 -1026px}.favicon-chinese{background-position:0 -1044px}.favicon-chinesemeta{background-position:0 -1062px}.favicon-christianity{background-position:0 -1080px}.favicon-christianitymeta{background-position:0 -1098px}.favicon-civicrm{background-position:0 -1116px}.favicon-civicrmmeta{background-position:0 -1134px}.favicon-codegolf{background-position:0 -1152px}.favicon-codegolfmeta{background-position:0 -1170px}.favicon-codereview{background-position:0 -1188px}.favicon-codereviewmeta{background-position:0 -1206px}.favicon-coffee{background-position:0 -1224px}.favicon-coffeemeta{background-position:0 -1242px}.favicon-communitybuilding{background-position:0 -1260px}.favicon-communitybuildingmeta{background-position:0 -1278px}.favicon-computergraphics{background-position:0 -1296px}.favicon-computergraphicsmeta{background-position:0 -1314px}.favicon-conlang{background-position:0 -1332px}.favicon-conlangmeta{background-position:0 -1350px}.favicon-cooking{background-position:0 -1368px}.favicon-cookingmeta{background-position:0 -1386px}.favicon-craftcms{background-position:0 -1404px}.favicon-craftcmsmeta{background-position:0 -1422px}.favicon-crafts{background-position:0 -1440px}.favicon-craftsmeta{background-position:0 -1458px}.favicon-crypto{background-position:0 -1476px}.favicon-cryptometa{background-position:0 -1494px}.favicon-cs{background-position:0 -1512px}.favicon-cs50{background-position:0 -1530px}.favicon-cs50meta{background-position:0 -1548px}.favicon-cseducators{background-position:0 -1566px}.favicon-cseducatorsmeta{background-position:0 -1584px}.favicon-csmeta{background-position:0 -1602px}.favicon-cstheory{background-position:0 -1620px}.favicon-cstheorymeta{background-position:0 -1638px}.favicon-datascience{background-position:0 -1656px}.favicon-datasciencemeta{background-position:0 -1674px}.favicon-dba{background-position:0 -1692px}.favicon-dbameta{background-position:0 -1710px}.favicon-deepweb{background-position:0 -1728px}.favicon-deepwebmeta{background-position:0 -1746px}.favicon-devops{background-position:0 -1764px}.favicon-devopsmeta{background-position:0 -1782px}.favicon-diy{background-position:0 -1800px}.favicon-diymeta{background-position:0 -1818px}.favicon-drones{background-position:0 -1836px}.favicon-dronesmeta{background-position:0 -1854px}.favicon-drupal{background-position:0 -1872px}.favicon-drupalmeta{background-position:0 -1890px}.favicon-dsp{background-position:0 -1908px}.favicon-dspmeta{background-position:0 -1926px}.favicon-earthscience{background-position:0 -1944px}.favicon-earthsciencemeta{background-position:0 -1962px}.favicon-ebooks{background-position:0 -1980px}.favicon-ebooksmeta{background-position:0 -1998px}.favicon-economics{background-position:0 -2016px}.favicon-economicsmeta{background-position:0 -2034px}.favicon-edx-cs169-1x{background-position:0 -2052px}.favicon-edx-cs169-1xmeta{background-position:0 -2070px}.favicon-electronics{background-position:0 -2088px}.favicon-electronicsmeta{background-position:0 -2106px}.favicon-elementaryos{background-position:0 -2124px}.favicon-elementaryosmeta{background-position:0 -2142px}.favicon-ell{background-position:0 -2160px}.favicon-ellmeta{background-position:0 -2178px}.favicon-emacs{background-position:0 -2196px}.favicon-emacsmeta{background-position:0 -2214px}.favicon-embedded{background-position:0 -2232px}.favicon-embeddedmeta{background-position:0 -2250px}.favicon-engineering{background-position:0 -2268px}.favicon-engineeringmeta{background-position:0 -2286px}.favicon-english{background-position:0 -2304px}.favicon-englishmeta{background-position:0 -2322px}.favicon-eosio{background-position:0 -2340px}.favicon-eosiometa{background-position:0 -2358px}.favicon-es{background-position:0 -2376px}.favicon-esmeta{background-position:0 -2394px}.favicon-esperanto{background-position:0 -2412px}.favicon-esperantometa{background-position:0 -2430px}.favicon-ethereum{background-position:0 -2448px}.favicon-ethereummeta{background-position:0 -2466px}.favicon-expatriates{background-position:0 -2484px}.favicon-expatriatesmeta{background-position:0 -2502px}.favicon-expressionengine{background-position:0 -2520px}.favicon-expressionenginemeta{background-position:0 -2538px}.favicon-fitness{background-position:0 -2556px}.favicon-fitnessmeta{background-position:0 -2574px}.favicon-freelancing{background-position:0 -2592px}.favicon-freelancingmeta{background-position:0 -2610px}.favicon-french{background-position:0 -2628px}.favicon-frenchmeta{background-position:0 -2646px}.favicon-gamedev{background-position:0 -2664px}.favicon-gamedevmeta{background-position:0 -2682px}.favicon-gamification{background-position:0 -2700px}.favicon-gamificationmeta{background-position:0 -2718px}.favicon-gaming{background-position:0 -2736px}.favicon-gamingmeta{background-position:0 -2754px}.favicon-gardening{background-position:0 -2772px}.favicon-gardeningmeta{background-position:0 -2790px}.favicon-genealogy{background-position:0 -2808px}.favicon-genealogymeta{background-position:0 -2826px}.favicon-german{background-position:0 -2844px}.favicon-germanmeta{background-position:0 -2862px}.favicon-gis{background-position:0 -2880px}.favicon-gismeta{background-position:0 -2898px}.favicon-graphicdesign{background-position:0 -2916px}.favicon-graphicdesignmeta{background-position:0 -2934px}.favicon-ham{background-position:0 -2952px}.favicon-hammeta{background-position:0 -2970px}.favicon-hardwarerecs{background-position:0 -2988px}.favicon-hardwarerecsmeta{background-position:0 -3006px}.favicon-hermeneutics{background-position:0 -3024px}.favicon-hermeneuticsmeta{background-position:0 -3042px}.favicon-hinduism{background-position:0 -3060px}.favicon-hinduismmeta{background-position:0 -3078px}.favicon-history{background-position:0 -3096px}.favicon-historymeta{background-position:0 -3114px}.favicon-homebrew{background-position:0 -3132px}.favicon-homebrewmeta{background-position:0 -3150px}.favicon-hsm{background-position:0 -3168px}.favicon-hsmmeta{background-position:0 -3186px}.favicon-i2p{background-position:0 -3204px}.favicon-i2pmeta{background-position:0 -3222px}.favicon-interpersonal{background-position:0 -3240px}.favicon-interpersonalmeta{background-position:0 -3258px}.favicon-iot{background-position:0 -3276px}.favicon-iota{background-position:0 -3294px}.favicon-iotameta{background-position:0 -3312px}.favicon-iotmeta{background-position:0 -3330px}.favicon-islam{background-position:0 -3348px}.favicon-islammeta{background-position:0 -3366px}.favicon-italian{background-position:0 -3384px}.favicon-italianmeta{background-position:0 -3402px}.favicon-ja{background-position:0 -3420px}.favicon-jameta{background-position:0 -3438px}.favicon-japanese{background-position:0 -3456px}.favicon-japanesemeta{background-position:0 -3474px}.favicon-joomla{background-position:0 -3492px}.favicon-joomlameta{background-position:0 -3510px}.favicon-judaism{background-position:0 -3528px}.favicon-judaismmeta{background-position:0 -3546px}.favicon-korean{background-position:0 -3564px}.favicon-koreanmeta{background-position:0 -3582px}.favicon-languagelearning{background-position:0 -3600px}.favicon-languagelearningmeta{background-position:0 -3618px}.favicon-latin{background-position:0 -3636px}.favicon-latinmeta{background-position:0 -3654px}.favicon-law{background-position:0 -3672px}.favicon-lawmeta{background-position:0 -3690px}.favicon-lifehacks{background-position:0 -3708px}.favicon-lifehacksmeta{background-position:0 -3726px}.favicon-linguistics{background-position:0 -3744px}.favicon-linguisticsmeta{background-position:0 -3762px}.favicon-literature{background-position:0 -3780px}.favicon-literaturemeta{background-position:0 -3798px}.favicon-magento{background-position:0 -3816px}.favicon-magentometa{background-position:0 -3834px}.favicon-martialarts{background-position:0 -3852px}.favicon-martialartsmeta{background-position:0 -3870px}.favicon-math{background-position:0 -3888px}.favicon-matheducators{background-position:0 -3906px}.favicon-matheducatorsmeta{background-position:0 -3924px}.favicon-mathematica{background-position:0 -3942px}.favicon-mathematicameta{background-position:0 -3960px}.favicon-mathmeta{background-position:0 -3978px}.favicon-mathoverflow{background-position:0 -3996px}.favicon-mathoverflowmeta{background-position:0 -4014px}.favicon-mattermodeling{background-position:0 -4032px}.favicon-mattermodelingmeta{background-position:0 -4050px}.favicon-mechanics{background-position:0 -4068px}.favicon-mechanicsmeta{background-position:0 -4086px}.favicon-medicalsciences{background-position:0 -4104px}.favicon-medicalsciencesmeta{background-position:0 -4122px}.favicon-monero{background-position:0 -4140px}.favicon-monerometa{background-position:0 -4158px}.favicon-money{background-position:0 -4176px}.favicon-moneymeta{background-position:0 -4194px}.favicon-movies{background-position:0 -4212px}.favicon-moviesmeta{background-position:0 -4230px}.favicon-music{background-position:0 -4248px}.favicon-musicfans{background-position:0 -4266px}.favicon-musicfansmeta{background-position:0 -4284px}.favicon-musicmeta{background-position:0 -4302px}.favicon-mythology{background-position:0 -4320px}.favicon-mythologymeta{background-position:0 -4338px}.favicon-neo{background-position:0 -4356px}.favicon-neometa{background-position:0 -4374px}.favicon-networkengineering{background-position:0 -4392px}.favicon-networkengineeringmeta{background-position:0 -4410px}.favicon-opendata{background-position:0 -4428px}.favicon-opendatameta{background-position:0 -4446px}.favicon-openscience{background-position:0 -4464px}.favicon-opensciencemeta{background-position:0 -4482px}.favicon-opensource{background-position:0 -4500px}.favicon-opensourcemeta{background-position:0 -4518px}.favicon-or{background-position:0 -4536px}.favicon-ormeta{background-position:0 -4554px}.favicon-outdoors{background-position:0 -4572px}.favicon-outdoorsmeta{background-position:0 -4590px}.favicon-parenting{background-position:0 -4608px}.favicon-parentingmeta{background-position:0 -4626px}.favicon-patents{background-position:0 -4644px}.favicon-patentsmeta{background-position:0 -4662px}.favicon-pets{background-position:0 -4680px}.favicon-petsmeta{background-position:0 -4698px}.favicon-philosophy{background-position:0 -4716px}.favicon-philosophymeta{background-position:0 -4734px}.favicon-photo{background-position:0 -4752px}.favicon-photometa{background-position:0 -4770px}.favicon-physics{background-position:0 -4788px}.favicon-physicsmeta{background-position:0 -4806px}.favicon-pm{background-position:0 -4824px}.favicon-pmmeta{background-position:0 -4842px}.favicon-poker{background-position:0 -4860px}.favicon-pokermeta{background-position:0 -4878px}.favicon-politics{background-position:0 -4896px}.favicon-politicsmeta{background-position:0 -4914px}.favicon-portuguese{background-position:0 -4932px}.favicon-portuguesemeta{background-position:0 -4950px}.favicon-productivity{background-position:0 -4968px}.favicon-productivitymeta{background-position:0 -4986px}.favicon-proofassistants{background-position:0 -5004px}.favicon-proofassistantsmeta{background-position:0 -5022px}.favicon-psychology{background-position:0 -5040px}.favicon-psychologymeta{background-position:0 -5058px}.favicon-puzzling{background-position:0 -5076px}.favicon-puzzlingmeta{background-position:0 -5094px}.favicon-quant{background-position:0 -5112px}.favicon-quantmeta{background-position:0 -5130px}.favicon-quantumcomputing{background-position:0 -5148px}.favicon-quantumcomputingmeta{background-position:0 -5166px}.favicon-raspberrypi{background-position:0 -5184px}.favicon-raspberrypimeta{background-position:0 -5202px}.favicon-retrocomputing{background-position:0 -5220px}.favicon-retrocomputingmeta{background-position:0 -5238px}.favicon-reverseengineering{background-position:0 -5256px}.favicon-reverseengineeringmeta{background-position:0 -5274px}.favicon-robotics{background-position:0 -5292px}.favicon-roboticsmeta{background-position:0 -5310px}.favicon-rpg{background-position:0 -5328px}.favicon-rpgmeta{background-position:0 -5346px}.favicon-ru{background-position:0 -5364px}.favicon-rumeta{background-position:0 -5382px}.favicon-rus{background-position:0 -5400px}.favicon-rusmeta{background-position:0 -5418px}.favicon-russian{background-position:0 -5436px}.favicon-russianmeta{background-position:0 -5454px}.favicon-salesforce{background-position:0 -5472px}.favicon-salesforcemeta{background-position:0 -5490px}.favicon-scicomp{background-position:0 -5508px}.favicon-scicompmeta{background-position:0 -5526px}.favicon-scifi{background-position:0 -5544px}.favicon-scifimeta{background-position:0 -5562px}.favicon-security{background-position:0 -5580px}.favicon-securitymeta{background-position:0 -5598px}.favicon-serverfault{background-position:0 -5616px}.favicon-serverfaultmeta{background-position:0 -5634px}.favicon-sharepoint{background-position:0 -5652px}.favicon-sharepointmeta{background-position:0 -5670px}.favicon-sitecore{background-position:0 -5688px}.favicon-sitecoremeta{background-position:0 -5706px}.favicon-skeptics{background-position:0 -5724px}.favicon-skepticsmeta{background-position:0 -5742px}.favicon-softwareengineering{background-position:0 -5760px}.favicon-softwareengineeringmeta{background-position:0 -5778px}.favicon-softwarerecs{background-position:0 -5796px}.favicon-softwarerecsmeta{background-position:0 -5814px}.favicon-sound{background-position:0 -5832px}.favicon-soundmeta{background-position:0 -5850px}.favicon-space{background-position:0 -5868px}.favicon-spacemeta{background-position:0 -5886px}.favicon-spanish{background-position:0 -5904px}.favicon-spanishmeta{background-position:0 -5922px}.favicon-sports{background-position:0 -5940px}.favicon-sportsmeta{background-position:0 -5958px}.favicon-sqa{background-position:0 -5976px}.favicon-sqameta{background-position:0 -5994px}.favicon-stackapps{background-position:0 -6012px}.favicon-stackexchange{background-position:0 -6030px}.favicon-stackexchangemeta{background-position:0 -6048px}.favicon-stackoverflow{background-position:0 -6066px}.favicon-stackoverflowmeta{background-position:0 -6084px}.favicon-stats{background-position:0 -6102px}.favicon-statsmeta{background-position:0 -6120px}.favicon-stellar{background-position:0 -6138px}.favicon-stellarmeta{background-position:0 -6156px}.favicon-substrate{background-position:0 -6174px}.favicon-substratemeta{background-position:0 -6192px}.favicon-superuser{background-position:0 -6210px}.favicon-superusermeta{background-position:0 -6228px}.favicon-sustainability{background-position:0 -6246px}.favicon-sustainabilitymeta{background-position:0 -6264px}.favicon-techcomm{background-position:0 -6282px}.favicon-techcommmeta{background-position:0 -6300px}.favicon-tex{background-position:0 -6318px}.favicon-texmeta{background-position:0 -6336px}.favicon-tezos{background-position:0 -6354px}.favicon-tezosmeta{background-position:0 -6372px}.favicon-tor{background-position:0 -6390px}.favicon-tormeta{background-position:0 -6408px}.favicon-travel{background-position:0 -6426px}.favicon-travelmeta{background-position:0 -6444px}.favicon-tridion{background-position:0 -6462px}.favicon-tridionmeta{background-position:0 -6480px}.favicon-ukrainian{background-position:0 -6498px}.favicon-ukrainianmeta{background-position:0 -6516px}.favicon-unix{background-position:0 -6534px}.favicon-unixmeta{background-position:0 -6552px}.favicon-ux{background-position:0 -6570px}.favicon-uxmeta{background-position:0 -6588px}.favicon-vegetarianism{background-position:0 -6606px}.favicon-vegetarianismmeta{background-position:0 -6624px}.favicon-vi{background-position:0 -6642px}.favicon-vimeta{background-position:0 -6660px}.favicon-webapps{background-position:0 -6678px}.favicon-webappsmeta{background-position:0 -6696px}.favicon-webmasters{background-position:0 -6714px}.favicon-webmastersmeta{background-position:0 -6732px}.favicon-windowsphone{background-position:0 -6750px}.favicon-windowsphonemeta{background-position:0 -6768px}.favicon-woodworking{background-position:0 -6786px}.favicon-woodworkingmeta{background-position:0 -6804px}.favicon-wordpress{background-position:0 -6822px}.favicon-wordpressmeta{background-position:0 -6840px}.favicon-workplace{background-position:0 -6858px}.favicon-workplacemeta{background-position:0 -6876px}.favicon-worldbuilding{background-position:0 -6894px}.favicon-worldbuildingmeta{background-position:0 -6912px}.favicon-writing{background-position:0 -6930px}.favicon-writingmeta{background-position:0 -6948px}.autocomplete{position:relative}.autocomplete .autocomplete-suggestions-list{background:hsl(0,0%,100%);border:1px solid hsl(210,8%,80%);color:hsl(210,8%,45%);position:absolute;z-index:999;bottom:6px;left:0;right:0;transform:translate(0, 100%);box-shadow:0 6px 6px hsla(210,8%,5%,0.1);max-height:350px;overflow:auto}.autocomplete .autocomplete-suggestions-list a{color:hsl(210,8%,45%)}.autocomplete .autocomplete-suggestions-list .autocomplete-category-name,.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion,.autocomplete .autocomplete-suggestions-list .autocomplete-default,.autocomplete .autocomplete-suggestions-list .autocomplete-default{padding:10px}.autocomplete .autocomplete-suggestions-list .autocomplete-category-name{background:#f6f6f7;font-size:11px;text-transform:uppercase}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion{cursor:pointer;display:flex;align-items:center}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion.child{padding-left:26px;margin-top:-5px;position:relative}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion.child:before{content:'';display:inline-block;width:12px;height:12px;border-left:1px solid #b9c1c5;border-bottom:1px solid #b9c1c5;position:relative;top:-6px;left:-6px}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion:hover,.autocomplete .autocomplete-suggestions-list .autocomplete-default:hover{background:#eeeef0;color:hsl(210,8%,5%)}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-item{max-width:90%;word-wrap:break-word;overflow:hidden;flex-grow:1;margin-left:6px}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-image{width:20px;height:20px;overflow:hidden;flex-shrink:0}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-image img{max-width:100%;height:auto}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-match{color:hsl(210,8%,5%);font-weight:700}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-url{font-size:11px;color:hsl(210,8%,75%)}.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-count{font-size:13px;color:hsl(210,8%,60%)}.autocomplete .autocomplete-suggestions-list .autocomplete-default{border-top:1px solid hsl(210,8%,80%);display:block}#tabs,.tabs{float:right}#tabs a,.tabs a{float:left;margin-right:8px;padding:12px 8px 14px;color:var(--black-400);line-height:1;text-decoration:none;border-bottom:2px solid transparent}#tabs a:last-child,.tabs a:last-child{margin-right:0}#tabs a:focus,.tabs a:focus{outline:none}#tabs a:hover,.tabs a:hover{color:var(--black-500);border-bottom-color:var(--black-500)}#tabs a.youarehere,.tabs a.youarehere{font-weight:700;color:var(--black-800);border-bottom-color:var(--black-800)}#tabs .mod-flag-indicator,.tabs .mod-flag-indicator{margin-left:-4px}#tabs .bounty-indicator-tab,.tabs .bounty-indicator-tab{margin-right:0;padding:.4em .5em .3em;vertical-align:middle;line-height:1}.subtabs,.filter{box-sizing:border-box;float:right;margin:0}.subtabs a,.filter a{display:block;margin:0 0 0 2px;padding:8px;border-bottom:1px solid transparent;color:var(--black-500);font-size:12px;line-height:1.92307692;text-decoration:none;transition:all 150ms cubic-bezier(.19, 1, .22, 1)}.subtabs a.youarehere,.filter a.youarehere,.subtabs a.active,.filter a.active,.subtabs a:hover,.filter a:hover{border-color:var(--theme-primary-color);color:var(--black-700);text-decoration:none}.subtabs a.youarehere,.filter a.youarehere,.subtabs a.active,.filter a.active{border-color:var(--theme-primary-color);font-weight:700}.subtabs a.youarehere:hover,.filter a.youarehere:hover,.subtabs a.active:hover,.filter a.active:hover{border-color:var(--theme-primary-500);color:var(--black-900)}.subtabs a{float:right}.subtabs.filters.tag-synonyms{width:auto}.filter{margin:0}.filter a{display:inline-flex;padding-left:4px;padding-right:4px;border-bottom-width:2px}[class*="gravatar-wrapper-"]{padding:0;overflow:hidden}[class*="gravatar-wrapper-"] img{margin:0 auto}.gravatar-wrapper-256,.gravatar-wrapper-164,.gravatar-wrapper-128,.gravatar-wrapper-256 img,.gravatar-wrapper-164 img,.gravatar-wrapper-128 img{border-radius:4px}.gravatar-wrapper-64,.gravatar-wrapper-50,.gravatar-wrapper-48,.gravatar-wrapper-64 img,.gravatar-wrapper-50 img,.gravatar-wrapper-48 img{border-radius:2px}.gravatar-wrapper-256,.gravatar-wrapper-256 img{width:256px;height:256px}.gravatar-wrapper-164,.gravatar-wrapper-164 img{width:164px;height:164px}.gravatar-wrapper-128,.gravatar-wrapper-128 img{width:128px;height:128px}.gravatar-wrapper-64,.gravatar-wrapper-64 img{width:64px;height:64px}.gravatar-wrapper-50,.gravatar-wrapper-50 img{width:50px;height:50px}.gravatar-wrapper-48,.gravatar-wrapper-48 img{width:48px;height:48px}.gravatar-wrapper-42,.gravatar-wrapper-42 img{width:42px;height:42px}.gravatar-wrapper-40,.gravatar-wrapper-40 img{width:40px;height:40px}.gravatar-wrapper-32,.gravatar-wrapper-32 img{width:32px;height:32px}.gravatar-wrapper-25,.gravatar-wrapper-25 img{width:25px;height:25px}.dropdown.left:before{left:4px}.dropdown.right:before{right:4px}.dropdown{position:absolute !important;top:25px;z-index:100;box-shadow:0 2px 5px hsla(210,8%,5%,0.3);border-radius:2px;background-color:var(--white);margin:0}.dropdown:before{position:absolute;z-index:101;content:"";width:16px;height:16px;top:-11px;right:4px;background:url('../../Img/filter-sprites.png?v=25267dbcd657') -16px 0 no-repeat;background:url('../../Img/filter-sprites.svg?v=d1e85fbf5198') -16px 0 no-repeat}.dropdown ul{margin:0}.dropdown li{text-align:left;white-space:nowrap;position:relative;border-bottom:1px solid var(--black-050);line-height:12px;display:block;background-color:var(--white);height:auto;margin-bottom:0;transition:all .2s ease}.dropdown li:hover{background-color:var(--black-025)}.dropdown li:active{background-color:var(--black-050)}.dropdown li a.selected{background-color:hsl(210,8%,95%);color:hsl(210,8%,60%)}.dropdown li:first-child{border-top:1px solid var(--black-050)}.dropdown li .bounty-indicator-tab{margin-left:10px}.dropdown li .bounty-indicator-tab a:hover{text-decoration:none}.dropdown li a{box-sizing:border-box;width:100%;padding:10px 10px 10px 10px;display:inline-block}.dropdown li a#edit-favorite-tags{width:auto;font-size:11px}.-is-active .-frequency-menu{max-height:40em}@keyframes spinnerRotate{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}a.loading:before{content:"";position:relative;display:inline-block;top:1px;left:-4px;width:8px;height:8px;border-radius:50%;border:2px solid hsl(205,53%,88%);border-left-color:hsl(205,56%,76%);transform:translateZ(0);animation:spinnerRotate .8s infinite linear}.hero-background{background-image:url("../../Img/hero/anonymousHeroBackground.svg?v=b7f6054406b5");background-size:contain;background-repeat:no-repeat;background-position:center}.hero-box{background:#437dcc;margin:40px 0;color:hsl(0,0%,100%);text-align:center;position:relative}.hero-box .hero-content{padding:30px}.hero-box .hidden{display:none}.hero-box .hero-title{font-size:1.46153846rem;font-weight:400;margin-bottom:30px}.hero-box .hero-title small{display:block;font-size:1.30769231rem;padding-top:4px}.hero-box .subtitle{font-size:1.15384615rem}.hero-box .btn{background:#f48024;border-color:#9B6114;box-shadow:inset 0 1px 0 #ffc272}.hero-box .btn.loading{color:white}.hero-box .btn:hover{background:#da670b}.modal{max-width:700px;max-height:900px;min-width:400px;background-color:var(--white);border-radius:3px;position:fixed !important;z-index:9999;overflow:hidden}@media (prefers-color-scheme:dark){body.theme-system .modal{background-image:var(--black-100)}}body.theme-dark .modal,.theme-dark__forced .modal{background-image:var(--black-100)}.modal *{box-sizing:border-box}.modal.auto-center{left:50% !important;top:50% !important;transform:translate(-50%, -50%)}.modal.wmd-prompt-dialog{padding:0;border:0}.modal:focus{outline:none}.modal .modal-close{position:absolute;top:4px;right:4px;z-index:2;font-family:var(--ff-sans);color:var(--black-200);font-size:1.30769231rem;font-weight:600;line-height:1;width:30px;height:30px;text-align:center;padding-top:7px;border-radius:50%;cursor:pointer}.modal .modal-close:hover{color:var(--black-600);background:var(--black-050)}.modal .modal-content,.modal .modal-footer{padding:30px}.modal .modal-footer{background:hsl(210,8%,25%);color:hsl(0,0%,100%)}.modal .modal-footer a{color:inherit;text-decoration:underline}.modal .modal-footer a:hover{color:hsl(0,0%,100%)}.modal-overlay{position:fixed;top:0;right:0;bottom:0;left:0;background:hsla(210,8%,5%,0.5);z-index:1001}.modal.image-upload .modal-content{text-align:center}.modal.image-upload .modal-options{padding:24px 0 9px 0;color:var(--black-700)}.modal.image-upload .modal-options p{margin-bottom:0}.modal.image-upload .modal-options .ajax-loader{margin-left:10px}.modal.image-upload .modal-options-separator{margin:0 6px}.modal.image-upload .modal-dropzone-default,.modal.image-upload .modal-dropzone-preview{border:2px dashed var(--black-075);height:260px;border-radius:3px;padding:15px;width:620px;position:relative}.modal.image-upload .modal-dropzone-default{background:var(--black-050);cursor:pointer;transition:background 300ms ease, border 300ms ease}.modal.image-upload .modal-dropzone-default:hover,.modal.image-upload .modal-dropzone-default.hover{background:var(--black-075);border-color:var(--black-100)}.modal.image-upload .modal-dropzone-default:hover .modal-dropzone-img:before,.modal.image-upload .modal-dropzone-default.hover .modal-dropzone-img:before{top:-50px}.modal.image-upload .modal-dropzone-default:hover .modal-dropzone-img:after,.modal.image-upload .modal-dropzone-default.hover .modal-dropzone-img:after{top:-76px}.modal.image-upload .modal-dropzone-default>*{pointer-events:none}.modal.image-upload .modal-dropzone-default .modal-dropzone-img{background-image:url("../../Img/img-upload.png?v=f6bb23984932");background-image:url('../../Img/img-upload.svg?v=16d9e4614ece'),none;background-position:0 0;width:86px;height:78px;position:absolute;top:88px;left:50%;margin-left:-43px}.modal.image-upload .modal-dropzone-default .modal-dropzone-img:before,.modal.image-upload .modal-dropzone-default .modal-dropzone-img:after{position:absolute;background-image:url("../../Img/img-upload.png?v=f6bb23984932");background-image:url('../../Img/img-upload.svg?v=16d9e4614ece'),none;display:block;content:'';transition:all .15s ease}.modal.image-upload .modal-dropzone-default .modal-dropzone-img:before{background-position:-120px -21px;width:156px;height:65px;top:-44px;left:-33px}.modal.image-upload .modal-dropzone-default .modal-dropzone-img:after{background-position:-130px -90px;width:53px;height:61px;top:-66px;left:18px}.modal.image-upload .modal-dropzone-default p{margin-top:166px;margin-bottom:0;color:var(--black-350);font-size:1.30769231rem}.modal.image-upload .modal-dropzone-default p b{font-size:2.07692308rem;color:var(--black-500);font-weight:700;display:block;margin-bottom:10px}.modal.image-upload .modal-options-error-message{color:var(--red-500);font-weight:bold}.modal.image-upload .modal-footer p{padding-top:12px}.modal.wmd-prompt-dialog.insert-link{padding:20px;width:470px;overflow:visible}.modal.wmd-prompt-dialog.insert-link .tabs{margin-bottom:20px;float:left;width:100%;height:41px;border-bottom:1px solid var(--black-050)}.modal.wmd-prompt-dialog.insert-link .notes{padding:5px}.modal.wmd-prompt-dialog.insert-link form{padding:0;margin:0;float:left;width:100%;position:relative}.modal.wmd-prompt-dialog.insert-link form input[type=text]{display:block;width:100%;margin:0 auto}.modal.wmd-prompt-dialog.insert-link form input[type=button]{margin:20px 10px 0 0;display:inline}.modal.wmd-prompt-dialog.insert-link form input[type=button].insert-hyperlink{width:5em}.popup{z-index:2000;display:none;position:absolute;padding:16px;box-shadow:var(--bs-sm);background-color:var(--white);border:solid 1px var(--black-300)}@media (prefers-color-scheme:dark){body.theme-system .popup{background-color:var(--black-100)}}body.theme-dark .popup,.theme-dark__forced .popup{background-color:var(--black-100)}.popup .already-flagged{display:inline-block;margin-left:23px;margin-top:8px;color:var(--red-700);font-weight:700}.popup .disabled-action{cursor:default !important}.popup .disabled-action .action-desc,.popup .disabled-action .action-name{opacity:.6;cursor:default !important}.popup textarea{width:100%}.popup .subheader{margin-bottom:10px !important;margin-top:25px !important}.popup .popup-title-container{margin-bottom:10px}.popup .popup-title-container .popup-breadcrumbs .breadcrumb .arrow{padding:0 6px}.popup #search-text,.popup .close-as-duplicate-pane .actual-edit-overlay{width:755px !important}.popup .question-summary{border:0}.message.message-config,.contributor-dropdown,.ask-confirmation-popup{border-radius:5px;border:0;box-shadow:var(--bs-sm)}.message.message-config .message-close,.contributor-dropdown .message-close,.ask-confirmation-popup .message-close,.message.message-config .popup-close a,.contributor-dropdown .popup-close a,.ask-confirmation-popup .popup-close a{margin:0;padding:0;position:absolute;z-index:2;top:11px;right:10px;border:0;font-size:1.30769231rem;cursor:pointer;color:var(--black-200) !important;font-weight:600}.message.message-config .message-close:hover,.contributor-dropdown .message-close:hover,.ask-confirmation-popup .message-close:hover,.message.message-config .popup-close a:hover,.contributor-dropdown .popup-close a:hover,.ask-confirmation-popup .popup-close a:hover{color:var(--black-600) !important}.message.message-config .popup-close a,.contributor-dropdown .popup-close a,.ask-confirmation-popup .popup-close a{background:none;right:22px}.ask-confirmation-popup .popup-close a{top:16px;right:16px}.ask-confirmation-popup .popup-title{padding-right:32px}.ask-confirmation-popup .popup-actions{display:flex;justify-content:center;align-items:center;margin-top:8px}.ask-confirmation-popup .popup-actions-cancel{margin-right:16px}.message.message-config .message-tip .popup-title{font-weight:700 !important}.message.message-config .message-tip.message-tip-top-right:before,.message.message-config .message-tip.message-tip-top-left:before{width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-bottom:6px solid var(--white);top:-12px}.message.message-config .message-tip.message-tip-top-right:before{right:12px}.message.message-config .message-tip.message-tip-top-left:before{left:12px}.message.message-config h1,.message.message-config h2,.message.message-config h3,.message.message-config h4{color:var(--black-900);margin-bottom:1em}.message.message-config h4{text-align:left;letter-spacing:0;margin-right:16px}.message.message-config h4.popup-nav-title{text-align:center;margin:0 15px 15px 10px}.message.message-config .actions{margin:20px -20px -20px -20px;padding:0 15px 0 15px;background:hsl(210,8%,25%);height:48px;border-radius:0 0 3px 3px}.message.message-config .actions:before,.message.message-config .actions:after{content:"";display:table}.message.message-config .actions:after{clear:both}.message.message-config .actions .rep-number,.message.message-config .actions .button{text-align:center;font-size:12px}.message.message-config .actions .rep-number{float:left;display:inline-block;color:hsl(0,0%,100%);font-weight:700;padding-top:16px}.message.message-config .actions .button{float:right;padding:8px 16px;margin-top:10px;text-decoration:none;display:inline-block;color:hsl(0,0%,100%) !important;font-weight:600;background:var(--blue-400);box-shadow:none!important;border:0;border-radius:3px}.message.message-config .actions .button:hover{background:var(--blue-600)}.message.message-config .actions .button:after{content:" ";display:inline-block;background-image:url("../../Img/user-profile-sprite.png?v=6829b895a42c");background-image:url("../../Img/user-profile-sprite.svg?v=d88bb7069e3d"),none;background-position:-15px -409px;width:7px;height:10px;position:relative;top:2px;left:4px}.message.message-config .message-text{padding:20px !important;border-radius:6px;position:relative;z-index:1}.message.message-config .message-text .question-hyperlink,.message.message-config .message-text .answer-hyperlink{font-size:13px;text-decoration:none;color:var(--theme-post-title-color)}.message.message-config .message-text .question-hyperlink:hover,.message.message-config .message-text .answer-hyperlink:hover{color:var(--theme-post-title-color-hover)}.message.message-config .popup-nav{list-style:none;margin:0 -20px -20px -20px;padding:0;text-align:center}.message.message-config .popup-nav li{margin:0;padding:0;border-bottom:1px solid var(--black-050)}.message.message-config .popup-nav li:last-child{border-bottom:0}.message.message-config .popup-nav li:first-child{border-top:1px solid var(--black-050)}.message.message-config .popup-nav li a{transition:color .3s ease,background .3s ease;text-decoration:none;color:var(--black-500);font-size:13px;display:block;padding:10px 15px}.message.message-config .popup-nav li a:hover,.message.message-config .popup-nav li a.active,.message.message-config .popup-nav li a.youarehere{background:var(--blue-600);color:var(--white)}.message.message-config .unstyled{padding:0;list-style:none;text-align:center;margin:0 -20px -20px -20px}.message.message-config .unstyled li{border-bottom:1px solid var(--black-050);padding:10px}.message.message-config .unstyled li .badge{text-decoration:none}.message.message-config .unstyled li:first-child{border-top:1px solid var(--black-050)}.message.message-config .unstyled li:last-child{border-bottom:0}.message.message-config.tooltip{border-radius:3px;pointer-events:none}.message.message-config.tooltip .message-inner:before{display:none}.message.message-config.tooltip .message-text{font-weight:500;font-size:11px;color:var(--black-900);padding:3px 8px!important;border-radius:3px}.message.message-config .no-cta p{margin-bottom:0}.message.message-config .no-cta .bars-wrapper{margin-top:10px}.envelope-on,.envelope-off,.vote-up-off,.vote-up-on,.vote-down-off,.vote-down-on,.feed-icon,.vote-accepted-off,.vote-accepted-on,.vote-accepted-bounty,.badge-earned-check,.delete-tag,.grippie,.expander-arrow-hide,.expander-arrow-show,.expander-arrow-small-hide,.expander-arrow-small-show,.anonymous-gravatar,.badge1,.badge2,.badge3{background-image:url("../../Img/unified/sprites.png?v=0786b22b9381");background-image:url("../../Img/unified/sprites.svg?v=fcc0ea44ba27"),none;background-size:initial;background-repeat:no-repeat;overflow:hidden}.vote-up-off,.vote-up-on,.vote-down-off,.vote-down-on,.vote-accepted-off,.vote-accepted-on{display:block;margin:0 auto;text-indent:-999em;width:40px;height:40px;margin-bottom:2px}.vote-up-off,.vote-down-off,.vote-accepted-off{cursor:pointer}.vote-up-off,.vote-up-on,.vote-down-off,.vote-down-on,.vote-accepted-off,.vote-accepted-on{text-indent:-9999em;font-size:1px}.vote-up-off{background-position:0 -170px}.vote-up-on{background-position:-40px -170px}.vote-down-off{background-position:0 -220px;margin-bottom:8px}.vote-down-on{background-position:-40px -220px;margin-bottom:8px}.vote-accepted-off{background-position:0 -270px}.vote-accepted-on{background-position:-40px -270px}.migrated.to,.migrated.from{background-image:url("../../Img/unified/sprites.png?v=0786b22b9381") !important;background-repeat:no-repeat;overflow:hidden;background-color:transparent}.icon-bg{display:inline-block;border:none;height:18px;width:18px;padding:0}.icon-bg::after{content:"";height:100%;width:100%;display:inline-block;background-color:currentColor;-webkit-mask:var(--bg-icon) no-repeat center;mask:var(--bg-icon) no-repeat center;-webkit-mask-size:contain;mask-size:contain}.icon-bg.native::after{background-color:unset;-webkit-mask:none;mask:none;background-image:var(--bg-icon);background-size:contain;background-repeat:no-repeat;background-position:center}.icon-bg.iconAchievements{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconAchievements' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M15 2V1H3v1H0v4c0 1.6 1.4 3 3 3v1c.4 1.5 3 2.6 5 3v2H5s-1 1.5-1 2h10c0-.4-1-2-1-2h-3v-2c2-.4 4.6-1.5 5-3V9c1.6-.2 3-1.4 3-3V2h-3zM3 7c-.5 0-1-.5-1-1V4h1v3zm8.4 2.5L9 8 6.6 9.4l1-2.7L5 5h3l1-2.7L10 5h2.8l-2.3 1.8 1 2.7h-.1zM16 6c0 .5-.5 1-1 1V4h1v2z'/%3E%3C/svg%3E")}.icon-bg.iconFaceMindBlown{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconFaceMindBlown' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath opacity='.4' d='M1.06 8a8 8 0 1015.88 0H16l-1 .5-1-.5h-1.5l-1.5.5L9 8l-.5.5-1-.5H6l-1 .5-.5-.5h-1l-.5.5L2 8h-.94z' fill='%23FFAA3B'/%3E%3Cpath opacity='.3' d='M3.5 8h.41a11.5 11.5 0 0010.38 7A8 8 0 011.06 8H2l1 .5.5-.5z' fill='%23FF9700'/%3E%3Cpath d='M6.07 14.68a.7.7 0 00.67.28c1.5-.16 3.01-.16 4.51 0a.71.71 0 00.67-.28.7.7 0 00.06-.72A3.23 3.23 0 009 12.36a3.3 3.3 0 00-3 1.6.7.7 0 00.07.72z' fill='var(--black-900)'/%3E%3Cpath d='M7.36 4.37c.18.23.4.42.68.55a2.19 2.19 0 001.95 0c.26-.13.48-.31.65-.53.15.93.36 2.29.36 2.61 0 .5-4 .5-4 0 0-.32.21-1.7.36-2.63z' fill='%23F75D37'/%3E%3Cpath opacity='.67' d='M15.33 2.43a2.8 2.8 0 00-1.73-.53c-.06-.4-.28-.76-.64-1.05-.35-.26-.8-.44-1.27-.5-.49-.06-.98 0-1.42.16A2.9 2.9 0 008.4.08c-.39.05-.75.17-1.06.36A3.04 3.04 0 006.02.37c-.8.13-1.48.6-1.72 1.2-.11.27-.13.55-.07.83-.77.07-1.47.45-1.8.99-.6.98.26 2.4 1.6 2.6.97.14 2.13-.15 2.63-.79.22-.27.33-.58.34-.9.21.26.5.47.86.62a2.92 2.92 0 002.28 0c.35-.15.64-.37.85-.63.04.43.27.83.65 1.14a2.93 2.93 0 003.03.25c.81-.42 1.42-1.42 1.32-2.16-.05-.41-.28-.8-.66-1.09z' fill='%23FFC166'/%3E%3Cpath opacity='.78' d='M7.4 2c1.19 0 2.3-.2 3.26-.55.9 1.2 2.88 2.13 5.32 2.44A2.61 2.61 0 0113.1 6a2.68 2.68 0 01-1.45-.56A1.65 1.65 0 0111 4.3c-.2.26-.5.48-.85.63a2.92 2.92 0 01-2.28 0A2.21 2.21 0 017 4.3c0 .32-.12.63-.34.9-.5.64-1.66.93-2.62.78-1.35-.2-2.22-1.6-1.6-2.6a2.36 2.36 0 011.79-.98 1.4 1.4 0 01.1-.88c.9.3 1.95.48 3.07.48z' fill='%23FFC166'/%3E%3Cpath opacity='.52' d='M11.09 3.47a7.43 7.43 0 01-5.43.05c-1 .27-2.17.44-3.42.47-.06.88.71 1.83 1.8 2 .96.14 2.12-.15 2.62-.79.22-.27.33-.58.34-.9.21.26.5.47.86.62a2.92 2.92 0 002.28 0c.35-.15.64-.37.85-.63.04.43.27.83.65 1.14a2.93 2.93 0 003.03.25c.35-.18.66-.47.9-.8a11.57 11.57 0 01-4.48-1.4z' fill='%23F75D37'/%3E%3Ccircle cx='11' cy='10.5' r='1.35' fill='var(--black-900)'/%3E%3Ccircle cx='7' cy='10.5' r='1.35' fill='var(--black-900)'/%3E%3Ccircle opacity='.6' cx='3.5' cy='6.5' r='.5'/%3E%3Ccircle opacity='.6' cx='14.5' cy='.5' r='.5'/%3E%3Ccircle opacity='.6' cx='14.5' cy='6.5' r='.5'/%3E%3Ccircle opacity='.6' cx='16.5' cy='4.5' r='.5'/%3E%3Ccircle opacity='.6' cx='3.5' cy='.5' r='.5'/%3E%3Ccircle opacity='.6' cx='1.5' cy='3.5' r='.5'/%3E%3C/svg%3E")}.icon-bg.iconWave{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconWave' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M10.7 17c-2.3 0-3.9-2.05-5.07-3.54l-.49-.6c-.67-.8-1.59-1.63-2.4-2.36A10.91 10.91 0 011.1 8.87a.79.79 0 01-.09-.56c.04-.19.14-.34.27-.4.14-.07.29-.1.45-.1.35 0 .67.18.87.34l3.5 2.75c.04.03.1.03.13 0a.09.09 0 00.02-.13l-.02-.02c-.57-.8-3.42-4.77-3.71-5.15-.21-.27-.3-.58-.24-.84.05-.2.2-.37.4-.48.18-.09.35-.13.52-.13.44 0 .76.28.96.51l3.6 4.42c.04.04.07.06.14.02.05-.02.06-.07.03-.12L4.41 2.96a.94.94 0 01-.1-.73.92.92 0 01.47-.57 1.06 1.06 0 011.4.39l3.8 6.14c.03.04.07.07.14.04.04-.03.06-.07.04-.13A153.8 153.8 0 008.1 2.54c-.31-.68-.2-1.14.36-1.42.52-.27 1.14-.07 1.47.48l3.69 8.3c.02.04.05.05.1.06a.1.1 0 00.09-.07l.66-2.28c.1-.3.31-.56.62-.72.3-.15.65-.18.98-.1.7.2 1.09.87.89 1.52-.1.37-.46 1.73-.99 3.43l-.1.33c-.58 1.86-1.03 3.33-3.11 4.4-.7.35-1.38.53-2.05.53z' fill='%23FFC166'/%3E%3Cpath d='M14 .37a.5.5 0 00-.88.45l1.96 3.9a.5.5 0 00.9-.45L14 .37zm-1.17 2.17a.5.5 0 00-.91.42l.84 1.87a.5.5 0 10.91-.41l-.84-1.88zm-10.6 9.74a.5.5 0 01.7-.02l1.7 1.6a.5.5 0 01-.7.72l-1.68-1.6a.5.5 0 01-.02-.7zm-1.39.98a.5.5 0 10-.68.73l3.03 2.84a.5.5 0 00.68-.73L.84 13.26z' opacity='.4'/%3E%3C/svg%3E")}.icon-bg.iconFire{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconFire' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath opacity='.6' d='M13.18 9c-.8.33-1.46.6-1.97 1.3A9.21 9.21 0 0010 13.89a10 10 0 001.32-.8 2.53 2.53 0 01-.63 2.91h.78a3 3 0 001.66-.5 4.15 4.15 0 001.26-1.61c.4-.96.47-1.7.55-2.73.05-1.24-.1-2.49-.46-3.68a2 2 0 01-.4.91 2.1 2.1 0 01-.9.62z' fill='%23FF6700'/%3E%3Cpath d='M10.4 12.11a7.1 7.1 0 01.78-1.76c.3-.47.81-.8 1.37-1.08 0 0-.05-3.27-1.55-5.27-1.5-2-3.37-2.75-4.95-2.61 0 0 3.73 2.42.72 5.15C4.63 8.45 3.59 10.87 4.13 13a4.14 4.14 0 003.1 3 4.05 4.05 0 011.08-3.89C9.42 10.92 8 9.79 8 9.79c.67.02 1.3.28 1.81.72a2 2 0 01.58 1.6z' fill='%23EF2E2E'/%3E%3C/svg%3E")}.icon-bg.iconHeart{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconHeart' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M5.25 2c-1.5 0-2.35.5-3.15 1.36C.5 5 .5 8.2 2.1 10l6 5.87c.2.2.6.2.8 0l6-5.87c1.6-1.8 1.6-5 0-6.64A3.86 3.86 0 0011.75 2C10.2 2 9 3 8.5 3.9 8 3 6.5 2 5.25 2zm8.6 4.85l-2 2a.5.5 0 01-.7-.7l2-2a.5.5 0 01.7.7z' fill='%23F75D37'/%3E%3C/svg%3E")}.icon-bg.iconClap{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconClap' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M12.5 3a.5.5 0 01-.5-.5v-2a.5.5 0 011 0v2a.5.5 0 01-.5.5zM14 4.5c0-.28.22-.5.5-.5h2a.5.5 0 010 1h-2a.5.5 0 01-.5-.5zm-.35-1.85a.5.5 0 00.7.7l1.5-1.5a.5.5 0 00-.7-.7l-1.5 1.5z' opacity='.4'/%3E%3Cpath d='M2.58 8.69c.33.45.73.8 1.15 1.06L5.8 6c.17-.29.4-.56.68-.74.44-.28.99-.26 1.4-.02h.02c.32-.04 1.6-.06 2.73-.08a41.5 41.5 0 001.77-.04c.49-.04.68-.3.65-.75-.02-.46-.44-.65-.9-.6l-6.76.36c-.05.01-.1-.07-.07-.11l1.03-1.36c.3-.4.16-.97-.21-1.26a.87.87 0 00-1.25.13C4.3 2.26 3.74 3 3.19 3.76c-1.08 1.47-1.83 3.29-.61 4.93zm10.1.41h-.75c.11-.23.18-.47.17-.73 0-.19-.06-.37-.15-.53l.73.01c.41.03.68.35.68.6 0 .24-.23.66-.68.65zM10.9 7.15l2.6-.02a.66.66 0 00.6-.77c-.08-.41-.47-.64-.87-.64l-2.66.04c.35.37.48.9.33 1.4zM5.52 17c-2.04 0-3.15-1.78-3.7-3.52a53.2 53.2 0 01-.77-2.7c-.15-.46.14-.94.63-1.07.47-.13 1 .1 1.15.58l.47 1.63c.02.06.11.06.14 0l3.01-5.54c.24-.4.6-.73.97-.54.4.2.47.54.25 1.02-.08.18-.33.66-.63 1.22-.51.96-1.15 2.16-1.26 2.49-.01.04-.03.21.08.29.1.07.28-.06.3-.09l2.71-4.14c.2-.34.63-.66.98-.48.34.18.46.6.26.93L7.37 11.2c-.02.03-.14.32.05.43.19.12.4-.04.42-.07L10.2 8.3c.27-.31.51-.51.9-.32.34.18.33.61.06.97-.45.6-.8 1.13-1.16 1.64-.4.58-.8 1.15-1.28 1.8-.02.03-.13.23 0 .37.12.13.27 0 .27 0l1.9-2.3c.23-.3.48-.42.8-.25.28.14.22.58.09.8-.53.91-1.2 1.72-1.86 2.53C8.75 14.94 7.55 17 5.52 17z' fill='%23FFC166'/%3E%3C/svg%3E")}.icon-bg.iconFaceSmile{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconFaceSmile' width='18' height='18' viewBox='0 0 18 18'%3E%3Ccircle opacity='.4' cx='9' cy='9' r='8' fill='%23FFAA3B'/%3E%3Cpath opacity='.3' d='M8.41 17a10 10 0 01.38-15.75c.1-.08.2-.16.28-.25a8 8 0 00-.66 16z' fill='%23FF9700'/%3E%3Cpath d='M6.5 8a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm2.6 6a7.37 7.37 0 01-4.79-2.06 1.1 1.1 0 010-1.54c.42-.51 1.15-.51 1.67-.1.31.3 3.23 2.88 6.14 0a1.06 1.06 0 011.57.1 1.1 1.1 0 010 1.54C12.13 13.38 10.56 14 9.1 14zM13 6.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z' fill='var(--black-900)'/%3E%3C/svg%3E")}.icon-bg.iconTada{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconTada' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath opacity='.4' d='M10.38 7.48c-2.9-2.9-5.4-3.73-5.51-3.38l-3.8 11.45c-.14.4-.03.86.27 1.15.3.3.78.38 1.17.22l11.42-3.31c.3-.15-.64-3.22-3.54-6.13z' fill='%23FF9700'/%3E%3Cpath d='M6.8 11.07a18.02 18.02 0 01-2.93-3.96l1-3C5.47 6.15 6.65 8 8.25 9.4a21.72 21.72 0 005.59 4.22l-2.86.83a31.19 31.19 0 01-4.17-3.39zM3.6 14.2a4.26 4.26 0 01-1.33-2.24l.91-2.74c.5 1.27 1.25 2.43 2.2 3.4.95.95 2 1.81 3.1 2.57l-2.57.74a9.03 9.03 0 01-2.31-1.72z' opacity='.6' fill='%23FF9700'/%3E%3Cpath d='M15.85 2.15c.2.2.2.5 0 .7l-4 4a.5.5 0 01-.7-.7l4-4c.2-.2.5-.2.7 0z' fill='%23F75D37'/%3E%3Cpath d='M10 1.5a.5.5 0 00-1 0v3a.5.5 0 001 0v-3zM13.5 8a.5.5 0 000 1h3a.5.5 0 000-1h-3z' fill='%2307C'/%3E%3Cpath d='M7.5 3a.5.5 0 100-1 .5.5 0 000 1zm5 0a.5.5 0 100-1 .5.5 0 000 1zM16 5.5a.5.5 0 11-1 0 .5.5 0 011 0zm-.5 5.5a.5.5 0 100-1 .5.5 0 000 1z' opacity='.6' fill='%2307C'/%3E%3C/svg%3E")}.icon-bg.iconSmileyAdd{--bg-icon:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconSmileyAdd' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M13 0h2v3h3v2h-3v3h-2V5h-3V3h3V0zM6.44 2.15A8 8 0 018 2v2a6 6 0 106 6h2a8 8 0 11-9.56-7.85zM8.1 14.22a5.51 5.51 0 01-3.72-1.6.88.88 0 011.24-1.24 3.24 3.24 0 004.76 0 .88.88 0 011.24 1.24 4.9 4.9 0 01-3.52 1.6zM7.25 8a1.25 1.25 0 11-2.5 0 1.25 1.25 0 012.5 0zM10 9.25a1.25 1.25 0 100-2.5 1.25 1.25 0 000 2.5z'/%3E%3C/svg%3E")}.informative-tooltip{position:absolute;padding:.8em;max-width:200px;z-index:3000;border-radius:3px;background:#474747;font-size:12px;color:hsl(0,0%,100%)}.informative-tooltip.arrow:before{position:absolute;content:"";width:0;height:0}.informative-tooltip.arrow.up-left:before,.informative-tooltip.arrow.up-center:before,.informative-tooltip.arrow.up-right:before{top:-4px;border-left:5px solid transparent;border-right:5px solid transparent;border-bottom:5px solid #474747}.informative-tooltip.arrow.up-center:before{left:50%;margin-left:-5px}.informative-tooltip.arrow.up-left:before{left:10px}.informative-tooltip.arrow.up-right:before{right:10px}.informative-tooltip.arrow.down-left:before,.informative-tooltip.arrow.down-center:before,.informative-tooltip.arrow.down-right:before{bottom:-4px;border-left:5px solid transparent;border-right:5px solid transparent;border-top:5px solid #474747}.informative-tooltip.arrow.down-center:before{left:50%;margin-left:-5px}.informative-tooltip.arrow.down-left:before{left:10px}.informative-tooltip.arrow.down-right:before{right:10px}.informative-tooltip.arrow.left-top:before,.informative-tooltip.arrow.left-center:before,.informative-tooltip.arrow.left-bottom:before{left:-4px;border-top:5px solid transparent;border-bottom:5px solid transparent;border-right:5px solid #474747}.informative-tooltip.arrow.left-center:before{top:50%;margin-top:-5px}.informative-tooltip.arrow.left-top:before{top:10px}.informative-tooltip.arrow.left-bottom:before{bottom:10px}.informative-tooltip.arrow.right-top:before,.informative-tooltip.arrow.right-center:before,.informative-tooltip.arrow.right-bottom:before{right:-4px;border-top:5px solid transparent;border-bottom:5px solid transparent;border-left:5px solid #474747}.informative-tooltip.arrow.right-center:before{top:50%;margin-top:-5px}.informative-tooltip.arrow.right-top:before{top:10px}.informative-tooltip.arrow.right-bottom:before{bottom:10px}.informative-tooltip.error{background:hsl(358,68%,59%);color:white}.informative-tooltip.display-above,.informative-tooltip.display-right{top:0;max-width:none}.informative-tooltip.display-above:before,.informative-tooltip.display-right:before{content:"";position:absolute;width:0;height:0;border-width:5px;border-style:solid;border-color:transparent}.informative-tooltip.display-above.size-200,.informative-tooltip.display-right.size-200{width:200px}.informative-tooltip.display-above.error:before,.informative-tooltip.display-right.error:before{border-top-color:hsl(358,68%,59%)}.informative-tooltip.display-above{left:50%;transform:translate(-50%, -110%)}.informative-tooltip.display-above:before{bottom:-4px;left:50%;margin-left:-5px;border-bottom-width:0;border-top-color:#474747}.informative-tooltip.display-right{right:50%;transform:translate(115%, 0%)}.informative-tooltip.display-right:before{left:-4px;top:50%;margin-top:-5px;border-left-width:0;border-right-color:#474747}.has-tooltip{position:relative}.has-tooltip .informative-tooltip{opacity:0;visibility:hidden;transition:opacity 300ms ease, transform 300ms ease}.has-tooltip:hover .informative-tooltip{opacity:1;visibility:visible}.has-tooltip.on-hover .tooltip-above.arrow.down-right{right:-6px;top:-10px;-webkit-transform:translate(0, -80%);transform:translate(0, -80%)}.has-tooltip.on-hover:hover .tooltip-above.arrow.down-right{-webkit-transform:translate(0, -100%);transform:translate(0, -100%)}.has-tooltip .informative-tooltip.display-above{transform:translate(-50%, -80%)}.has-tooltip:hover .informative-tooltip.display-above{transform:translate(-50%, -110%)}.has-tooltip .informative-tooltip.display-right{transform:translate(120%, 0%)}.has-tooltip:hover .informative-tooltip.display-right{transform:translate(115%, 0%)}.css-tooltip{position:relative}.css-tooltip[data-title]:hover:after{content:attr(data-title);background:#474747;padding:.8em;margin-left:5px;max-width:200px;color:hsl(0,0%,100%);font-size:12px;border-radius:3px;position:absolute;z-index:1031;left:0;top:100%}.users-grid{margin-bottom:30px;display:flex;flex-wrap:wrap}.users-grid .-user{border:1px solid var(--black-050);border-radius:3px;padding:20px 10px 20px 20px;margin:0 20px 20px 0;width:calc((100% / 3) - (40px / 3));display:flex;flex-wrap:nowrap;align-items:center}.users-grid .-user .-details{padding-left:15px;max-width:calc(100% - 64px);flex-grow:2}.users-grid .-user .-details>*:not(:last-child){margin-bottom:4px}.users-grid .-user .-details h3,.users-grid .-user .-details p{max-width:100%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.users-grid .-user .-details h3{font-weight:400;font-size:1.30769231rem}.users-grid .-user .-details p{margin-bottom:0;color:var(--black-400)}.users-grid .-user .-details p:last-child{margin-bottom:0}.users-grid .-user:nth-child(3n){margin-right:0}.users-grid .-user .-avatar{width:64px;height:64px}.users-grid .-user .-avatar img{max-width:100%;height:auto}.users-grid .-user.-private .-avatar{background:url('../../Img/user.svg?v=20c64bb67fc9') no-repeat center center var(--powder-050);background-size:50%}.users-grid .-user.-private .-details h3{margin-bottom:0}.list-card{position:absolute;z-index:3000;background:var(--white);width:395px;padding:20px;border-radius:3px;box-shadow:0 1px 25px rgba(0,0,0,0.15);transform:translate(0%, -110%);align-items:center;border:1px solid var(--black-075)}.list-card:before{content:'';width:0;height:0;border-left:12px solid transparent;border-right:12px solid transparent;border-top:9px solid var(--white);position:absolute;bottom:-7px;left:20px}.list-card .-avatar{width:100px;height:100px;align-self:flex-start;border-radius:2px;background:var(--white);padding:6px;border:1px solid var(--black-075);border-radius:3px;display:flex;align-items:center;margin-right:15px;flex:0 0 auto}.list-card .-avatar img{border-radius:3px;max-width:100%;height:auto;width:100%}.list-card .-avatar .logo-blank{background-color:var(--black-050);color:var(--black-300);max-width:100%;width:100%;height:100%;border-radius:3px}.list-card .-details{color:var(--black-500);font-weight:400;font-size:13px;width:100%}.list-card .-details .-name{color:var(--black-700);font-weight:700;font-size:1.30769231rem;margin-bottom:0}.list-card .-details .-users-list{display:flex;flex-wrap:wrap;margin:5px 0}.list-card .-details .-users-list .-user:not(:last-child){margin-right:4px}.list-card .-details .-users-list .avatar{width:26px;height:26px;overflow:hidden}.list-card .-details .-users-list .avatar img{max-width:100%;height:auto;width:100%}.list-card .-details .-users-list .avatar.-private{background:url('../../Img/user.svg?v=20c64bb67fc9') no-repeat center center var(--powder-100);background-size:50%}.list-card .-details .more{display:inline-block;margin-top:2px}.modal.auto-center.snippet-modal{position:fixed;transform:translateZ(0) !important;width:100% !important;height:100% !important;top:0 !important;left:0 !important;right:0;bottom:0;background:none !important;display:flex;justify-content:center;align-items:center;pointer-events:none}@media (prefers-color-scheme:dark){body.theme-system .modal.auto-center.snippet-modal{background-color:var(--black-050)}}body.theme-dark .modal.auto-center.snippet-modal,.theme-dark__forced .modal.auto-center.snippet-modal{background-color:var(--black-050)}.modal.auto-center.snippet-modal .snippet-holder{background:var(--white);border-radius:3px;width:95%;height:95%;overflow:hidden;pointer-events:auto}.snippet-modal *{box-sizing:border-box}.snippet-modal.modal{max-width:none;max-height:none}.snippet-box-edit{box-sizing:border-box;position:absolute;top:0;left:0;width:100%;height:100%;margin-top:0;border:0;margin:0;resize:none;background:var(--white);overflow:auto}.snippet-box-result{background-color:hsl(0,0%,100%)}textarea.snippet-box-edit{background-color:var(--white);background-image:linear-gradient(to bottom, var(--white) 0%, var(--black-025) 69%, var(--black-050) 100%)}.snippet-box-label{position:absolute;top:10px;right:20px;padding:3px;border:1px solid var(--black-350);font-size:11px;color:var(--black-500)}.snippet-footer{text-align:center;padding:5px}.snippet-code{border:1px solid var(--black-100);border-radius:5px;padding:12px}.snippet-code .snippet-ctas{font-size:13px}.snippet-code .snippet-ctas>*:not(:last-child){margin-right:6px}.snippet-code .snippet-ctas .icon-play-white{position:relative;top:1px;margin-right:2px}.snippet-code .hideResults:before{content:'';display:inline-block;background:url('../../Img/share-sprite-new.svg?v=0e11bfd41fbc') no-repeat;background-position:0 -238px;width:12px;height:12px;margin-right:6px;position:relative;top:1px}.snippet-code .snippet-result .snippet-result-code{padding-top:20px;margin-top:20px;height:200px;position:relative}.snippet-code .popin,.snippet-code .popout,.snippet-code .popout-code{font-size:13px;right:0}.snippet-code .popout{position:absolute;top:-48px}.ask-mainbar .snippet-code .popout{top:-43px}.snippet-code .popout-code{display:inline;margin-left:10px}.snippet-code .popout:before,.snippet-code .popout-code:before{content:'';display:inline-block;background:url('../../Img/share-sprite-new.svg?v=0e11bfd41fbc') no-repeat;background-position:0 -220px;width:9px;height:9px;margin-right:6px}.snippet-code .popin{position:fixed;background:var(--powder-025);padding:4px 6px;right:0;top:0;z-index:9001}div.snippet-hidden div.snippet-currently-hidden{display:none}a.snippet-show-link-chevron,a.snippet-show-link-chevron:hover{border-bottom:0;text-decoration:none}.expanded-snippet{position:absolute;top:0;left:0;margin:5px;width:99%;z-index:900}.CodeMirror{font-family:monospace;color:var(--black);position:absolute !important;top:0;left:0;width:100%;height:100%}.CodeMirror-lines{padding:4px 0}.CodeMirror pre{padding:0 4px}.CodeMirror-scrollbar-filler,.CodeMirror-gutter-filler{background-color:var(--white)}.CodeMirror-gutters{border-right:1px solid var(--black-100);background-color:var(--black-025);white-space:nowrap}.CodeMirror-linenumber{padding:0 3px 0 5px;min-width:20px;text-align:right;color:var(--black-350);white-space:nowrap}.CodeMirror-guttermarker{color:var(--black)}.CodeMirror-guttermarker-subtle{color:var(--black-350)}.CodeMirror-cursor{border-left:1px solid var(--black);border-right:none;width:0}.CodeMirror div.CodeMirror-secondarycursor{border-left:1px solid silver}.cm-fat-cursor .CodeMirror-cursor{width:auto;border:0 !important;background:#7e7}.cm-fat-cursor div.CodeMirror-cursors{z-index:1}.cm-animate-fat-cursor{width:auto;border:0;animation:blink 1.06s steps(1) infinite;background-color:#7e7}@keyframes blink{50%{background-color:transparent}}.cm-tab{display:inline-block;text-decoration:inherit}.CodeMirror-rulers{position:absolute;left:0;right:0;top:-50px;bottom:-20px;overflow:hidden}.CodeMirror-ruler{border-left:1px solid var(--black-150);top:0;bottom:0;position:absolute}.cm-s-default .cm-header{color:var(--blue-800)}.cm-s-default .cm-quote{color:var(--green-600)}.cm-negative{color:var(--red-400)}.cm-positive{color:var(--green-600)}.cm-header,.cm-strong{font-weight:bold}.cm-em{font-style:italic}.cm-link{text-decoration:underline}.cm-strikethrough{text-decoration:line-through}.cm-s-default .cm-keyword{color:var(--powder-700)}.cm-s-default .cm-atom{color:var(--powder-800)}.cm-s-default .cm-number{color:var(--green-700)}.cm-s-default .cm-def{color:var(--blue-700)}.cm-s-default .cm-variable-2{color:var(--blue-800)}.cm-s-default .cm-variable-3{color:var(--green-600)}.cm-s-default .cm-comment{color:var(--orange-800)}.cm-s-default .cm-string{color:var(--red-700)}.cm-s-default .cm-string-2{color:var(--orange-500)}.cm-s-default .cm-meta{color:var(--black-600)}.cm-s-default .cm-qualifier{color:var(--black-600)}.cm-s-default .cm-builtin{color:var(--powder-700)}.cm-s-default .cm-bracket{color:var(--black-350)}.cm-s-default .cm-tag{color:var(--green-700)}.cm-s-default .cm-attribute{color:var(--blue-800)}.cm-s-default .cm-hr{color:var(--black-350)}.cm-s-default .cm-link{color:var(--blue-800)}.cm-s-default .cm-error{color:var(--red-500)}.cm-invalidchar{color:var(--red-500)}.CodeMirror-composing{border-bottom:2px solid}div.CodeMirror span.CodeMirror-matchingbracket{color:#0f0}div.CodeMirror span.CodeMirror-nonmatchingbracket{color:var(--red-400)}.CodeMirror-matchingtag{background:rgba(255,150,0,0.3)}.CodeMirror-activeline-background{background:var(--powder-100)}.CodeMirror{position:relative;overflow:hidden;background:var(--white)}.CodeMirror-scroll{overflow:scroll !important;margin-bottom:-30px;margin-right:-30px;padding-bottom:30px;height:100%;outline:none;position:relative}.CodeMirror-sizer{position:relative;border-right:30px solid transparent}.CodeMirror-vscrollbar,.CodeMirror-hscrollbar,.CodeMirror-scrollbar-filler,.CodeMirror-gutter-filler{position:absolute;z-index:6;display:none}.CodeMirror-vscrollbar{right:0;top:0;overflow-x:hidden;overflow-y:scroll}.CodeMirror-hscrollbar{bottom:0;left:0;overflow-y:hidden;overflow-x:scroll}.CodeMirror-scrollbar-filler{right:0;bottom:0}.CodeMirror-gutter-filler{left:0;bottom:0}.CodeMirror-gutters{position:absolute;left:0;top:0;min-height:100%;z-index:3;padding-bottom:30px}.CodeMirror-gutter{white-space:normal;height:100%;display:inline-block;vertical-align:top;margin-bottom:-30px}.CodeMirror-gutter-wrapper{position:absolute;z-index:4;background:none !important;border:none !important}.CodeMirror-gutter-background{position:absolute;top:0;bottom:0;z-index:4}.CodeMirror-gutter-elt{position:absolute;cursor:default;z-index:4}.CodeMirror-gutter-wrapper{-webkit-user-select:none;-moz-user-select:none;user-select:none}.CodeMirror-lines{cursor:text;min-height:1px}.CodeMirror pre{border-radius:0;border-width:0;background:transparent;font-family:inherit;font-size:inherit;margin:0;white-space:pre;word-wrap:normal;line-height:inherit;color:inherit;z-index:2;position:relative;overflow:visible;-webkit-tap-highlight-color:transparent;-webkit-font-variant-ligatures:none;font-variant-ligatures:none}.CodeMirror-wrap pre{word-wrap:break-word;white-space:pre-wrap;word-break:normal}.CodeMirror-linebackground{position:absolute;left:0;right:0;top:0;bottom:0;z-index:0}.CodeMirror-linewidget{position:relative;z-index:2;overflow:auto}.CodeMirror-code{outline:none}.CodeMirror-scroll,.CodeMirror-sizer,.CodeMirror-gutter,.CodeMirror-gutters,.CodeMirror-linenumber{box-sizing:content-box}.CodeMirror-measure{position:absolute;width:100%;height:0;overflow:hidden;visibility:hidden}.CodeMirror-cursor{position:absolute;pointer-events:none}.CodeMirror-measure pre{position:static}div.CodeMirror-cursors{visibility:hidden;position:relative;z-index:3}div.CodeMirror-dragcursors{visibility:visible}.CodeMirror-focused div.CodeMirror-cursors{visibility:visible}.CodeMirror-selected{background:var(--black-100)}.CodeMirror-focused .CodeMirror-selected{background:#d7d4f0}.CodeMirror-crosshair{cursor:crosshair}.CodeMirror-line::selection,.CodeMirror-line>span::selection,.CodeMirror-line>span>span::selection{background:var(--powder-100)}.CodeMirror-line::-moz-selection,.CodeMirror-line>span::-moz-selection,.CodeMirror-line>span>span::-moz-selection{background:var(--powder-100)}.cm-searching{background:#ffa;background:rgba(255,255,0,0.4)}.cm-force-border{padding-right:.1px}@media print{.CodeMirror div.CodeMirror-cursors{visibility:hidden}}.cm-tab-wrap-hack:after{content:''}span.CodeMirror-selectedtext{background:none}.post-layout{display:grid;grid-template-columns:-webkit-max-content 1fr;grid-template-columns:max-content 1fr}.post-layout--left{grid-column:1;width:auto}.post-layout--left,.post-layout--left.votecell{width:auto;padding-right:16px}.post-layout--right{padding-right:16px;grid-column:2;width:auto;min-width:0}.post-layout--right .s-prose,.post-layout--right .comments{width:100%}.post-layout--full{grid-column:1 / 3}.wmd-container{width:100%;box-sizing:border-box}.wmd-button-bar{clear:both;background-color:transparent;margin:10px 0 0 0;padding:0;width:100%;border:1px solid var(--bc-darker);border-bottom:0;min-height:44px;overflow:hidden;z-index:2;position:relative}textarea.wmd-input,textarea#wmd-input{padding:10px;margin:-1px 0 0;height:200px;line-height:1.3;width:100%;font-family:var(--ff-mono);font-size:1.15384615rem;-moz-tab-size:4;-o-tab-size:4;tab-size:4}.wmd-button-row{padding:0 4px 0 8px;margin:0;display:flex;list-style:none;flex-wrap:wrap;justify-content:flex-end;height:44px;border-bottom:1px solid var(--bc-darker)}.wmd-spacer{height:44px;flex:1 0 4px;max-width:27px;display:flex;flex-wrap:wrap;overflow:hidden;position:relative;left:4px}.wmd-spacer:before,.wmd-spacer:after{flex:none;justify-content:center;content:'';position:relative;top:-44px;background:var(--green-600)}.wmd-spacer:before{width:9px;height:44px}.wmd-spacer:after{background:var(--black-200);width:1px;height:43px;margin-top:1px}.wmd-spacer-max{max-width:none}.wmd-button{max-width:28px;height:44px;flex:10 0 23px;padding:0;padding:12px 0 0 0;text-align:center;cursor:pointer}.wmd-button>span{background-repeat:no-repeat;background-position:0 0;width:20px;height:20px;display:inline-block}.wmd-prompt-background{background-color:var(--black);z-index:8950}.wmd-prompt-dialog{padding:15px;box-shadow:var(--bs-sm);background-color:var(--white);border:solid 1px var(--black-300)}.wmd-button>span{background-image:url("../../Img/unified/wmd-buttons.svg?v=c26278fc22d9");background-size:initial !important}@media (prefers-color-scheme:dark){body.theme-system .wmd-button>span{background-image:url("../../Img/unified/wmd-buttons-dark.svg?v=41498242bcce")}}body.theme-dark .wmd-button>span,.theme-dark__forced .wmd-button>span{background-image:url("../../Img/unified/wmd-buttons-dark.svg?v=41498242bcce")}.wmd-snippet-button span{background-position:-260px 0 !important}.wmd-snippet-button span:hover{background-position:-260px -40px !important}.wmd-schematic-button span{background-position:-320px 0 !important}.wmd-schematic-button span:hover{background-position:-320px -40px !important}.wmd-virtual-keyboard-button span{background-position:-280px 0 !important}.wmd-virtual-keyboard-button span:hover,.wmd-virtual-keyboard-button span.enabled{background-position:-280px -40px !important}.wmd-mockup-button span{background-position:-300px 0 !important}.wmd-mockup-button span:hover{background-position:-300px -40px !important}.wmd-cite-button span{background-position:-340px 0 !important}.wmd-cite-button span:hover{background-position:-340px -40px !important}.wmd-inline-dialog{border:1px solid var(--bc-darker);border-top:none;position:absolute;width:100%;z-index:1;padding:16px;background-color:var(--white);box-shadow:var(--bs-sm)}.wmd-button__active{border-left:1px solid var(--bc-darker);border-right:1px solid var(--bc-darker);border-bottom:1px solid var(--white);background-color:var(--white)}.wmd-button__active>span{background-position-y:-40px !important}.wmd-button-bar.has-active-button .wmd-button:not(.wmd-button__active){cursor:not-allowed;pointer-events:none;opacity:.3}.wmd-help-button.active-help{background-color:var(--black-050)}.mdhelp{background-color:var(--black-050);color:var(--fc-dark);border-right:1px solid var(--bc-darker);border-left:1px solid var(--bc-darker)}.mdhelp-tabs{background-color:var(--black-050);list-style-type:none;margin:0;padding:3px 0 0 3px;overflow:hidden}.mdhelp-tabs li{display:inline-block;padding:3px 6px 6px;margin:0 2px;cursor:pointer}.mdhelp-tabs li.selected{background-color:var(--yellow-050)}.mdhelp-tab{padding:10px;display:none;line-height:1.2}.mdhelp-tab pre{background-color:var(--yellow-100);border:none!important}.mdhelp-tab--content{display:flex;flex-wrap:wrap;justify-content:space-between;margin-left:-2%}.mdhelp-tab--content .col1,.mdhelp-tab--content .col2{min-width:150px;flex-grow:1}.mdhelp-tab--content>*:not(ol){margin-left:2%}.mdhelp-tab--content>p,.mdhelp-tab--content>pre{width:100%}.grippie{background-position:calc(50% + 34px) -364px;border:1px solid var(--bc-darker);border-width:0 1px 1px;cursor:s-resize;height:11px;overflow:hidden;background-color:var(--black-050)}.wmd-button-bar.btr-sm~.grippie{border-bottom-left-radius:3px;border-bottom-right-radius:3px}.user-page .grippie{margin-bottom:3px}.grippie{margin-top:-4px}.wmd-preview.s-prose{clear:both;width:100%}.bg-inherit{background-color:inherit !important}.s-input__readonly{border-color:var(--black-075);background-color:var(--black-050);color:var(--black-200);cursor:not-allowed}.s-editor-shadow{transform-style:preserve-3d}.s-editor-shadow:after{content:"";position:absolute;transform:translateZ(-1px);top:-112px;left:0;right:0;height:62px;background:radial-gradient(50% 50% at 50% 45%, rgba(0,0,0,0.8) -200%, rgba(0,0,0,0) 115%);opacity:0;pointer-events:none;transition:top 1s ease,opacity 1.5s ease}@media not all and (min-resolution:.001dpcm){@supports (-webkit-appearance: none) and (stroke-color: transparent){.s-editor-shadow:after{transition:none}}}.s-editor-shadow.is-stuck:after{top:0;opacity:1;transition:top .2s ease,opacity .1s ease}.s-editor-btn{position:relative;display:inline-block;padding:2px;border:1px solid transparent;border-radius:3px;color:var(--black-700);background-color:transparent;outline:none;font-family:inherit;font-size:13px;font-weight:normal;line-height:1.15384615;text-align:center;text-decoration:none;cursor:pointer}.s-editor-btn:hover{background-color:var(--black-050);color:var(--black-700)}.s-editor-btn.is-selected,.s-editor-btn:active{color:var(--black-900);background-color:var(--black-100)}.s-editor-btn.is-disabled{color:var(--black-150);cursor:default}.s-editor-btn.is-disabled:hover{background-color:transparent}.s-editor-btn:focus{box-shadow:0 0 0 4px var(--focus-ring-muted)}.s-editor-btn.s-btn__dropdown{padding-right:16px}.s-editor-btn.s-btn__dropdown:after{right:4px}.s-editor-resizable{max-height:48.6153846rem;resize:vertical}.s-editor-resizable[style*="height"]{max-height:none}.ProseMirror{min-height:inherit;word-wrap:break-word;white-space:pre-wrap;white-space:break-spaces;font-variant-ligatures:none}.ProseMirror .ProseMirror-hideselection *::selection{background:transparent}.ProseMirror .ProseMirror-hideselection{caret-color:transparent}.ProseMirror .ProseMirror-selectednode{box-shadow:0 0 0 4px var(--focus-ring)}.ProseMirror .ProseMirror-widget{white-space:normal;word-wrap:normal}.ProseMirror .ProseMirror-widget .ProseMirror-contentdom{word-wrap:break-word;white-space:pre-wrap;white-space:break-spaces}.ProseMirror img{max-width:100%}.ProseMirror.s-prose .spoiler *{visibility:visible}.ProseMirror.s-prose div{margin-bottom:var(--s-prose-spacing)}.ProseMirror.s-prose div:last-child,.ProseMirror.s-prose div:only-child{margin-bottom:0}.ProseMirror.s-prose ol div,.ProseMirror.s-prose ul div{margin-bottom:var(--s-prose-spacing-condensed)}.ProseMirror pre,.ProseMirror code{word-wrap:break-word;white-space:pre-wrap}.ProseMirror>pre,.ProseMirror>code{margin:0;padding:0;width:auto;max-height:unset;background-color:inherit;border-radius:0}.ProseMirror[contenteditable="true"] p>a[href]{cursor:inherit}.ProseMirror[contenteditable="false"] pre,.ProseMirror[contenteditable="false"] code{opacity:80%}.ProseMirror[contenteditable="false"] .ProseMirror-widget,.ProseMirror[contenteditable="false"] .ProseMirror-widget *{background-color:inherit}.icon-bg{display:inline-block;vertical-align:bottom;border:none;height:18px;width:18px;padding:0}.icon-bg::after{content:"";height:100%;width:100%;display:inline-block;background-color:currentColor;-webkit-mask:var(--bg-icon) no-repeat center;mask:var(--bg-icon) no-repeat center;-webkit-mask-size:contain;mask-size:contain}.icon-bg.iconBold{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M13 6C13 4.5 11.43 3 9.5 3H4V15H10.25C12.04 15 13.5 13.29 13.5 11.5C13.5 10.2 12.6 9.02 11.5 8.5C12.33 7.92 13 7.5 13 6ZM6.5 5H9C9.39782 5 9.77936 5.15804 10.0607 5.43934C10.342 5.72064 10.5 6.10218 10.5 6.5C10.5 6.89782 10.342 7.27936 10.0607 7.56066C9.77936 7.84196 9.39782 8 9 8H6.5V5ZM9.5 13H6.5V10H9.5C9.89782 10 10.2794 10.158 10.5607 10.4393C10.842 10.7206 11 11.1022 11 11.5C11 11.8978 10.842 12.2794 10.5607 12.5607C10.2794 12.842 9.89782 13 9.5 13Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconHeader{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M13.62 10.08L12.1 4.66H12.04L10.54 10.08H13.62ZM5.7 11.13L4.53 7.02H4.45L3.32 11.13H5.7ZM17.31 15H15.06L14.11 11.75H10.04L9.09 15H6.84L6.15 12.67H2.87L2.17 15H0L3.3 5.41H5.8L7.97 11.75L10.86 3H13.38L17.32 15H17.31Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconItalic{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M7 3V5H9.58L5.92 13H3V15H11V13H8.42L12.08 5H15V3H7Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconCode{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M8 4.41L6.59 3L0.589996 9L6.59 15L8 13.59L3.41 9L8 4.41Z' fill='black'/%3e %3cpath d='M10 4.41L11.41 3L17.41 9L11.41 15L10 13.59L14.59 9L10 4.41Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconStrikethrough{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M11.9572 6.19964C11.879 6.12146 11.7339 6.01537 11.5217 5.88135C11.3206 5.74733 11.0694 5.6189 10.7678 5.49605C10.4775 5.36204 10.1592 5.25036 9.81295 5.16101C9.46675 5.07167 9.11495 5.027 8.75758 5.027C8.121 5.027 7.64636 5.14426 7.33365 5.37879C7.02095 5.61332 6.8646 5.94277 6.8646 6.36716C6.8646 6.61285 6.92044 6.81946 7.03212 6.98698L7.04249 7H4.49366C4.48843 6.9143 4.48581 6.8262 4.48581 6.7357C4.48581 6.13263 4.59749 5.59657 4.82085 5.12751C5.04421 4.65845 5.35133 4.26757 5.74221 3.95487C6.14426 3.64216 6.60773 3.40763 7.13263 3.25128C7.65753 3.08376 8.22151 3 8.82458 3C9.66219 3 10.4328 3.13402 11.1364 3.40205C11.84 3.65891 12.4542 3.96603 12.9791 4.32341L11.9572 6.19964Z' fill='black'/%3e %3cpath d='M3 8V10H8.0204C8.42354 10.1155 8.79211 10.2224 9.12612 10.3206C9.50583 10.4323 9.82971 10.5552 10.0977 10.6892C10.3658 10.8232 10.5724 10.9795 10.7176 11.1582C10.8627 11.3369 10.9353 11.5547 10.9353 11.8116C10.9353 12.6268 10.2988 13.0345 9.02561 13.0345C8.56772 13.0345 8.121 12.9786 7.68545 12.8669C7.24989 12.7553 6.85343 12.6213 6.49605 12.4649C6.13868 12.2974 5.82597 12.1354 5.55794 11.9791C5.30107 11.8116 5.12239 11.6776 5.02187 11.577L4 13.5705C4.69242 14.0619 5.47418 14.4416 6.34528 14.7097C7.21639 14.9777 8.09866 15.1117 8.99211 15.1117C9.57284 15.1117 10.1257 15.0503 10.6506 14.9274C11.1866 14.7934 11.6557 14.5868 12.0577 14.3076C12.4709 14.0284 12.7948 13.6655 13.0293 13.2187C13.275 12.7608 13.3979 12.2136 13.3979 11.577C13.3979 11.0298 13.3085 10.5719 13.1299 10.2034C13.0971 10.1337 13.0617 10.0659 13.0236 10H15V8H3Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconLink{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M7.2233 11.8311C7.7117 12.1908 8.25504 12.4768 8.83653 12.676L9.45259 10.8781C8.59978 10.5859 7.86707 10.0207 7.36788 9.27009C6.86868 8.51944 6.63083 7.62517 6.69115 6.72571C6.75147 5.82624 7.10659 4.97174 7.70155 4.29447C8.2965 3.61719 9.09811 3.15491 9.9823 2.97918C10.8665 2.80345 11.784 2.92407 12.5927 3.32236C13.4014 3.72066 14.0563 4.37442 14.456 5.18246C14.8557 5.9905 14.9778 6.90775 14.8036 7.79224C14.6294 8.67673 14.1685 9.47913 13.4923 10.0752L14.749 11.5009C15.2101 11.0945 15.6028 10.6225 15.9165 10.1034C16.2762 9.50815 16.5321 8.85098 16.6683 8.15952C16.9233 6.86498 16.7445 5.52249 16.1595 4.33984C15.5745 3.15719 14.616 2.20034 13.4324 1.61739C12.2487 1.03445 10.9059 0.857909 9.61182 1.11511C8.31772 1.37231 7.14448 2.04891 6.2737 3.04017C5.40292 4.03143 4.88317 5.28208 4.79488 6.59854C4.7066 7.915 5.05471 9.22385 5.78534 10.3225C6.17558 10.9093 6.66334 11.4187 7.2233 11.8311Z' fill='black'/%3e %3cpath d='M10.6461 6.23494C10.1644 5.86633 9.62642 5.57045 9.04869 5.36057L8.39975 7.14688C9.24706 7.45469 9.96928 8.03321 10.4546 8.79289C10.94 9.55257 11.1614 10.4511 11.0846 11.3493C11.0077 12.2475 10.637 13.0953 10.0297 13.7616C9.42245 14.4278 8.6125 14.8753 7.72523 15.0348C6.83797 15.1943 5.92288 15.0568 5.1216 14.6438C4.32031 14.2307 3.67753 13.565 3.29274 12.7498C2.90794 11.9346 2.8026 11.0152 2.99301 10.1341C3.18342 9.25295 3.65896 8.45914 4.34603 7.87552L3.11565 6.42702C2.64717 6.82495 2.24588 7.28966 1.92268 7.80296C1.55212 8.39146 1.28421 9.04383 1.13536 9.73267C0.856672 11.0223 1.01086 12.3679 1.57404 13.561C2.13723 14.7542 3.07801 15.7285 4.25077 16.3331C5.42352 16.9376 6.76286 17.1388 8.06146 16.9053C9.36006 16.6719 10.5455 16.017 11.4343 15.0418C12.3231 14.0667 12.8658 12.8258 12.9782 11.5112C13.0906 10.1966 12.7665 8.88155 12.0562 7.76968C11.6768 7.1758 11.1984 6.65756 10.6461 6.23494Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconQuote{width:17px;--bg-icon:url("data:image/svg+xml,%3csvg width='17' height='18' viewBox='0 0 17 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M0 4C0 2.89543 0.89543 2 2 2H6C7.10457 2 8 2.89543 8 4V13L6.25 16H4L5.75 13H2C0.895431 13 0 12.1046 0 11V4Z' fill='black'/%3e %3cpath d='M9 4C9 2.89543 9.89543 2 11 2H15C16.1046 2 17 2.89543 17 4V13L15.25 16H13L14.75 13H11C9.89543 13 9 12.1046 9 11V4Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconCodeblock{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M1 3C1 1.89543 1.89543 1 3 1H13L17 5V15C17 16.1046 16.1046 17 15 17H3C1.89543 17 1 16.1046 1 15V3ZM10.7106 5L9.30063 6.41L11.8906 9L9.30063 11.59L10.7106 13L14.7106 9L10.7106 5ZM8.71329 6.41L7.30329 5L3.30329 9L7.30329 13L8.71329 11.59L6.12329 9L8.71329 6.41Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconImage{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M1 3C1 1.9 1.9 1 3 1H15C16.0893 1 17 1.91067 17 3V15C17 16.0893 16.0893 17 15 17H3C1.91067 17 1 16.0893 1 15V3ZM5.5 10.5L2 15H16L11.5 9L8 13.51L5.5 10.5ZM5.5 6C5.89782 6 6.27936 5.84196 6.56066 5.56066C6.84196 5.27936 7 4.89782 7 4.5C7 4.10218 6.84196 3.72064 6.56066 3.43934C6.27936 3.15804 5.89782 3 5.5 3C5.10218 3 4.72064 3.15804 4.43934 3.43934C4.15804 3.72064 4 4.10218 4 4.5C4 4.89782 4.15804 5.27936 4.43934 5.56066C4.72064 5.84196 5.10218 6 5.5 6Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconTable{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M1 3C1 1.89543 1.89543 1 3 1H15C16.1046 1 17 1.89543 17 3V15C17 16.1046 16.1046 17 15 17H3C1.89543 17 1 16.1046 1 15V3ZM8 7V3H3V7H8ZM8 11V9H3V11H8ZM15 9H10V11H15V9ZM15 15V13H10V15H15ZM8 13H3V15H8V13ZM15 3H10V7H15V3Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconOrderedList{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M3 6H4V2H2V3H3V6ZM3.8 8H2V7H5V7.9L3.2 10H5V11H2V10.1L3.8 8ZM2 13V12H5V16H2V15H4V14.5H3V13.5H4V13H2ZM7 5V3H16V5H7ZM7 15H16V13H7V15ZM16 10H7V8H16V10Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconUnorderedList{--bg-icon:url("data:image/svg+xml,%3csvg width='17' height='18' viewBox='0 0 17 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M4.25 4C4.25 4.69036 3.69036 5.25 3 5.25C2.30964 5.25 1.75 4.69036 1.75 4C1.75 3.30964 2.30964 2.75 3 2.75C3.69036 2.75 4.25 3.30964 4.25 4Z' fill='black'/%3e %3cpath d='M15 5H6V3H15V5Z' fill='black'/%3e %3cpath d='M15 15H6V13H15V15Z' fill='black'/%3e %3cpath d='M6 10H15V8H6V10Z' fill='black'/%3e %3cpath d='M4.25 14C4.25 14.6904 3.69036 15.25 3 15.25C2.30964 15.25 1.75 14.6904 1.75 14C1.75 13.3096 2.30964 12.75 3 12.75C3.69036 12.75 4.25 13.3096 4.25 14Z' fill='black'/%3e %3cpath d='M3 10.25C3.69036 10.25 4.25 9.69036 4.25 9C4.25 8.30964 3.69036 7.75 3 7.75C2.30964 7.75 1.75 8.30964 1.75 9C1.75 9.69036 2.30964 10.25 3 10.25Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconHorizontalRule{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M2 8H16V10H2V8Z' fill='black'/%3e %3cpath opacity='0.4' d='M2 2H16V3H2V2ZM2 5H16V6H2V5ZM2 12H16V13H2V12ZM2 15H16V16H2V15Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconUndo{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M3.35147 3.35C4.80238 1.9 6.79362 1 9.005 1C13.4278 1 17 4.58 17 9C17 13.42 13.4278 17 9.005 17C5.27267 17 2.16073 14.45 1.27017 11H3.35147C4.17198 13.33 6.39337 15 9.005 15C12.3171 15 15.0088 12.31 15.0088 9C15.0088 5.69 12.3171 3 9.005 3C7.34396 3 5.86304 3.69 4.78236 4.78L8.00438 8H1V1L3.35147 3.35Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconRefresh{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M14.6485 3.35C13.1976 1.9 11.2064 1 8.995 1C4.57223 1 1 4.58 1 9C1 13.42 4.57223 17 8.995 17C12.7273 17 15.8393 14.45 16.7298 11H14.6485C13.828 13.33 11.6066 15 8.995 15C5.68293 15 2.99124 12.31 2.99124 9C2.99124 5.69 5.68293 3 8.995 3C10.656 3 12.137 3.69 13.2176 4.78L9.99562 8H17V1L14.6485 3.35Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconHelp{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M9 1C4.64267 1 1 4.64267 1 9C1 13.3573 4.64266 17 9 17C13.3573 17 17 13.3573 17 9C17 4.64266 13.3573 1 9 1ZM9.81 13.13C9.79 13.84 9.26 14.28 8.57 14.26C7.91 14.24 7.4 13.77 7.42 13.06C7.44 12.34 7.98 11.88 8.64 11.9C9.34 11.93 9.84 12.41 9.81 13.13ZM11.77 8C11.1836 8.6629 9.99229 9.08507 9.72 9.97C9.66641 10.2166 9.63627 10.4677 9.63 10.72C9.63 10.77 9.6 10.88 9.45 10.88H7.88C7.72 10.88 7.7 10.78 7.7 10.73C7.76152 9.37659 8.36087 8.53141 9.53 7.85C9.91723 7.55958 10.2225 7.10274 10.2282 6.60861C10.2427 5.36872 8.5915 4.79041 7.88 5.89C7.67 6.22 7.7 6.62 7.7 6.99H5.75C5.75 5.01906 6.77665 3.73 8.78 3.73C10.5347 3.73 12.25 4.60389 12.25 6.56C12.25 7.13 12.05 7.61 11.77 8Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconPlay{--bg-icon:url("data:image/svg+xml,%3csvg width='17' height='18' viewBox='0 0 17 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M3 2.86852C3 2.06982 3.89015 1.59343 4.5547 2.03647L13.7519 8.16795C14.3457 8.56377 14.3457 9.43623 13.7519 9.83205L4.5547 15.9635C3.89014 16.4066 3 15.9302 3 15.1315V2.86852Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconShare{--bg-icon:url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M2.99406 1H8V3H3V15H15V10H17V15.0059C17 16.1072 16.1055 17 15.0059 17H2.99406C1.89277 17 1 16.1055 1 15.0059V2.99406C1 1.89277 1.89451 1 2.99406 1Z' fill='black'/%3e %3cpath d='M17 1H10V3H13.5L6 10.5L7.5 12L15 4.5V8H17V1Z' fill='black'/%3e %3c/svg%3e")}.icon-bg.iconPencilSm{--bg-icon:url("data:image/svg+xml,%3csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M11.0937 1.71081L12.2347 2.83019C12.4347 3.03005 12.4347 3.33983 12.2347 3.53968L11.0898 4.70381L9.21 2.86474L10.3837 1.71081C10.5837 1.51095 10.8937 1.51095 11.0937 1.71081Z' fill='black'/%3e %3cpath d='M2 10.12L8.37 3.69427L10.2466 5.57034L3.88 12H2V10.12Z' fill='black'/%3e %3c/svg%3e");height:14px;width:14px}.icon-bg.iconTrashSm{--bg-icon:url("data:image/svg+xml,%3csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M11 2C11.5523 2 12 2.44772 12 3V4H2V3C2 2.44772 2.44772 2 3 2H5C5 1.44772 5.44772 1 6 1H8C8.55228 1 9 1.44772 9 2H11Z' fill='black'/%3e %3cpath d='M11 5H3V11C3 12.1046 3.89543 13 5 13H9C10.1046 13 11 12.1046 11 11V5Z' fill='black'/%3e %3c/svg%3e");height:14px;width:14px}.icon-bg.iconMarkdown{width:21px;--bg-icon:url("data:image/svg+xml,%3csvg width='21' height='18' viewBox='0 0 21 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M21 14C21 15.1046 20.1046 16 19 16H2.00098C0.896407 16 0.000976562 15.1046 0.000976562 14V4C0.000976562 2.89543 0.896407 2 2.00098 2L19 2C20.1046 2 21 2.89543 21 4V14ZM4.308 13V8.345L6.5 11.23L8.692 8.345V13H11V5H8.692L6.5 7.885L4.308 5H2V13H4.308ZM19.5 8.99999H17V5H15.0055V8.99999H12.5L16 13.5L19.5 8.99999Z' fill='black'/%3e %3c/svg%3e")}.s-code-block.markdown .hljs-section{color:var(--black-800) !important;font-weight:bold;font-size:1.15384615rem}.s-code-block.markdown .hljs-link{color:var(--blue-600) !important}.s-code-block.markdown .hljs-quote,.s-code-block.markdown .hljs-string,.s-code-block.markdown .hljs-symbol,.s-code-block.markdown .hljs-tag{color:var(--black-600) !important}.uql-nav .uql-nav--collapsed-item{display:none !important}@media screen and (max-width:1111px) and (min-width:980.1px){html.html__responsive:not(.html__unpinned-leftnav) .uql-nav .uql-nav--expanded-item{display:none !important}html.html__responsive:not(.html__unpinned-leftnav) .uql-nav .uql-nav--collapsed-item{display:flex !important}}@media screen and (max-width:947px) and (min-width:816.1px){html.html__responsive.html__unpinned-leftnav .uql-nav .uql-nav--expanded-item{display:none !important}html.html__responsive.html__unpinned-leftnav .uql-nav .uql-nav--collapsed-item{display:flex !important}}@media screen and (max-width:771px) and (min-width:640.1px){html.html__responsive:not(.html__unpinned-leftnav) .uql-nav .uql-nav--expanded-item{display:none !important}html.html__responsive:not(.html__unpinned-leftnav) .uql-nav .uql-nav--collapsed-item{display:flex !important}}@media screen and (max-width:607px) and (min-width:640.1px){html.html__responsive.html__unpinned-leftnav .uql-nav .uql-nav--expanded-item{display:none !important}html.html__responsive.html__unpinned-leftnav .uql-nav .uql-nav--collapsed-item{display:flex !important}}@media screen and (max-width:607px){html.html__responsive .uql-nav .uql-nav--expanded-item{display:none !important}html.html__responsive .uql-nav .uql-nav--collapsed-item{display:flex !important}}@media print{.uql-nav .uql-nav--expanded-item{display:none !important}.uql-nav .uql-nav--collapsed-item{display:flex !important}}.uql-nav .uql-item{margin:8px 0;display:flex}.uql-nav .uql-item.uql-item__separator{height:1px;margin-left:-12px;margin-right:-12px}.topbar-dialog{font-family:var(--ff-sans);color:var(--black-700);font-size:12px;background-color:var(--white);box-shadow:var(--bs-sm);z-index:999;position:absolute;text-align:left;border-left:1px solid var(--black-075);border-right:1px solid var(--black-075);border-bottom:1px solid var(--black-075)}.topbar-dialog .child-content-loading{text-align:center;padding-top:10px}.topbar-dialog a:not(.s-btn):not(.nav-links--link){color:var(--blue-600);text-decoration:none}.topbar-dialog a:not(.s-btn):not(.nav-links--link):visited{color:var(--blue-600)}.topbar-dialog a:not(.s-btn):not(.nav-links--link):hover{color:var(--blue-500);text-decoration:none}.topbar-dialog .related-links{color:var(--black-400);white-space:nowrap}.topbar-dialog .related-links a,.topbar-dialog .related-links a:visited{margin-left:10px;color:var(--blue-600)}.topbar-dialog.siteSwitcher-dialog{width:375px;overflow-y:scroll;overflow-x:hidden;min-height:390px;max-height:390px;scrollbar-color:var(--scrollbar) transparent}.topbar-dialog.siteSwitcher-dialog::-webkit-scrollbar{width:10px;height:10px;background-color:transparent}.topbar-dialog.siteSwitcher-dialog::-webkit-scrollbar-track{border-radius:10px;background-color:transparent}.topbar-dialog.siteSwitcher-dialog::-webkit-scrollbar-thumb{border-radius:10px;background-color:var(--scrollbar)}.topbar-dialog.siteSwitcher-dialog::-webkit-scrollbar-corner{background-color:transparent;border-color:transparent}.topbar-dialog.siteSwitcher-dialog .call-to-login{padding:7px 0 7px 0;text-align:center;line-height:1.3}.topbar-dialog.siteSwitcher-dialog .modal-content{padding:0}.topbar-dialog.siteSwitcher-dialog .modal-content li:first-child{padding-top:2px}.topbar-dialog.siteSwitcher-dialog .modal-content li:last-child{padding-bottom:2px}.topbar-dialog.siteSwitcher-dialog .modal-content li{padding-left:7px;padding-right:7px}.topbar-dialog.siteSwitcher-dialog .modal-content .pinned-site-candidate{padding-top:6px;padding-bottom:6px}.topbar-dialog.siteSwitcher-dialog .modal-content#your-communities-section{max-height:none}.topbar-dialog.siteSwitcher-dialog .other-sites{min-height:345px}.topbar-dialog.siteSwitcher-dialog .other-sites .other-site-link{display:inline-block;width:100%}.topbar-dialog.siteSwitcher-dialog .current-site .current-site-link{font-weight:bold}.topbar-dialog.siteSwitcher-dialog .current-site li{border:none}.topbar-dialog.siteSwitcher-dialog .current-site li:hover{background-color:var(--powder-100)}.topbar-dialog.siteSwitcher-dialog .site-desc{margin-bottom:0;margin-left:25px;color:var(--black-300);font-size:12px;padding-right:4px}.topbar-dialog.siteSwitcher-dialog .L-shaped-icon-container{float:left;padding:0;margin:8px 6px 0 15px}.topbar-dialog.siteSwitcher-dialog .L-shaped-icon{width:10px;height:10px;border:solid #b9c1c5;border-width:0 0 1px 1px;display:inline-block}.topbar-dialog.inbox-dialog .modal-content .message-text,.topbar-dialog.modInbox-dialog .modal-content .message-text{width:313px}.topbar-dialog.inbox-dialog,.topbar-dialog.modInbox-dialog,.topbar-dialog.achievements-dialog{width:375px;max-height:505px}.topbar-dialog.inbox-dialog .modal-content,.topbar-dialog.modInbox-dialog .modal-content,.topbar-dialog.achievements-dialog .modal-content{min-height:390px;max-height:390px;overflow-y:auto;overflow-x:hidden;scrollbar-color:var(--scrollbar) transparent}.topbar-dialog.inbox-dialog .modal-content::-webkit-scrollbar,.topbar-dialog.modInbox-dialog .modal-content::-webkit-scrollbar,.topbar-dialog.achievements-dialog .modal-content::-webkit-scrollbar{width:10px;height:10px;background-color:transparent}.topbar-dialog.inbox-dialog .modal-content::-webkit-scrollbar-track,.topbar-dialog.modInbox-dialog .modal-content::-webkit-scrollbar-track,.topbar-dialog.achievements-dialog .modal-content::-webkit-scrollbar-track{border-radius:10px;background-color:transparent}.topbar-dialog.inbox-dialog .modal-content::-webkit-scrollbar-thumb,.topbar-dialog.modInbox-dialog .modal-content::-webkit-scrollbar-thumb,.topbar-dialog.achievements-dialog .modal-content::-webkit-scrollbar-thumb{border-radius:10px;background-color:var(--scrollbar)}.topbar-dialog.inbox-dialog .modal-content::-webkit-scrollbar-corner,.topbar-dialog.modInbox-dialog .modal-content::-webkit-scrollbar-corner,.topbar-dialog.achievements-dialog .modal-content::-webkit-scrollbar-corner{background-color:transparent;border-color:transparent}.topbar-dialog.inbox-dialog .modal-content .timestamp,.topbar-dialog.modInbox-dialog .modal-content .timestamp,.topbar-dialog.achievements-dialog .modal-content .timestamp{color:var(--black-350)}.topbar-dialog.inbox-dialog .inbox-item .item-content .item-header,.topbar-dialog.modInbox-dialog .inbox-item .item-content .item-header,.topbar-dialog.achievements-dialog .inbox-item .item-content .item-header{color:var(--black-400)}.topbar-dialog.inbox-dialog .inbox-item .item-content .item-creation,.topbar-dialog.modInbox-dialog .inbox-item .item-content .item-creation,.topbar-dialog.achievements-dialog .inbox-item .item-content .item-creation{float:right}.topbar-dialog.inbox-dialog .inbox-item .item-content .item-location,.topbar-dialog.modInbox-dialog .inbox-item .item-content .item-location,.topbar-dialog.achievements-dialog .inbox-item .item-content .item-location{margin:4px 0}.topbar-dialog.inbox-dialog .inbox-item .item-content .item-summary,.topbar-dialog.modInbox-dialog .inbox-item .item-content .item-summary,.topbar-dialog.achievements-dialog .inbox-item .item-content .item-summary{color:var(--black-700)}.topbar-dialog.inbox-dialog .inbox-item.inbox-se-link,.topbar-dialog.modInbox-dialog .inbox-item.inbox-se-link,.topbar-dialog.achievements-dialog .inbox-item.inbox-se-link{text-align:center}.topbar-dialog.inbox-dialog.anon,.topbar-dialog.achievements-dialog.anon{width:275px}.topbar-dialog.inbox-dialog.anon .modal-content,.topbar-dialog.achievements-dialog.anon .modal-content{min-height:200px;padding:13px 20px}.topbar-dialog.inbox-dialog.anon .huge-button-container,.topbar-dialog.achievements-dialog.anon .huge-button-container{text-align:center}.topbar-dialog.inbox-dialog.anon .huge-button,.topbar-dialog.achievements-dialog.anon .huge-button{width:35%;padding:3% 0}.topbar-dialog.help-dialog{width:215px}.topbar-dialog.help-dialog .modal-content{max-height:none}.topbar-dialog.help-dialog .item-summary{display:block;color:var(--black-700);margin-top:4px}.topbar-dialog.help-dialog a{display:block}.topbar-dialog.review-dialog{width:215px}.topbar-dialog.review-dialog.review-dialog-mod{width:265px}.topbar-dialog.review-dialog .modal-content{max-height:none}.topbar-dialog.review-dialog .modal-content .timestamp{color:var(--black-350)}.topbar-dialog.review-dialog .modal-content li{display:block}.topbar-dialog.review-dialog .modal-content li>a{display:flex;align-items:center;flex-flow:row nowrap}.topbar-dialog.review-dialog .modal-content li>a:visited{color:var(--blue)}.topbar-dialog.review-dialog .modal-content li>a .-title{flex-grow:2}.topbar-dialog.review-dialog .modal-content li>a .-indicator{font-size:11px;display:inline-block;padding:3px 5px;background:hsla(210,8%,5%,0.05);color:var(--black-400);border-radius:3px}.topbar-dialog.review-dialog .modal-content .suspension-notice .notice-content .notice-header{color:var(--black-400)}.topbar-dialog.review-dialog .modal-content .suspension-notice .notice-content .notice-creation{float:right}.topbar-dialog.review-dialog .modal-content .suspension-notice .notice-content .notice-location{margin:4px 0}.topbar-dialog.review-dialog .modal-content .suspension-notice .notice-content .notice-summary{color:var(--black-700)}.topbar-dialog.review-dialog.danger-dialog .-item a{padding-left:32px;position:relative}.topbar-dialog.review-dialog.danger-dialog .-item a:before{content:'';width:10px;height:10px;position:absolute;left:10px;top:50%;margin-top:-5px;border-radius:50%;background:transparent}.topbar-dialog.review-dialog.danger-dialog .-item.danger-urgent .-title{font-weight:bold}.topbar-dialog.review-dialog.danger-dialog .-item.danger-urgent a:before{background:hsl(358,62%,52%);box-shadow:0 0 5px hsla(358,62%,52%,0.2)}.topbar-dialog.review-dialog.danger-dialog .-item.danger-active a:before{background:hsl(210,8%,85%)}.topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:before,.topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:after{left:20px}.topbar-dialog.network-logo-dialog{width:320px;border:1px solid var(--black-200);border-radius:3px;font-size:13px;box-shadow:var(--bs-sm)}.topbar-dialog.network-logo-dialog .dialog-content{padding:16px;background:var(--white);border-radius:5px}.topbar-dialog.network-logo-dialog h4{margin-bottom:12px}.topbar-dialog.network-logo-dialog a{font-weight:normal}.topbar-dialog.network-logo-dialog .icon-close{position:absolute;top:16px;right:16px;display:block;width:18px;height:18px;border-radius:3px;color:#d1d1d1;transition:opacity .2s ease-in-out}.topbar-dialog.network-logo-dialog .icon-close:hover{opacity:.5}.topbar-dialog ul{padding-left:0;margin-left:0;margin-bottom:0}.topbar-dialog ul li{list-style:none;margin-left:0;line-height:1.3}.topbar-dialog .header{background-color:var(--black-050);width:100%;box-sizing:border-box;position:relative;clear:both;display:flex;justify-content:space-between;align-items:center;padding:8px 10px}.topbar-dialog .header h3{font-family:var(--ff-sans);color:var(--black-500);font-weight:bold;text-transform:uppercase;font-size:11px;margin-bottom:0;display:inline-block}.topbar-dialog .header h3 a{font-size:inherit;color:inherit;font-family:var(--ff-sans)}.topbar-dialog .header .-right{color:var(--black-300)}.topbar-dialog .header .-right a{color:var(--blue)}.topbar-dialog #edit-pinned-sites,.topbar-dialog #cancel-pinned-sites{float:right}.topbar-dialog .modal-content{width:100%;max-height:300px;position:relative}.topbar-dialog .modal-content li{border-bottom:1px solid var(--black-050);margin-bottom:0}.topbar-dialog .modal-content li .rep-score{float:right;color:var(--black-400);font-size:12px}.topbar-dialog .modal-content li:hover{background-color:var(--black-075)}.topbar-dialog .modal-content li>*{padding:8px}.topbar-dialog .modal-content li>a>*{white-space:normal}.topbar-dialog .modal-content li>a.pinned-site-link{display:inline-block}.topbar-dialog .modal-content li:last-child{border-bottom:none}.topbar-dialog .modal-content .message-text{display:inline-block}.topbar-dialog .modal-content .message-text h4{margin-bottom:0;font-size:100%;font-weight:normal;font-family:var(--ff-sans);color:inherit}.topbar-dialog .unread-item{background-color:var(--powder-100);padding-bottom:8px;padding-top:8px}.topbar-dialog .unread-item .unread-bold{font-weight:bold;color:var(--blue-700)}.topbar-dialog .unread-item:hover{background-color:var(--powder-200)}.topbar-dialog .site-icon{width:16px;height:16px;vertical-align:top;flex:none}.topbar-dialog .site-title,.topbar-dialog .site-title:visited{color:var(--black-700)}.topbar-dialog .pinned-site-editor-container{width:100%}.topbar-dialog .pinned-site-editor-container .site-filter-input{width:100%}.topbar-dialog .pinned-site-editor-container .found-sites{position:absolute;background-color:var(--white);border:1px solid var(--black-075)}.topbar-dialog .pinned-site-editor-container .found-sites li:hover{font-weight:bold;cursor:pointer}.topbar-dialog .pinned-site-editor-container .found-sites li.already-pinned-site{font-weight:normal;background-color:var(--blue-050);cursor:default}.topbar-dialog .pinned-site-editor-container .remove-pinned-site-link{float:right}.topbar-dialog .pinned-site-editor-container .remove-pinned-site-link a{padding:0 5px 2px 5px;font-weight:bold;color:var(--black-350);background-color:var(--black-050);font-family:var(--ff-sans);line-height:1;border-radius:15px}.topbar-dialog .pinned-site-editor-container .remove-pinned-site-link a:hover{color:var(--white);background-color:var(--black-400)}.topbar-dialog .pinned-site-editor-container .sortable li{cursor:move}.achievements-dialog{width:450px;max-height:505px;font-size:12px}.achievements-dialog .utc-clock{color:var(--black-350);font-size:11px;font-weight:normal;display:inline-block;padding-left:5px;font-variant:small-caps}.achievements-dialog .date-group .date-group-toggle-row{cursor:pointer}.achievements-dialog .date-group .date-group-toggle{display:inline-block;width:10px;height:10px;background-position:2px -94px}.achievements-dialog .date-group .date-group-toggle.toggle-hidden{background-position:-17px -94px}.achievements-dialog ul{margin-bottom:10px}.achievements-dialog .rep-change{vertical-align:top;text-align:right;font-size:11px;display:inline-block;white-space:nowrap}.achievements-dialog .rep-up{color:var(--green-400)}.achievements-dialog .rep-down{color:var(--red-500)}.achievements-dialog .rep-site-container{margin:10px 0;width:100%;cursor:default}.achievements-dialog .rep-site-container .rep-site{width:30px;display:inline-block;text-align:center}.achievements-dialog .rep-site-container .rep-site img{display:block;margin:0 auto 4px auto}.achievements-dialog .date-header,.achievements-dialog .single-rep-site-container{font-weight:bold;margin:3px 0 4px 0;display:inline-block;font-size:12px}.achievements-dialog .date-header .rep-change,.achievements-dialog .single-rep-site-container .rep-change{font-size:12px}.achievements-dialog .date-header{padding:8px;color:var(--black-400)}.achievements-dialog .single-rep-site-container{margin-left:2px}.achievements-dialog .message-text{margin-left:2px;width:278px}.achievements-dialog .achievements-badge{text-align:right}.achievements-dialog .achievements-privilege-category .icon{vertical-align:top;margin:0;width:18px}.achievements-dialog .modal-content.short{min-height:297px;max-height:297px}.achievements-dialog .modal-content.tiny{min-height:197px;max-height:197px}.self-actions{width:200px;max-height:505px;left:535px}html{--top-bar-allocated-space:50px}.s-topbar~.container,.s-topbar~#announcement-banner{margin-top:var(--topbar-height)}.s-topbar~#announcement-banner~.container{margin-top:0}.s-topbar{--theme-topbar-height:50px}.s-topbar,.s-topbar *{box-sizing:border-box}.s-topbar .s-topbar--logo .-img{display:inline-block;text-indent:-9999em;height:30px;width:146px;margin-top:-4px;margin-left:0;background-position:0 -500px}.s-topbar .s-topbar--logo .-img._glyph{margin-left:0;width:150px;height:30px;margin-top:-4px}@media screen and (max-width:640px){html.html__responsive .s-topbar .s-topbar--logo .-img._glyph{width:25px;margin-top:0}}@media print{.s-topbar .s-topbar--logo .-img._glyph{width:25px;margin-top:0}}body.theme-highcontrast .s-topbar .s-topbar--logo .-img{filter:brightness(0)}@media (prefers-color-scheme:dark){body.theme-system .s-topbar .s-topbar--logo .-img{filter:invert(.5) brightness(2)}}body.theme-dark .s-topbar .s-topbar--logo .-img,.theme-dark__forced .s-topbar .s-topbar--logo .-img{filter:invert(.5) brightness(2)}@media screen and (max-width:640px){html.html__responsive .s-topbar .s-topbar--logo.network-logo{width:41px;overflow:hidden;display:block}html.html__responsive .s-topbar .s-topbar--logo.network-logo .svg-icon{transform:scale(2);transform-origin:0 -10px}}@media print{.s-topbar .s-topbar--logo.network-logo{width:41px;overflow:hidden;display:block}.s-topbar .s-topbar--logo.network-logo .svg-icon{transform:scale(2);transform-origin:0 -10px}}.s-topbar .topbar-dialog.leftnav-dialog{width:auto;right:auto}.s-topbar .topbar-dialog.leftnav-dialog .left-sidebar:not(:empty){width:240px}@media screen and (max-width:640px){html.html__responsive .s-topbar .topbar-dialog:not(.leftnav-dialog),html.html__responsive .s-topbar .topbar-dialog.review-dialog.review-dialog-mod{width:100%;left:0;right:0}html.html__responsive .s-topbar .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:before,html.html__responsive .s-topbar .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:after{left:105px}}@media print{.s-topbar .topbar-dialog:not(.leftnav-dialog),.s-topbar .topbar-dialog.review-dialog.review-dialog-mod{width:100%;left:0;right:0}.s-topbar .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:before,.s-topbar .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:after{left:105px}}.s-topbar .s-topbar--menu-btn{display:none}@media screen and (max-width:640px){html.html__responsive .s-topbar .s-topbar--menu-btn{display:flex}}@media print{.s-topbar .s-topbar--menu-btn{display:flex}}html.html__unpinned-leftnav .s-topbar .s-topbar--menu-btn{display:flex}.s-topbar .s-user-card .-badges{font-size:inherit;color:var(--black-050)}.s-topbar .s-user-card .-badges>span+span{padding-left:6px}.s-topbar .s-user-card .-badges .badge1,.s-topbar .s-user-card .-badges .badge2,.s-topbar .s-user-card .-badges .badge3{text-indent:-9999em}.s-topbar .s-user-card .-badges .badgecount{font-weight:normal}.s-topbar .s-user-card .-badges .badge1+.badgecount{color:var(--gold-darker)}.s-topbar .s-user-card .-badges .badge2+.badgecount{color:var(--silver-darker)}.s-topbar .s-user-card .-badges .badge3+.badgecount{color:var(--bronze-darker)}.s-topbar .topbar-dialog{--scrollbar:var(--hack-topbar-scrollbar-fallback)}body{--hack-topbar-scrollbar-fallback:var(--scrollbar)}.s-topbar .s-topbar--item__unset>*{align-self:center;padding-top:8px;padding-bottom:8px}.s-topbar .s-topbar--item__unset+.s-topbar--item__unset{margin-left:4px}.s-topbar .s-topbar--item__unset:last-child{margin-right:8px}.site-footer,.site-footer *,.site-footer *:before,.site-footer *:after{box-sizing:border-box}.site-footer .-list{margin:0;list-style:none}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) .site-footer .-list:not(.-social){display:flex;flex-wrap:wrap;column-gap:12px;row-gap:8px}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav .site-footer .-list:not(.-social){display:flex;flex-wrap:wrap;column-gap:12px;row-gap:8px}}@media print{.site-footer .-list:not(.-social){display:flex;flex-wrap:wrap;column-gap:12px;row-gap:8px}}.site-footer .-link{color:var(--theme-footer-link-color);padding:4px 0;line-height:1.30769231;display:inline-block;text-decoration:none}.site-footer .-link:hover{color:var(--theme-footer-link-color-hover)}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) .site-footer .-link{padding:0}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav .site-footer .-link{padding:0}}@media print{.site-footer .-link{padding:0}}.site-footer .-title{text-transform:uppercase;font-weight:bold;margin-bottom:12px;color:var(--theme-footer-title-color);line-height:1.30769231}.site-footer .-title a{color:var(--theme-footer-title-color);text-decoration:none}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) .site-footer .-title{margin-bottom:8px}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav .site-footer .-title{margin-bottom:8px}}@media print{.site-footer .-title{margin-bottom:8px}}.site-footer{background-color:var(--theme-footer-background-color);background-image:none;background-position:var(--theme-footer-background-position);background-repeat:var(--theme-footer-background-repeat);border-top:var(--theme-footer-background-border-top);background-size:var(--theme-footer-background-size);color:var(--theme-footer-text-color);padding-top:var(--theme-footer-padding-top);padding-bottom:var(--theme-footer-padding-bottom)}body.theme-highcontrast .site-footer{--theme-footer-background-color:hsl(210,8%,5%);--theme-footer-background-border-top:hsl(0,0%,100%);--theme-footer-title-color:hsl(0,0%,100%);--theme-footer-text-color:hsl(0,0%,100%);--theme-footer-link-color:hsl(0,0%,100%);--theme-footer-link-color-hover:hsl(0,0%,100%);--theme-footer-link-color-active:hsl(0,0%,100%);--theme-footer-link-caret-color:hsl(210,8%,5%);--theme-footer-divider-color:hsl(0,0%,100%);background-image:none !important;border-top:1px solid var(--black)}body.theme-highcontrast .site-footer a:hover,body.theme-highcontrast .site-footer a:focus{color:hsl(0,0%,100%);text-decoration:underline}.site-footer .site-footer--container,.site-footer .site-footer--extra{max-width:1264px;width:100%;margin:0 auto;padding:32px 12px 12px 12px;display:flex;flex-flow:row wrap}@media screen and (max-width:980px) and (min-width:640.1px){html.html__responsive:not(.html__unpinned-leftnav) .site-footer .site-footer--container,html.html__responsive:not(.html__unpinned-leftnav) .site-footer .site-footer--extra{padding:24px}}@media screen and (max-width:816px) and (min-width:640.1px){html.html__responsive.html__unpinned-leftnav .site-footer .site-footer--container,html.html__responsive.html__unpinned-leftnav .site-footer .site-footer--extra{padding:24px}}@media screen and (max-width:640px){html.html__responsive .site-footer .site-footer--container,html.html__responsive .site-footer .site-footer--extra{padding:16px}}@media print{.site-footer .site-footer--container,.site-footer .site-footer--extra{padding:16px}}.site-footer .site-footer--extra{padding:32px 12px;border-top:1px solid var(--theme-footer-divider-color)}.site-footer .site-footer--logo{flex:0 0 64px;margin:-12px 0 32px 0}@media screen and (max-width:640px){html.html__responsive .site-footer .site-footer--logo{display:none}}@media print{.site-footer .site-footer--logo{display:none}}.site-footer .site-footer--nav{display:flex;flex:2 1 auto;flex-wrap:wrap}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) .site-footer .site-footer--nav{flex-direction:column}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav .site-footer .site-footer--nav{flex-direction:column}}@media print{.site-footer .site-footer--nav{flex-direction:column}}.site-footer .site-footer--col{padding:0 12px 24px 0;flex:1 0 auto}.site-footer .site-footer--copyright{flex:1 1 150px;display:flex;flex-direction:column}.site-footer .site-footer--copyright ul{display:flex;list-style:none;margin:0;padding:0}.site-footer .site-footer--copyright ul li+li{margin-left:12px}.site-footer .site-footer--copyright p{margin-top:auto;margin-bottom:24px}.site-footer .site-footer--copyright p a,.site-footer .site-footer--copyright p a:visited{line-height:inherit;color:var(--theme-footer-link-color);padding:0}.message.error,.message.success,.message.regular,.message.incomplete,.message.gray{display:inline-block;padding:12px;margin:10px 0;border-radius:3px}.message.error.text-only,.message.success.text-only,.message.regular.text-only,.message.incomplete.text-only,.message.gray.text-only{background:none;border:0;padding:0;margin:0 0 10px 0;color:var(--black-500)}.message.error.text-only i[class^="icon-"],.message.success.text-only i[class^="icon-"],.message.regular.text-only i[class^="icon-"],.message.incomplete.text-only i[class^="icon-"],.message.gray.text-only i[class^="icon-"],.message.error.text-only span[class^="icon-"],.message.success.text-only span[class^="icon-"],.message.regular.text-only span[class^="icon-"],.message.incomplete.text-only span[class^="icon-"],.message.gray.text-only span[class^="icon-"]{margin-right:4px}.message.error.centered,.message.success.centered,.message.regular.centered,.message.incomplete.centered,.message.gray.centered{text-align:center}.message.error.centered-block,.message.success.centered-block,.message.regular.centered-block,.message.incomplete.centered-block,.message.gray.centered-block{display:block;margin:10px auto}.message.error.left-block,.message.success.left-block,.message.regular.left-block,.message.incomplete.left-block,.message.gray.left-block{display:block;margin:10px auto}.message.error .message-ctas,.message.success .message-ctas,.message.regular .message-ctas,.message.incomplete .message-ctas,.message.gray .message-ctas{display:flex;justify-content:space-between;align-items:center;margin-top:10px}.message.error .message-cta,.message.success .message-cta,.message.regular .message-cta,.message.incomplete .message-cta,.message.gray .message-cta{margin-top:10px}.message.error .message-title,.message.success .message-title,.message.regular .message-title,.message.incomplete .message-title,.message.gray .message-title{text-align:center;font-weight:700;padding:10px 0;margin:-12px -12px 10px -12px;border-radius:3px 3px 0 0}.message.error .message-title [class^="icon"],.message.success .message-title [class^="icon"],.message.regular .message-title [class^="icon"],.message.incomplete .message-title [class^="icon"],.message.gray .message-title [class^="icon"]{margin-right:4px;vertical-align:middle}.message.error .message-title [class*="icon-warning"],.message.success .message-title [class*="icon-warning"],.message.regular .message-title [class*="icon-warning"],.message.incomplete .message-title [class*="icon-warning"],.message.gray .message-title [class*="icon-warning"]{position:relative;top:-1px}.message.inline-message{display:block}.message.inline-message:before,.message.inline-message:after{content:"";display:table}.message.inline-message:after{clear:both}.message.inline-message .message-title{display:inline-block;margin:0 12px 0 0;color:var(--orange)}.message.inline-message .inline-message-cta{float:right}.message.regular{background:var(--yellow-050);color:var(--yellow-900);border:1px solid var(--yellow-100)}.message.error{color:var(--red-900);background:var(--red-050);border:1px solid var(--red-100)}.message.error.text-only{color:var(--red-500)}.message.error.text-only:before{top:3px;background-position:-72px -330px}.message.success{color:var(--green-900);background:var(--green-050);border:1px solid var(--green-100)}.message.success.text-only{color:var(--green-500)}.message.success.text-only:before{background-position:-95px -330px}.message.incomplete{color:var(--black-900);background:var(--orange-050);border:1px solid var(--orange-100)}.message.incomplete .message-title{color:var(--orange);background:var(--orange-100);padding:10px 0;margin:-12px -12px 10px -12px}.message.gray{background:#f6f6f7;color:hsl(210,8%,5%);border:1px solid hsl(210,8%,90%)}.message.gray .message-title{background:hsl(210,8%,90%);padding:10px 0}.job-requirements{padding:15px}.job-requirements input[type=submit].dno{display:none}.message.job-improve .message-title{background:hsl(210,8%,90%);padding:10px 0}.message.label.regular{font-size:12px;padding:6px;margin:0}.message.label.regular.has-tooltip{cursor:default}h1 .message.label,h2 .message.label,h3 .message.label{position:relative;top:-1px}.top-notification{background:hsl(206,100%,52%);color:hsl(0,0%,100%);font-size:12px;margin-bottom:20px;padding:10px 20px}.top-notification .container{width:100%;max-width:1050px;margin:0 auto;min-height:30px;align-items:center}.top-notification a{color:hsl(0,0%,100%)}.top-notification .-content p:last-child{margin-bottom:0}.top-notification .-content .btn{background:#F48024;box-shadow:inset 0 1px 0 rgba(255,255,255,0.4);margin-left:10px}.top-notification .-actions{text-align:right}.comments{width:660px;padding-bottom:10px}.comments>table{width:100%}.comments-link{padding:0 3px 2px 3px}a.comments-link:hover{padding:0 3px 2px 3px;text-decoration:none}tr.comment>td{padding:6px 6px 6px 0;vertical-align:top;line-height:1.3;border-bottom:1px solid var(--black-050)}.comment img{vertical-align:middle}.comment:not([style*="background-color"]){transition:background-color linear 2s}.comment-actions{padding-left:3px;width:15px}.comment-score span{font-size:13px;font-weight:normal;padding-right:4px}.comment-text,.comment-form{padding:0 6px 0 7px;vertical-align:text-top}.comment-text code{padding:1px 5px}.comment-text .comment-edited{margin-top:3px;margin-left:2px;vertical-align:top}.comment-form>form textarea,.comment-form>form div[contenteditable=true]{margin-bottom:4px;height:5em;width:100%;resize:vertical;overflow:auto}.comment-date{color:var(--black-400)}.text-counter{margin-right:20px}.comment-text .hover-only-label{visibility:hidden}.comment-text:hover .hover-only-label{visibility:visible}.comment-text:focus-within .hover-only-label{visibility:visible}.comment-text button:focus .hover-only-label{visibility:visible}@media (hover:none){.comment-text .hover-only-label{visibility:visible}}.comment__highlight:not([style*="background-color"]){transition:none;background-color:var(--yellow-100)}ul.comments-list{list-style-type:none;margin:0}ul.comments-list .comment{display:flex}ul.comments-list .comment-score{width:15px;width:2ch;padding-right:4px}ul.comments-list .comment-score>span{float:right;padding-right:0px;min-width:15px;min-width:2ch}ul.comments-list .comment-text{flex-grow:1}ul.comments-list .comment-voting,ul.comments-list .comment-flagging{width:20px}ul.comments-list .comment>*{border-bottom:1px solid var(--black-050)}ul.comments-list .comment-text,ul.comments-list comment-form,ul.comments-list .comment-actions{padding:6px 0}ul.comments-list .comment-text{min-width:0;flex-basis:0;padding-left:6px;padding-right:6px}ul.comments-list .comment-body{word-wrap:break-word}ul.comments-list .comment-actions{padding-right:2px}ul.comments-list .comment-text,ul.comments-list .comment-actions{transition:background-color ease-out 3s}ul.comments-list .deleted-comment{background-color:transparent}ul.comments-list .deleted-comment .comment-text,ul.comments-list .deleted-comment .comment-actions{background-color:var(--red-050)}ul.comments-list .comment__highlight{background-color:transparent}ul.comments-list .comment__highlight .comment-text{transition:none;background-color:var(--yellow-100)}ul.comments-list .comment-actions{width:38px;flex-shrink:0}ul.comments-list .comment-score{display:inline-block}ul.comments-list .comment-voting,ul.comments-list .comment-flagging{float:right}@supports (display: grid){ul.comments-list .comment-actions{display:grid;grid-template-columns:repeat(2, max-content);align-content:flex-start;width:37px;width:calc(2ch + 16px + 4px + 2px)}ul.comments-list .comment-flagging:nth-child(3){grid-column:2}}@supports (display: grid) and (display: contents) and (not (-apple-trailing-word: auto)){body:not(.no-grid-comments) ul.comments-list{display:grid;grid-template-columns:max-content 1fr}body:not(.no-grid-comments) ul.comments-list .comment-score{width:auto;min-width:16px}body:not(.no-grid-comments) ul.comments-list .comment-score>span{min-width:0;float:none}body:not(.no-grid-comments) ul.comments-list .comment-actions{width:auto}body:not(.no-grid-comments) ul.comments-list .comment{display:contents}body:not(.no-grid-comments) ul.comments-list .comment__highlight .comment-actions{transition:none;background-color:var(--yellow-100)}}.message.message-config.unsubscribe-all-popup{z-index:2000}.col-6.with-padding:first-child{padding-right:10px}.col-6.with-padding:last-child{padding-left:10px}.profile-section-title{font-weight:700;color:var(--fc-dark)}.profile-section-title span{font-weight:400;color:var(--fc-light)}#mod-content{margin-top:25px}#mod-content .mod-sidebar{padding-right:30px}#mod-content .mod-sidebar .account-details{margin-bottom:20px}.mod-quick-links{margin-bottom:30px}.mod-links li{margin-bottom:5px}.account-info .row.mod-section{padding-bottom:20px;margin-bottom:20px;border-bottom:1px solid hsl(210,8%,95%)}#mod-content .row h3{margin-bottom:10px}.row.mod-credentials{margin-top:20px;margin-bottom:0}.account-info dl{float:right;font-size:.8em}.account-info dl dt{display:inline-block;font-weight:bold}.account-info dl dd{display:inline-block;font-style:italic}.ui-datepicker.ui-widget{color:var(--fc-medium)}@media (prefers-color-scheme:dark){body.theme-system .ui-datepicker.ui-widget{background-color:var(--black-100);border-color:transparent;box-shadow:var(--bs-lg)}}body.theme-dark .ui-datepicker.ui-widget,.theme-dark__forced .ui-datepicker.ui-widget{background-color:var(--black-100);border-color:transparent;box-shadow:var(--bs-lg)}.ui-datepicker table.ui-datepicker-calendar .ui-state-default{color:inherit;background:none;border:0}.ui-datepicker table.ui-datepicker-calendar .ui-state-hover,.ui-datepicker .ui-datepicker-header .ui-state-hover{background-color:var(--theme-button-hover-background-color)}.ui-datepicker table.ui-datepicker-calendar .ui-state-active{background:var(--theme-button-primary-background-color);color:#fff}.ui-datepicker .ui-datepicker-header{color:inherit;background:none;border:0}@media (prefers-color-scheme:dark){body.theme-system .ui-datepicker .ui-datepicker-header .ui-icon{filter:invert(1)}}body.theme-dark .ui-datepicker .ui-datepicker-header .ui-icon,.theme-dark__forced .ui-datepicker .ui-datepicker-header .ui-icon{filter:invert(1)}.ui-datepicker .ui-datepicker-header.ui-widget-header .ui-state-hover{background:none;border-color:var(--black-200)}.ui-datepicker table.ui-datepicker-calendar .ui-state-highlight{font-weight:bold}.block{display:block}.fw{margin-bottom:4px;width:100%}.relative{position:relative}.cp{cursor:pointer}.help-text{color:var(--black-500)}.bold{font-weight:700}.help-text.has-icon,.message.text-only.has-icon{display:flex}.help-text.has-icon [class^='icon'],.message.text-only.has-icon [class^='icon'],.help-text.has-icon .svg-icon,.message.text-only.has-icon .svg-icon{flex-shrink:0;margin-top:-3px;margin-right:5px}.help-text.has-icon .icon-i-orange,.message.text-only.has-icon .icon-i-orange{position:relative;top:2px}.success-text{color:var(--green-500)}.error-text{color:var(--red-500)}.hidden,.dno,._hidden{display:none}.hidden-important{display:none !important}.stop-scrolling{height:100%;overflow:hidden}._blocked{overflow:hidden;position:fixed}html{height:100%;min-width:1264px}body{min-height:100%;display:flex;flex-direction:column;background-color:var(--theme-background-color);background-image:none;background-position:var(--theme-background-position);background-repeat:var(--theme-background-repeat);background-size:var(--theme-background-size);background-attachment:var(--theme-background-attachment);min-width:1279px;--mp-alt-row-color:var(--black-050);--mp-critical-color:var(--red-600);--mp-duration-color:var(--black-800);--mp-gap-bg-color:var(--black-025);--mp-gap-font-color:var(--black-700);--mp-highlight-default-color:var(--fc-dark);--mp-highlight-fade-color:var(--yellow-300);--mp-highlight-keyword-color:var(--blue-700);--mp-highlight-literal-color:var(--green-500);--mp-label-color:var(--black-700);--mp-link-color:var(--blue-700);--mp-main-bg-color:var(--white);--mp-muted-color:var(--black-300);--mp-popup-shadow:var(--bs-sm);--mp-query-border-color:var(--black-100);--mp-result-border:solid .5px var(--black-300);--mp-warning-color:var(--red-600)}body.read-only .askquestion,body.read-only .login-link,body.read-only .bookmark-off,body.read-only .vote-down-off,body.read-only .vote-up-off{opacity:.3}body.read-only .bookmark-off,body.read-only .vote-down-off,body.read-only .vote-up-off{cursor:not-allowed}.container{position:relative;width:100%;flex:1 0 auto;margin:0 auto;text-align:left}#content{box-sizing:content-box;margin:0 auto;padding:15px;width:1264px;background-color:hsl(0,0%,100%)}#content:before,#content:after{content:"";display:table}#content:after{clear:both}.ask-page:not(.wizard) #content{min-height:750px;overflow:visible}body:not(.unified-theme) .container._full #content{padding:0;width:100%}body:not(.unified-theme) .container._full #content .inner-content{box-sizing:content-box;margin:0 auto;padding:15px;width:1264px}body:not(.unified-theme) .container._full #content .inner-content:before,body:not(.unified-theme) .container._full #content .inner-content:after{content:"";display:table}body:not(.unified-theme) .container._full #content .inner-content:after{clear:both}.main-columns{display:flex}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) .main-columns{flex-direction:column}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav .main-columns{flex-direction:column}}@media print{.main-columns{flex-direction:column}}.main-columns #mainbar,.main-columns .mainbar{float:none}.main-columns #sidebar,.main-columns .sidebar{float:none;margin-left:24px}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) .main-columns #sidebar,html.html__responsive:not(.html__unpinned-leftnav) .main-columns .sidebar{margin-left:auto}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav .main-columns #sidebar,html.html__responsive.html__unpinned-leftnav .main-columns .sidebar{margin-left:auto}}@media print{.main-columns #sidebar,.main-columns .sidebar{margin-left:auto}}.container__full{max-width:100%}.container__full .left-sidebar{display:none}.container__full #content{padding:0;max-width:100%;width:100%}.container .container--inner{max-width:1264px;padding:0 24px;margin:0 auto}#header{margin:0 auto;width:1264px;height:96px;padding:0 15px;box-sizing:content-box;position:relative}#questions,#answers{clear:both;width:728px}#questions{float:left;margin-bottom:20px}#question-header .question-hyperlink{font-size:2.07692308rem;font-family:var(--theme-post-title-font-family);line-height:1.35;font-weight:normal;margin-bottom:0}.question-summary{overflow:hidden;padding:15px 0;float:left;width:728px;border-bottom:1px solid var(--black-050)}body.theme-highcontrast .question-summary{border-bottom-color:currentColor}.question-summary .question-summary-scroll{border-bottom:none}.question-summary .question-hyperlink{font-family:var(--theme-post-title-font-family)}.stats{margin:0;width:58px}.statscontainer{width:78px;float:left;margin-right:8px;margin-left:8px;color:var(--black-500);font-size:11px}.statscontainer .views{width:58px}.statscontainer .status{padding:7px 0 5px;border-radius:3px}.statscontainer .status strong{font-size:1.61538462rem;font-weight:normal}.narrow .status{display:inline-block;margin:0 3px 0 0;min-width:44px;height:auto;font-size:11px;padding:6px;border:1px solid transparent;border-radius:3px}.narrow .started{width:auto;padding-top:4px;white-space:nowrap}.narrow .votes{display:inline-block;height:38px;min-width:38px;margin:0 3px 0 0;font-size:11px;color:var(--black-400);padding:6px}.narrow .stats{background:none;margin:0 0 0 7px;padding:0;width:auto;height:48px;display:inline-block}.narrow .views{display:inline-block;height:38px;min-width:40px;margin:0 7px 0 0;font-size:11px;color:var(--black-400);padding:7px 6px}.narrow .summary{width:530px;padding:0;float:left}.narrow .summary h3{margin-bottom:.35em;line-height:1.3}.narrow .cp{vertical-align:top;float:left;margin-right:10px}.narrow .mini-counts{font-size:1.30769231rem;margin-bottom:4px}.votes{padding:0;margin-bottom:8px;text-align:center}.vote-count-post{display:block;font-size:1.61538462rem}.vote-count-post strong{font-weight:normal}.status{padding:0;margin-bottom:8px;text-align:center}.status strong{display:block}.vote-count-separator{border-top:1px solid var(--black-050);width:36px;margin-top:5px;margin-bottom:5px}.views{padding-top:4px;text-align:center}.views strong{display:block}#question-suggestions{overflow:hidden;padding-bottom:2px;font-size:1.15384615rem}#question-suggestions .answer-hyperlink,#question-suggestions .question-hyperlink{font-size:13px}#question-suggestions .answer-votes{font-size:11px;line-height:1.3;padding:1px 0 2px;font-weight:normal}#question-suggestions label{margin:10px 0}#question-suggestions .answer-summary{overflow:auto;display:flex}.question-originals-of-duplicate.question-status{width:auto;margin:10px 0;padding:10px;background-image:none}.question-originals-of-duplicate p{margin:0;font-weight:bold}.question-originals-of-duplicate ul{margin:0}.question-originals-of-duplicate ul li{list-style-type:none;margin:0}.question-originals-of-duplicate .question-originals-answer-count{font-style:italic;padding-left:5px}.question-originals-of-duplicate #edit-or-approve-duplicate{margin:15px 0 5px}.question-originals-of-duplicate #edit-or-approve-duplicate #got-my-answer{margin:0}.question-originals-of-duplicate #edit-or-approve-duplicate>div{line-height:33px}.question-status{margin-top:15px;margin-bottom:10px;padding:15px 8px 1px 60px;background-color:var(--black-050);border:var(--black-075);clear:both}.question-status h2{font-size:1.15384615rem;line-height:18px;margin-bottom:10px}.question-status p{font-size:13px;word-wrap:break-word}.question-status .site-specific-close-reason-status-list{margin-bottom:0}.question-status .close-status-suffix{display:block;margin-top:10px}.question-status .voter-history .badge1{vertical-align:middle}#answers{padding-top:10px}#answers-header{margin-top:10px;width:728px}.question{clear:both}.question .postcell{vertical-align:top}.question-page #answers .answer{border-bottom:1px solid var(--black-075)}hr{border:0;color:var(--black-300);background-color:var(--black-300);height:1px;margin-bottom:20px}.date{text-align:right;width:70px;white-space:nowrap;color:var(--black-300);height:35px;font-size:1.46153846rem}.date_brick{float:right;width:45px;color:var(--black-350);text-align:center;line-height:1.4;font-size:13px;margin-left:10px;padding-top:5px;letter-spacing:0;overflow:hidden}.revcell1{width:25px;cursor:pointer;text-align:right}.revcell2{width:50px;cursor:pointer;font-size:250%;font-weight:bold;color:var(--black-500);text-align:left}.revcell3{vertical-align:middle;width:660px;padding-top:8px;padding-bottom:5px}.revcell4{padding:5px;width:185px}.revcell5{margin-top:10px;margin-left:10px}.unanswered .mini-counts span{color:var(--black-800)}.votecell{vertical-align:top;padding-right:15px}.votecell .vote-count-post{margin:8px 0}.votecell .vote{min-width:46px}body.theme-highcontrast .votecell button,body.theme-highcontrast .votecell a{color:var(--black-300)}body.theme-highcontrast .votecell button:hover,body.theme-highcontrast .votecell a:hover,body.theme-highcontrast .votecell button:focus,body.theme-highcontrast .votecell a:focus{color:var(--black-900)}#scroller{margin-top:5px}.answer{padding-bottom:16px;padding-top:16px}.post-signature{text-align:left;vertical-align:top;width:200px}.owner{border-radius:3px;background-color:var(--theme-post-owner-background-color)}.new-contributor-indicator{background-color:var(--theme-post-owner-new-background-color)}.affiliate-badge{color:var(--orange-400)}.owner .affiliate-badge{color:var(--black-700)}.downvoted-answer .comment-body,.downvoted-answer .post-signature,.downvoted-answer .s-prose,.downvoted-answer .vote>*{opacity:.5;transition:opacity .5s}.downvoted-answer .vote .message{opacity:1}.downvoted-answer:hover .comment-body,.downvoted-answer:hover .post-signature,.downvoted-answer:hover .s-prose,.downvoted-answer:hover .vote>*{opacity:1}.item-multiplier{margin-right:4px;color:var(--black-400)}.reputation-score{font-weight:bold;font-size:12px;margin-right:2px}.relativetime{text-decoration:none}#notify-container{font-size:1.30769231rem;text-align:center;position:fixed;left:0;top:0;width:100%;height:0;z-index:5051}#notify-container span.notify-close{float:right;margin-right:20px;text-decoration:none;display:block;cursor:pointer}#notify-container span.notify-close a{text-decoration:none;font-size:1.30769231rem;font-weight:bold;color:hsl(0,0%,100%)}#notify-container div{color:hsl(0,0%,100%);padding:9px 0;background:#f90}.summarycount{text-align:center;font-size:2.07692308rem;line-height:1}.summarycount+p{margin-bottom:0}.lsep{margin:0 2px;color:hsl(210,8%,80%);color:#1b4072;font-size:1px;visibility:hidden}.post-taglist{margin-bottom:10px;clear:both}.post-menu{padding-top:2px}.post-menu>a{padding:0 1px;color:var(--black-400)}.post-menu>a:hover{color:var(--black-700);text-decoration:none}.post-menu .lsep{margin:0;padding:0}.post-menu>*:not(.s-popover){display:inline-block}.edit-tags-wrapper{padding-right:40px}.edit-tags-wrapper>a.post-tag{margin-right:6px}.inline-tag-edit-link{padding:0 3px 2px;color:var(--black-400)}.inline-tag-edit-link:hover{color:var(--black-700);text-decoration:none}.deleted-post{color:var(--red-400) !important;font-weight:bold !important}.deleted-post:hover{color:var(--white) !important;background-color:var(--red-400) !important}.search-highlight{color:var(--black-750);background-color:var(--yellow-050);font-weight:bold}.page-description{margin:10px 0}.page-description:not(.s-prose){font-size:1.15384615rem;line-height:18px}.content-page{padding:20px 0}.content-page h2{margin-bottom:10px;font-size:140%;font-weight:bold}.content-page h3{margin-bottom:10px;font-size:120%;font-weight:bold}.user-info{box-sizing:border-box;padding:5px 6px 7px 7px;color:var(--black-500)}.user-info:before,.user-info:after{content:"";display:table}.user-info:after{clear:both}.user-info .user-gravatar32{float:left;width:32px;height:32px;border-radius:1px}.user-info .user-gravatar32 img{border-radius:1px}.user-info .user-gravatar32+.user-details{margin-left:8px;width:calc(100% - 40px)}.user-info .user-gravatar48+.user-details{margin-left:8px;width:calc(100% - 48px)}.user-info .user-gravatar64+.user-details{margin-left:8px;width:calc(100% - 64px)}.user-info .user-action-time{margin-top:1px;margin-bottom:4px;font-size:12px;white-space:nowrap}.user-info .user-details{float:left;width:100%}.user-info .-flair{display:block}.user-info-td .user-info{padding:0}.user-details{line-height:17px;word-wrap:break-word}.user-details .badgecount{font-weight:400;font-size:12px}.user-details td{color:var(--black);padding:4px 0}.revision td{background-color:var(--black-050)}.owner-revision td{background-color:var(--powder-100)}.revision-comment{color:var(--black-750);padding:0}.answer-votes{color:var(--black-600);text-align:center;float:left;padding:3px;min-width:36px;min-height:15px;text-decoration:none;border-radius:2px}#mainbar h2,.mainbar h2,#mainbar h3,.mainbar h3,#mainbar h4,.mainbar h4{font-weight:400}.answer-link{float:left;width:700px;padding-left:10px;color:var(--black-600)}.answer-summary{padding:3px;clear:both}.bounty-indicator{float:left;color:var(--white);font-size:11px;padding:.2em .5em .25em;line-height:1.3;background-color:var(--blue-600);margin-right:5px;border-radius:2px}.bounty-indicator-tab{color:hsl(0,0%,100%);display:inline;background-color:var(--blue-600);padding:.2em .5em .25em;margin-right:5px;font-size:11px;line-height:1.3;border-radius:2px}.bounty p{margin-top:10px}#bounty-submit{box-shadow:var(--bs-sm);background-color:var(--red-600);border-color:var(--red-300) var(--red-900) var(--red-900) var(--red-300);border-style:solid;border-width:1px 2px 2px 1px;color:hsl(0,0%,100%);font-size:1.15384615rem;font-weight:bold;margin:3px;padding:4px}.history-table{line-height:180%}.history-table .answer-hyperlink,.history-table .question-hyperlink{font-size:13px}.history-table span.revision-comment{line-height:180%}.history-table .comments{border-top:none}.history-table p{margin-bottom:10px;margin-top:3px}#noscript-warning{font-family:sans-serif;position:fixed;top:0;left:0;width:100%;z-index:5050;text-align:center;font-weight:bold;font-size:120%;color:hsl(0,0%,100%);background-color:var(--red-600);padding:5px 0}#noscript-warning a{color:hsl(0,0%,100%);text-decoration:underline}.nav ul{margin:0}.nav ul li{display:inline-block;margin-left:15px}.nav ul li a{text-decoration:none;display:block}.top-banner-message-container{width:1264px;margin:0 auto 14px;padding:0;box-sizing:content-box;position:relative}.top-banner-message-container .message{width:100%}#sidebar,.sidebar{float:right;width:300px;margin:0 0 15px}#sidebar .badge,.sidebar .badge,#sidebar .badge-tag,.sidebar .badge-tag,#sidebar .moderator-tag,.sidebar .moderator-tag,#sidebar .post-tag,.sidebar .post-tag,#sidebar .required-tag,.sidebar .required-tag{margin-bottom:.5em}#sidebar h4,.sidebar h4{margin-bottom:1em}#sidebar.ask-sidebar{width:365px}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) #sidebar.ask-sidebar{width:300px}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav #sidebar.ask-sidebar{width:300px}}@media print{#sidebar.ask-sidebar{width:300px}}#mainbar,.mainbar{float:left;width:728px;margin:0;padding:0}#mainbar-full,.mainbar-full{width:100%;padding:0}#mainbar-full:before,.mainbar-full:before,#mainbar-full:after,.mainbar-full:after{content:"";display:table}#mainbar-full:after,.mainbar-full:after{clear:both}div.form-error{color:var(--red-700);font-weight:bold;font-size:130%}.subheader{clear:both;margin-bottom:10px;height:40px;border-bottom:1px solid var(--black-075)}body.theme-highcontrast .subheader{border-color:currentColor}.subheader h1,.subheader h2{float:left;margin-bottom:0;font-weight:normal}.subheader h1{color:var(--black-700);font-size:1.46153846rem;line-height:2.22}.subheader h2{color:var(--black-700);font-size:1.46153846rem}.subheader.tools-rev{margin-bottom:10px}.subheader a.link{color:var(--theme-link-color)}body.home-page .subheader,body.questions-page .subheader{margin-bottom:0}.cool,.mini-counts.cool{color:var(--black-350)}.coolbg{background-color:var(--black-350);color:hsl(0,0%,100%) !important}.mini-counts.warm,.warm{color:var(--orange-800)}.hot,.mini-counts.hot{color:var(--orange-600)}.hotbg{background-color:var(--orange-600);color:hsl(0,0%,100%) !important}.mini-counts.supernova,.supernova{color:var(--orange-400)}.supernovabg{background:var(--orange-400)}.answered,.answered .mini-counts,.answered strong{color:var(--green-500)}.answered strong{font-weight:normal;font-size:1.61538462rem}.answered-accepted{background-color:var(--green-400)}.answered-accepted,.answered-accepted .mini-counts,.answered-accepted .minicounts span{color:hsl(0,0%,100%)}body.theme-highcontrast .answered-accepted,body.theme-highcontrast .answered-accepted .mini-counts,body.theme-highcontrast .answered-accepted .minicounts span{color:var(--white)}.summary{float:left;width:630px}.summary h3{font-size:1.15384615rem;line-height:1.4;margin-bottom:.5em}.excerpt{padding:0;padding-bottom:5px;margin:0}.excerpt .started{float:right;width:185px;height:55px;margin-top:5px}.excerpt p{margin-bottom:3px}.excerpt .tags{width:410px;margin-top:5px}.tags{line-height:18px;float:left}.tags a:hover{text-decoration:none}.started{width:200px;float:right;line-height:18px}.started img{vertical-align:baseline}.started .user-action-time{margin-bottom:2px}.started .reputation-score,.started .user-info{color:var(--black-400)}.started .mod-flair,.started a:not(.started-link){font-size:12px;color:var(--theme-link-color)}.started .mod-flair:hover,.started a:not(.started-link):hover{color:var(--theme-link-color-hover)}.started-link{font-size:12px;color:var(--black-350)}.started-link:hover{color:var(--theme-link-color)}.mod-flair{color:var(--theme-link-color);margin-left:3px;font-weight:bold;font-size:1.15384615rem;line-height:1}.module{margin-bottom:1.5em}.module:not(.s-sidebarwidget) .spacer{margin-bottom:8px}.module:not(.s-sidebarwidget) ul{margin-left:15px;list-style-type:square;margin-right:30px;line-height:120%}.module:not(.s-sidebarwidget) li{margin-bottom:4px}.module:not(.s-sidebarwidget) h4{font-size:1.15384615rem;color:var(--black-700);font-weight:normal}.newuser{padding:15px 15px 10px;background-color:#FFF8DC;border:1px solid #E0DCBF;font-size:1.15384615rem}.vote{text-align:center}.vote span{display:block;color:var(--black-500)}.s-prose .post-tag{margin-bottom:0 !important}@media screen{.diffs .spoiler>*,.body-diffs .spoiler>*{opacity:.3}.diffs .spoiler>*:hover,.body-diffs .spoiler>*:hover{opacity:1}}.form-item{padding:10px 0 15px}.form-item label:not(.s-label){display:block;font-weight:bold;padding-bottom:3px}span.feed-icon{display:inline-block;text-decoration:none;vertical-align:middle;background-position:-79px -320px;width:24px;height:16px}span.form-error{color:#990000;font-weight:bold;margin-left:5px;font-size:90%}.post-editor{margin-top:10px;width:660px;box-sizing:border-box}.edit-block{display:none}.page-sizer,.pager{margin:20px 0}.page-sizer a,.pager a,.page-sizer a:hover,.pager a:hover{text-decoration:none}.leftcol{width:390px;padding-top:20px}.rightcol{padding-top:20px}.system-alert{padding:10px;font-weight:bold;margin-bottom:10px;margin-top:5px;border:1px dotted #AE0000}#popup-flag-post textarea{width:590px;max-width:100%}#start-bounty-popup{width:500px}#start-bounty-popup textarea{width:550px;max-width:100%}.edit-tags{padding:5px 0 0 15px}.close-reasons input{border:none;cursor:pointer}.close-reasons li{list-style-type:none}.close-reasons li td.close-desc{color:hsl(210,8%,45%);padding-top:2px;padding-bottom:8px;line-height:130%}.close-reasons tr td:last-child{cursor:pointer;padding-left:.5em}.close-reasons span.close-reason{font-weight:bold}.item-multiplier-count{font-size:11px;color:var(--black-500)}span.diff-delete{text-decoration:line-through;color:var(--red-700);background-color:var(--red-200)}img.diff-delete{border:2px solid var(--red-500);opacity:.5}span.diff-add{background:var(--green-100);color:var(--green-800)}img.diff-add{border:2px solid var(--green-500)}img.sponsor-tag-img{border:none;opacity:1;width:18px;height:16px;vertical-align:top;padding-right:4px;margin-top:-2px;box-sizing:content-box !important}.tagged-ignored{opacity:.35;background:transparent}.tagged-ignored-hidden{display:none !important}.tagged-interesting{background-color:var(--yellow-050)}@media (prefers-color-scheme:dark){body.theme-system .tagged-interesting{background-color:var(--black-025)}}body.theme-dark .tagged-interesting,.theme-dark__forced .tagged-interesting{background-color:var(--black-025)}.s-post-summary__watched{background-color:var(--yellow-050)}@media (prefers-color-scheme:dark){body.theme-system .s-post-summary__watched{background-color:var(--black-025)}}body.theme-dark .s-post-summary__watched,.theme-dark__forced .s-post-summary__watched{background-color:var(--black-025)}#interestingTag{font-size:12px;margin-right:5px}#ignoredTag{font-size:12px;margin-right:5px}.everyoneloves__top-leaderboard,.everyoneloves__mid-leaderboard,.everyoneloves__mid-second-leaderboard,.everyoneloves__bot-mid-leaderboard,.everyoneloves__tag-sponsorship{width:728px}.everyoneloves__inline-sidebar{display:none}.zone-container-responsive{display:none}.welovestackoverflow{padding:10px;line-height:1.3;overflow:hidden;margin-bottom:8px;border:2px solid var(--black-075)}.welovestackoverflow a{color:var(--theme-link-color)}.tagged{margin-top:5px}.related{line-height:1.3;font-size:12px}.related a{font-size:12px;font-weight:normal}.linked{line-height:1.3;font-size:12px}.linked a{font-size:12px;font-weight:normal}.cbt{clear:both}.space{padding-top:20px}.label-key{color:var(--black-350);font-size:1.15384615rem}.label-key b,.label-key strong{color:var(--black-700);font-weight:normal}.bottom-notice{margin-top:15px;padding-top:10px;font-weight:normal;padding:0 10px 0 0;line-height:1.4;font-size:1.30769231rem}#question-mini-list{overflow:auto;margin-bottom:30px}.tag-col{width:184px}.accept-reminder{clear:both;text-align:center;margin:0 0 8px;color:maroon}.pager-answers{padding-top:10px;overflow:hidden;clear:both}.ac_results{padding:0;border:1px solid var(--black-500);background-color:var(--white);overflow:hidden;z-index:10000;text-align:left}.ac_results ul{width:100%;list-style-position:outside;list-style:none;padding:0;margin:0}.ac_results li{margin:0;padding:2px 5px;cursor:default;display:block;line-height:16px;overflow:hidden}.ac_highlight{font-weight:bold;text-decoration:underline}.ac_loading{background:hsl(0,0%,100%) url(../../Img/progress-dots.gif?v=679ddd617b7d) right center no-repeat}.ac_over{color:hsl(0,0%,100%);background-color:var(--theme-primary-color)}@media print{*{position:relative}.site-footer,#header,#hlinks,#nav,#sidebar,#tabs,#feed-link,.bounty-link,.comments-link,.notify,.post-comments,.post-menu,.s-topbar,.tabs,div.vote,form,h2.bottom-notice,td.votecell{display:none}.container,body{font-size:10pt!important;overflow:visible!important;overflow-y:visible!important;height:auto}.container{width:710px}#answers,#content,#mainbar,#question-header,.container,.s-prose,.question{float:none !important;width:100%;overflow:visible!important}pre{max-height:none;display:block;width:600px;height:auto;overflow-x:auto;white-space:pre-wrap;word-wrap:break-word;clear:both}code,pre{font-size:9pt!important}#answers-header{clear:both;page-break-after:avoid}.comments{font-size:9pt;width:650px}#mainbar{margin:0}.s-prose{width:90%}#content{width:auto;height:100%;overflow:auto;overflow-x:auto;overflow-y:auto;border:none}.answer{width:700px;overflow-y:auto}}.comment-up-off,.comment-flag-off{color:var(--black-300);opacity:.4;cursor:pointer}.comment-up-off:hover,.comment-up-on{color:var(--theme-primary-color);cursor:pointer;opacity:1}.comment-flag-on,.comment-flag:hover,.flag-on{color:var(--red-500)}.delete-tag{width:14px;height:14px;vertical-align:middle;display:inline-block;background-position:-40px -319px;cursor:pointer;margin-left:3px;margin-top:-2px;margin-bottom:-1px}.delete-tag-active,.delete-tag:hover{background-position:-40px -340px}.badge-earned-check{width:20px;display:inline-block;background-position:-20px -322px;height:10px;position:relative;top:1px}.vote-accepted-bounty,.vote-accepted-off,.vote-accepted-on{display:block;margin:0 auto}.expander-arrow-hide{display:inline-block;width:20px;height:15px;background-position:0 -380px}.expander-arrow-show{display:inline-block;width:20px;height:15px;background-position:-20px -380px}.expander-arrow-small-hide{display:inline-block;width:8px;height:13px;background-position:0 -380px}.expander-arrow-small-show{display:inline-block;width:13px;height:8px;background-position:-20px -383px}.anonymous-gravatar{display:inline-block;width:32px;height:32px;background-position:0 -400px}.vcard{margin-top:10px}.mod-flag-indicator{color:hsl(0,0%,100%);display:inline;padding:.2em .5em .25em !important;margin-right:5px;font-size:11px;line-height:1;border-radius:2px}.tag-popup{width:390px;padding:12px}.tag-popup .-container{position:relative;background-color:var(--white);border:1px solid var(--black-200);border-radius:5px;padding:16px;font-size:13px;box-shadow:var(--bs-md)}.tag-popup .-arrow{position:absolute;display:none;left:50%}.tag-popup .-arrow:before{position:absolute;content:'';background:var(--white);border:1px solid var(--black-200);border-bottom:none;border-right:none;top:-6px;left:-6px;width:12px;height:12px}.tag-popup .-arrow.-top{display:block;transform:rotate(45deg);top:-1px}.tag-popup .-arrow.-bottom{display:block;transform:rotate(225deg);bottom:-1px}body.theme-dark .tag-popup .-container{background-color:var(--black-075);border-color:transparent;box-shadow:var(--bs-lg)}body.theme-dark .tag-popup .-arrow:before{background:var(--black-075);border-color:transparent}@media (prefers-color-scheme:dark){body.theme-system .tag-popup .-container{background-color:var(--black-075);border-color:transparent;box-shadow:var(--bs-lg)}body.theme-system .tag-popup .-arrow:before{background:var(--black-075);border-color:transparent}}#user-menu{border-radius:2px;border:1px solid var(--black-800);background-color:var(--black-600);color:var(--black-075);text-align:left;padding:10px;box-shadow:var(--bs-sm);font-family:var(--ff-sans);z-index:320;position:relative;width:300px;font-size:11px;line-height:1.2}#user-menu .um-gravatar{float:left;margin-right:.8em;margin-bottom:.75em}#user-menu .um-header-info .mod-flair,#user-menu .um-header-info .um-user-link{font-size:1.46153846rem;color:var(--black-075) !important}#user-menu .um-header-info .um-flair .badgecount,#user-menu .um-header-info .um-flair .reputation-score{color:var(--black-075)}#user-menu .um-about-me{clear:both;font-size:11px;margin:5px 0;overflow:hidden}#user-menu .um-links a{margin-right:8px;font-size:11px}#user-menu a,#user-menu a:visited{color:var(--powder-300);text-decoration:none}#user-menu a:hover{color:var(--powder-100)}.ask-mainbar,#mainbar.ask-mainbar{width:665px}.ask-mainbar #excerpt,#mainbar.ask-mainbar #excerpt{box-sizing:border-box}td.answercell{vertical-align:top}.nowrap{white-space:nowrap}code{white-space:pre-wrap;padding:1px 5px}pre code{white-space:inherit;padding:0}.user-timeline-deleted-action{display:block;color:hsl(210,8%,45%);font-size:11px}.expandable-question-summary{float:none}.expandable-question-summary:not(.is-expanded){position:relative}.expandable-question-summary:not(.is-expanded) .expandable-question-summary__body{height:100px;overflow:hidden;position:relative}.expandable-question-summary:not(.is-expanded) .expandable-question-summary__body:after{content:"";display:block;position:absolute;height:50%;left:0px;bottom:0px;right:0px;background:-webkit-linear-gradient(hsla(0,0%,100%,0), hsl(0,0%,100%)) left repeat;background:linear-gradient(hsla(0,0%,100%,0), hsl(0,0%,100%)) left repeat}.tag-sponsorship{height:135px;overflow:hidden;width:100%;padding-bottom:5px}.disabled-link{color:hsl(210,8%,55%);opacity:.6;padding:0 3px 2px}.disabled-button{opacity:.6;cursor:default !important}.show-votes .sidebar-linked .spacer,.show-votes .sidebar-related .spacer{margin-bottom:12px;display:flex}.show-votes .sidebar-linked .spacer>a:first-child,.show-votes .sidebar-related .spacer>a:first-child{padding-right:10px}.show-votes .sidebar-linked .spacer>a:first-child .answer-votes,.show-votes .sidebar-related .spacer>a:first-child .answer-votes{padding:3px 0;white-space:nowrap;width:38px;text-align:center;box-sizing:border-box;height:auto;float:none;border-radius:2px;font-size:90%;background-color:var(--black-050);color:var(--black-700);transform:translateY(-1px)}.show-votes .sidebar-linked .spacer>a:first-child .answer-votes.answered-accepted,.show-votes .sidebar-related .spacer>a:first-child .answer-votes.answered-accepted{color:hsl(0,0%,100%);background-color:var(--green-400)}body.theme-highcontrast .show-votes .sidebar-linked .spacer>a:first-child .answer-votes.answered-accepted,body.theme-highcontrast .show-votes .sidebar-related .spacer>a:first-child .answer-votes.answered-accepted{color:var(--white)}.show-votes .sidebar-linked .spacer>a:first-child .answer-votes.extra-large,.show-votes .sidebar-related .spacer>a:first-child .answer-votes.extra-large,.show-votes .sidebar-linked .spacer>a:first-child .answer-votes.large,.show-votes .sidebar-related .spacer>a:first-child .answer-votes.large{padding:3px 0;min-width:16px}.show-votes .sidebar-linked .spacer>a.question-hyperlink,.show-votes .sidebar-related .spacer>a.question-hyperlink{display:inline-block;padding-top:2px;width:calc(100% - 48px);margin-bottom:0}.comments .deleted-comment,.comments .deleted-comment:hover{background-color:var(--red-050)}.comments .deleted-comment .deleted-comment-info{color:#B65454;display:block;text-align:right}.comments .deleted-comment .deleted-comment-info a{text-decoration:none;border-bottom:0}.highlighted-post{animation:highlighted-post-fade 3s;animation-timing-function:ease-out}@keyframes highlighted-post-fade{0%{background-color:var(--yellow-100)}100%{background-color:rgba(0,0,0,0)}}.deleted-answer{margin-left:-24px;padding-left:24px;margin-top:-1px;width:auto !important;background-color:var(--red-050);border-top:1px solid var(--red-100)}.deleted-answer pre,.deleted-answer pre code{background-color:inherit}.deleted-answer .hidden-deleted-answer a,.deleted-answer .hidden-deleted-question a{font-weight:bold;text-decoration:underline}.deleted-answer .comments .comment:hover{background-color:var(--red-050)}.deleted-answer .comments .deleted-comment,.deleted-answer .comments .deleted-comment:hover{background-color:var(--red-050)}.deleted-answer .comments .deleted-comment .undelete-comment,.deleted-answer .comments .deleted-comment:hover .undelete-comment{display:none}.deleted-answer-info{color:#B65454;margin-top:10px;margin-left:3px}.comment-date,.comment-date>a,.comment-date>a:hover{border-bottom:none;color:var(--black-350)}.existing-flag-count:before{content:'('}.existing-flag-count:after{content:')'}.popup-submit{float:right}.popup-cancel{float:left}.popup-close{float:right}.popup-close a{padding:3px 6px 2px;font-size:1.30769231rem;font-weight:normal;color:hsl(0,0%,100%) !important;background-color:hsl(210,8%,5%);font-family:Arial,Helvetica,sans-serif;line-height:1}.popup-close a:hover{text-decoration:none}#popup-close-question{width:800px}#popup-close-question #close-question-form{overflow:hidden}#popup-close-question #close-question-form.close-question-voted label span{cursor:default !important}#popup-close-question #close-question-form.close-question-voted input[type=submit]{visibility:hidden}#popup-close-question .action-list>li{width:auto}#popup-close-question .popup-pane,#popup-close-question .popup-subpane{min-height:430px}#popup-close-question .bounty-indicator-tab{margin-left:3px}#popup-close-question .popup-actions{text-align:right;margin-bottom:2px}#popup-close-question .popup-actions .last-flag-details{display:inline-block;line-height:17px;text-align:left}#popup-close-question .popup-actions .popup-submit{float:none}.close-as-duplicate-pane .search-prompt{font-weight:bold}.close-as-duplicate-pane .search-errors{color:var(--red-800);text-align:left;font-weight:bold;font-size:13px;height:13px;margin:4px 0}.close-as-duplicate-pane .original-display{margin:13px 0}.close-as-duplicate-pane .original-display .navi-container{font-weight:bold;color:var(--black-750);margin-bottom:7px}.close-as-duplicate-pane .original-display .navi-container .navi{display:inline-block;margin-right:5px}.close-as-duplicate-pane .original-display .preview{height:310px;overflow-y:auto;border:1px solid var(--black-300);padding:7px 0}.close-as-duplicate-pane .original-display .preview .show-original .show-title{font-size:1.30769231rem;margin:3px 0 10px}.close-as-duplicate-pane .original-display .preview .show-original .answer-count{font-size:1.15384615rem;font-weight:bold;border-bottom:1px solid var(--black-300);padding:5px;margin:0 3px 0 5px}.close-as-duplicate-pane .original-display .preview .show-original .answer{border-bottom-color:var(--black-150)}.close-as-duplicate-pane .original-display .list-originals{height:310px;overflow-y:auto;border:1px solid var(--black-300);padding:7px 0}.close-as-duplicate-pane .original-display .list-originals .list{padding:0 8px}.close-as-duplicate-pane .original-display .list-originals .list .item{float:left;padding:9px 5px 9px 0;border-bottom:1px solid var(--black-100);cursor:pointer}.close-as-duplicate-pane .original-display .list-originals .list .item:last-child{border-bottom:0}.close-as-duplicate-pane .original-display .list-originals .list .item .stats{float:left;margin:0 10px 0 0;padding:4px 7px 6px;width:58px}.close-as-duplicate-pane .original-display .list-originals .list .item .summary{width:605px;float:left}.close-as-duplicate-pane .original-display .list-originals .list .item .post-link{font-weight:bold;font-size:1.15384615rem;margin-bottom:5px}.close-as-duplicate-pane .original-display .list-originals .list .item .post-link a:hover{text-decoration:none !important;border-bottom:0}.close-as-duplicate-pane .original-display .list-originals .list .item .bounty-indicator-tab{margin-left:3px}.close-as-duplicate-pane .original-display .list-originals .list .item .post-type-abbr{font-weight:bold}.close-as-duplicate-pane .original-display .list-originals .list .item .votes-and-usages{color:var(--black-350)}.close-as-duplicate-pane .original-display .list-originals .list .item .body-summary{line-height:15px;color:var(--black-750)}.close-as-duplicate-pane .original-display .list-originals .list .item.hover{background-color:var(--black-075)}.migration-pane .migration-targets td{vertical-align:middle}.migration-pane .migration-targets .target-icon{min-width:58px;min-height:58px}.migration-pane .migration-targets .target-icon img{width:58px;height:58px}.popup-tab-content{clear:both}.action-list:not(.popup-condensed){margin-left:5px !important;margin-right:5px;margin-bottom:10px !important}.action-list:not(.popup-condensed)>li{width:650px;max-width:100%}.action-list:not(.popup-condensed) li{list-style-type:none;padding:6px}.action-list:not(.popup-condensed) li>label{display:block;margin:5px 0}.popup._hidden-descriptions .action-list:not(.popup-condensed) li>label{margin:0}.action-list:not(.popup-condensed) input[type=radio]{margin-right:1px;margin-top:1px}.action-list:not(.popup-condensed) .action-desc,.action-list:not(.popup-condensed) .action-name{cursor:pointer;margin-left:5px}.action-list:not(.popup-condensed) .action-disabled-reason-muted{color:var(--black-500);margin-left:18px}.action-list:not(.popup-condensed) .action-name{font-weight:bold;font-size:105%;vertical-align:top}.action-list:not(.popup-condensed) .action-desc{display:block;color:var(--black-500);line-height:115%;padding:0 0 0 18px;margin-top:-17px}.action-list:not(.popup-condensed) .action-desc p:last-child{margin-bottom:0}.action-list:not(.popup-condensed) .action-subform p:last-child{margin-bottom:1em}.action-list:not(.popup-condensed) .action-name~.action-desc{padding-top:23px}.action-list:not(.popup-condensed) .action-disabled span{color:var(--black-350);font-weight:normal;cursor:default !important}.action-list:not(.popup-condensed) .action-selected{background-color:var(--black-075)}.action-list:not(.popup-condensed) .action-subform{display:none;margin:15px auto;width:535px;max-width:100%}.action-list:not(.popup-condensed) .action-subform .wide{width:400px}.action-list:not(.popup-condensed) h4{margin-bottom:5px}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav)  .responsively-horizontally-centered-legacy-popup{width:800px;max-width:90vw !important;left:0 !important;right:0 !important;margin:0 auto}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav  .responsively-horizontally-centered-legacy-popup{width:800px;max-width:90vw !important;left:0 !important;right:0 !important;margin:0 auto}}@media print{.responsively-horizontally-centered-legacy-popup{width:800px;max-width:90vw !important;left:0 !important;right:0 !important;margin:0 auto}}#tags-table .answer-votes{margin-right:5px;width:25px;margin-top:2px;display:inline-block;float:none}#tags-browser{width:100%}#overlay-header{opacity:0;display:none;background:var(--black-050);font-size:1.30769231rem;font-weight:normal;text-align:center;left:0;padding:.5em 10%;position:fixed;top:0;width:100%;z-index:5052;box-shadow:var(--bs-sm)}#overlay-header .close-overlay{color:var(--black-350);cursor:pointer;font-size:12px;font-weight:normal}.mod-post-actions{padding:2px;line-height:20px}.bounty-indicator-tab.flagbg{background-color:red !important}.answer-votes{cursor:pointer}.answer-votes.large{font-size:90%;padding-top:4px;padding-bottom:2px}.answer-votes.extra-large{font-size:90%;padding-top:4px;padding-bottom:2px;min-width:32px}.quality-score{font-size:80%;margin-right:10px}.revision-comment.blur{color:hsl(210,8%,60%)}.revision-comment{line-height:20px}.full-diff{table-layout:fixed;width:100%}.full-diff .content{font-family:ui-monospace,"Cascadia Mono","Segoe UI Mono","Liberation Mono",Menlo,Monaco,Consolas,monospace;font-size:12px}.full-diff td{vertical-align:top;margin-right:5px;border-left:4px solid var(--white);border-right:4px solid var(--white)}.full-diff td.content{width:50%;max-width:50%;word-wrap:break-word;white-space:pre-wrap;color:var(--black-350)}.full-diff .deleted>div{background-color:var(--red-050)}.full-diff .inserted>div{background-color:var(--green-025)}.full-diff td.content.deleted,.full-diff td.content.inserted{background-color:transparent;color:inherit}.full-diff .skip{text-align:center;padding:10px;background-color:var(--black-050);color:var(--black-300);border-top:4px solid var(--white);border-bottom:4px solid var(--white)}.suggested-edit{width:960px}.suggested-edit .summary{width:910px}.suggested-edit .score{display:block;background:hsl(210,8%,95%);padding:8px 8px 6px;color:hsl(210,8%,35%);font-size:120%;font-weight:bold;margin-bottom:30px;text-decoration:none;text-align:center;width:15px}.suggested-edit .revision{display:block;margin-bottom:8px}.suggested-edit .revision-comment{padding-right:8px}.suggested-edit .body-diffs{margin-top:18px}.suggested-edit .body-diffs td{vertical-align:top}.suggested-edit .body-diffs table{table-layout:fixed;width:900px}.suggested-edit .body-diffs .full-diff{width:900px}.suggested-edit .body-diffs .full-diff td.content{width:435px;max-width:435px}.suggested-edit .body-diffs .full-html-diff .s-prose{width:435px;max-width:435px}.suggested-edit .body-diffs .full-html-diff .s-prose img{max-width:430px}.suggested-edit .body-diffs .full-html-diff .gutter{width:30px;max-width:30px}.suggested-edit .body-diffs .full-html-diff th{color:var(--black-350);padding:6px 0 4px}.suggested-edit .user-info-actions{width:900px}.suggested-edit .user-info-actions .started{float:none !important}.suggested-edit .user-info-actions .current-owner{width:445px}.suggested-edit .user-info-actions .gutter{width:7px}.suggested-edit .user-info-actions .actions{text-align:right}.suggested-edit .user-info-actions .form-error{padding:15px 0 5px;display:none}.lightbox{display:none;background:hsl(210,8%,5%);opacity:.7;filter:alpha(opacity=70);position:absolute;top:0;left:0;min-width:100%;z-index:8950}.lightbox-panel{display:none;z-index:1001;border:0 !important}.comment-help code{background-color:var(--powder-300) !important}div.form-field-error.form-error{font-size:12px;display:block;margin-top:-15px}#hot-network-questions h4 a{font-weight:inherit;font-size:inherit;width:inherit}#hot-network-questions ul{margin:0}#hot-network-questions li{list-style-type:none;white-space:nowrap;margin-bottom:10px;margin-left:0}#hot-network-questions .favicon,#hot-network-questions a,#hot-network-questions img{display:inline-block;vertical-align:top}#hot-network-questions .favicon,#hot-network-questions img{margin:2px 6px 0 0}#hot-network-questions a{font-weight:normal;font-size:12px;white-space:normal;width:90%}#hot-network-questions .show-more{margin-left:22px}.questions-page .show-more,.tagged-questions-page .show-more,.tags-page .show-more{display:block;margin:5px 0}.more-arrow{display:block;margin-top:5px}.tag-editor{cursor:text;background-color:var(--white);position:relative;overflow:hidden;white-space:normal;height:auto !important;min-height:37px !important;padding-top:2px !important;padding-bottom:2px !important}.tag-editor .rendered-element{margin:2px;font-size:12px}.tag-editor input{border:none !important;box-shadow:none !important;outline:0 !important;padding:0 !important;margin:0 3px;background-color:transparent !important;height:25px}.tag-editor input[type="text"]{margin:0;height:29px;box-sizing:content-box}.tag-editor input[type="text"]:not([placeholder=""]){min-width:100%}.tag-editor:not(.s-input){border:1px solid var(--black-150)}.tag-editor:not(.s-input) span:not(:empty)+input{padding-left:4px !important}.tag-editor:not(.s-input) input[type="text"]:not([placeholder=""]){font-size:13px}.tag-editor.s-input{padding-left:2px !important}.tag-editor.s-input input{padding-left:calc(.7em - 2px) !important}.tag-editor.s-input span:not(:empty)+input{padding-left:4px !important}#tagnames{width:100%}.tag-suggestions{background-color:var(--white);border:1px solid var(--black-150);padding:4px;z-index:300;border-radius:5px;box-shadow:var(--bs-md);display:flex;flex-wrap:wrap}.tag-suggestions>div{padding:8px;width:200px;overflow:hidden;position:relative;border-radius:3px;cursor:pointer}.tag-suggestions>div:focus{background-color:var(--black-075)}.tag-suggestions>div:focus .more-info{background-color:var(--black-075)}.tag-suggestions>div:hover{background-color:var(--black-050)}.tag-suggestions>div:hover .more-info{background-color:var(--black-050)}.tag-suggestions>div p{font-size:11px;line-height:1.15384615}.tag-suggestions>div p.more-info{visibility:hidden;position:absolute;margin-bottom:0;right:5px;top:7px;padding:3px}.tag-suggestions>div p.more-info a{text-indent:-9999em;width:16px;height:16px;border:1px solid hsl(210,8%,55%);box-sizing:border-box;border-radius:50%;display:inline-block;position:relative;transition:none}.tag-suggestions>div p.more-info a:after,.tag-suggestions>div p.more-info a:before{content:'';width:2px;height:2px;position:absolute;left:6px;top:3px;display:inline-block;background-color:hsl(210,8%,55%)}.tag-suggestions>div p.more-info a:after{top:6px;height:5px}.tag-suggestions>div p.more-info a:hover{border-color:var(--theme-link-color)}.tag-suggestions>div p.more-info a:hover:after,.tag-suggestions>div p.more-info a:hover:before{background-color:var(--theme-link-color)}.tag-suggestions>div:focus p.more-info,.tag-suggestions>div:hover p.more-info{visibility:visible}.tag-suggestions .match{font-weight:bold;text-decoration:underline}.search-prompt{padding-right:3px}.tools-rev-dim-link{color:hsl(210,8%,65%) !important}.tools-rev h1 .lsep{color:hsl(210,8%,85%);visibility:visible;font-size:100%;margin-left:5px;margin-right:5px}.diff-skipped>div{border-bottom:2px dotted #d0d0d0}.diff-skipped{padding:4px 0 8px;cursor:pointer}a.bounty-link{padding:0 3px 2px}.comment-form form{position:relative}#tabcomplete{position:absolute;top:-17px;margin-left:5px}#tabcomplete li{display:inline;background-color:hsl(0,0%,100%);color:hsl(210,8%,5%);padding:2px;margin-right:5px;border:1px solid hsl(210,8%,55%);cursor:pointer}#tabcomplete li.chosen{font-weight:bold}.comments{-webkit-tap-highlight-color:hsla(0,0%,100%,0)}span.highlight{background-color:#FFFF77}textarea{resize:none}.new-post-activity,.new-answer-activity{background-color:var(--black-050)}.post-section-title{font-weight:bold;font-size:120%}.similar-questions{height:200px}.title-search-float{border:1px solid hsl(210,8%,5%);z-index:99;background:hsl(0,0%,100%)}.title-search-container{max-height:150px;overflow-y:scroll;overflow-x:hidden}.title-float-selected{background-color:#00FFFF;height:24px}.title-loading{background-image:url("../../Img/progress-dots.gif?v=679ddd617b7d");background-repeat:no-repeat;background-position:center right}#show-editor-button{margin-bottom:8px}.ask-page .privacy-policy-agreement,.question-page .privacy-policy-agreement{margin-top:15px}.newsletter-popup .privacy-policy-agreement{margin-top:15px;font-size:90%}.privacy-policy-agreement{font-style:italic}body.read-only .login-link{opacity:.3}body.read-only #question-header .btn,body.read-only #questions-count .btn,body.read-only .askquestion{opacity:.3}body.read-only .bookmark-off,body.read-only .vote-down-off,body.read-only .vote-up-off{opacity:.3;cursor:not-allowed}.review-post-author-guidance{background:var(--black-050);border:var(--black-075);padding:10px}.review-post-author-guidance p:last-child{margin-bottom:0}.facebook-login,.facebook-login:hover{color:hsl(0,0%,100%);background-color:#395697}.auth-shadow{box-shadow:0 10px 25px rgba(0,0,0,0.05),0 20px 48px rgba(0,0,0,0.05),0 1px 4px rgba(0,0,0,0.1)}.module{word-wrap:break-word}.module p.took-ms{font-size:.9em}.module p.side-desc{margin-bottom:.1em}#tag-suggestions{min-height:30px;margin-bottom:10px}#tag-suggestions .post-tag{margin-right:6px}#tag-suggestions span.post-tag{opacity:.5}.general-error{color:#c04848;font-weight:bold;margin-bottom:10px}.general-success{color:#44B449;font-weight:bold;margin-bottom:10px}.validation-error{border-color:#C04848 !important}.val-message{margin:24px auto;padding:32px;width:100%;max-width:640px;border:1px solid transparent;color:hsl(210,8%,15%);text-align:center}.val-message p{margin-bottom:.5em;padding-left:12px;padding-right:12px;font-size:1.15384615rem;line-height:1.30769231}.val-message p:last-of-type{margin-bottom:0}.val-message .val--title{margin-bottom:.57em;font-size:1.46153846rem;line-height:1.30769231}.val-message .val--icon{width:36px;height:36px;color:var(--green-500)}.val-textemphasis{font-weight:700;margin-top:12px}.val-success{background-color:hsl(140,42%,95%);border-color:hsl(140,40%,65%)}.val-success .val--title{color:var(--green-500)}.val-error{background-color:hsl(358,75%,97%);border-color:hsl(358,68%,59%)}.val-info{background-color:hsl(47,87%,94%);border-color:hsl(47,73%,50%)}.message.message-error{z-index:3000;display:none;color:var(--red-050);background-color:var(--red-600);text-align:left;width:auto;font-family:var(--theme-body-font-family);font-size:13px;line-height:1.30769231}.message.message-error.message-dismissable{cursor:pointer}.message.message-error a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn){color:var(--white);text-decoration:underline}.message.message-error ul{margin:0 0 0 15px;padding:0}.message.message-error ul li{margin:0 0 5px;padding:0}.message.message-error ul li:last-child{margin-bottom:0}.message.message-error code{background:transparent}.message.message-error .message-inner{position:relative}.message.message-error .message-tip:before{content:"";position:absolute;border-width:9px;border-style:solid;border-color:transparent}.message.message-error .message-tip-top-center:before{top:-9px;left:50%;border-top-width:0;border-bottom-color:var(--red-600)}.message.message-error .message-tip-left-top:before{top:0;left:-9px;border-bottom-width:0;border-right-width:0;border-top-color:var(--red-600)}.message.message-error .message-tip-top-left:before{top:-9px;left:0;border-bottom-width:0;border-right-width:0;border-left-color:var(--red-600)}.message.message-error .message-tip-left-bottom:before{bottom:0;left:-9px;border-bottom-width:0;border-left-width:0;border-right-color:var(--red-600)}.message.message-error .message-tip-bottom-left:before{top:100%;left:0;border-bottom-width:0;border-left-width:0;border-top-color:var(--red-600)}.message.message-error .message-tip-right-top:before{top:0;left:100%;border-bottom-width:0;border-left-width:0;border-top-color:var(--red-600)}.message.message-error .message-tip-top-right:before{top:-9px;right:0;border-bottom-width:0;border-left-width:0;border-right-color:var(--red-600)}.message.message-error .message-tip-right-bottom:before{bottom:0;left:100%;border-bottom-width:0;border-right-width:0;border-left-color:var(--red-600)}.message.message-error .message-tip-bottom-right:before{top:100%;right:0;border-bottom-width:0;border-right-width:0;border-top-color:var(--red-600)}.message.message-error .message-tip-bottom-center:before{top:100%;left:50%;border-bottom-width:0;border-top-color:var(--red-600)}.message.message-error .message-text{padding:12px}.message.message-error .message-close{box-sizing:border-box;float:right;margin-top:8px;margin-right:8px;width:24px;height:24px;background-color:transparent;text-align:center;font-family:var(--ff-sans);font-size:1.30769231rem;line-height:24px;font-weight:700;color:var(--white) !important;transition:all 600ms cubic-bezier(.165, .84, .44, 1)}.message.message-error .message-close:hover{background-color:var(--white);border-color:var(--white);color:var(--red-600) !important}.message.message-error .popup-title-award{text-overflow:ellipsis;overflow:hidden;display:block}.message.message-info{z-index:3000;display:none;color:var(--blue-050);background-color:var(--blue-600);text-align:left;width:auto;font-family:var(--theme-body-font-family);font-size:13px;line-height:1.30769231}.message.message-info.message-dismissable{cursor:pointer}.message.message-info a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn){color:var(--white);text-decoration:underline}.message.message-info ul{margin:0 0 0 15px;padding:0}.message.message-info ul li{margin:0 0 5px;padding:0}.message.message-info ul li:last-child{margin-bottom:0}.message.message-info code{background:transparent}.message.message-info .message-inner{position:relative}.message.message-info .message-tip:before{content:"";position:absolute;border-width:9px;border-style:solid;border-color:transparent}.message.message-info .message-tip-top-center:before{top:-9px;left:50%;border-top-width:0;border-bottom-color:var(--blue-600)}.message.message-info .message-tip-left-top:before{top:0;left:-9px;border-bottom-width:0;border-right-width:0;border-top-color:var(--blue-600)}.message.message-info .message-tip-top-left:before{top:-9px;left:0;border-bottom-width:0;border-right-width:0;border-left-color:var(--blue-600)}.message.message-info .message-tip-left-bottom:before{bottom:0;left:-9px;border-bottom-width:0;border-left-width:0;border-right-color:var(--blue-600)}.message.message-info .message-tip-bottom-left:before{top:100%;left:0;border-bottom-width:0;border-left-width:0;border-top-color:var(--blue-600)}.message.message-info .message-tip-right-top:before{top:0;left:100%;border-bottom-width:0;border-left-width:0;border-top-color:var(--blue-600)}.message.message-info .message-tip-top-right:before{top:-9px;right:0;border-bottom-width:0;border-left-width:0;border-right-color:var(--blue-600)}.message.message-info .message-tip-right-bottom:before{bottom:0;left:100%;border-bottom-width:0;border-right-width:0;border-left-color:var(--blue-600)}.message.message-info .message-tip-bottom-right:before{top:100%;right:0;border-bottom-width:0;border-right-width:0;border-top-color:var(--blue-600)}.message.message-info .message-tip-bottom-center:before{top:100%;left:50%;border-bottom-width:0;border-top-color:var(--blue-600)}.message.message-info .message-text{padding:12px}.message.message-info .message-close{box-sizing:border-box;float:right;margin-top:8px;margin-right:8px;width:24px;height:24px;background-color:transparent;text-align:center;font-family:var(--ff-sans);font-size:1.30769231rem;line-height:24px;font-weight:700;color:var(--white) !important;transition:all 600ms cubic-bezier(.165, .84, .44, 1)}.message.message-info .message-close:hover{background-color:var(--white);border-color:var(--white);color:var(--blue-600) !important}.message.message-info .popup-title-award{text-overflow:ellipsis;overflow:hidden;display:block}.message.message-warning{z-index:3000;display:none;color:var(--yellow-900);background-color:var(--yellow-300);text-align:left;width:auto;font-family:var(--theme-body-font-family);font-size:13px;line-height:1.30769231}.message.message-warning.message-dismissable{cursor:pointer}.message.message-warning a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn){color:var(--blue-600);text-decoration:underline}.message.message-warning ul{margin:0 0 0 15px;padding:0}.message.message-warning ul li{margin:0 0 5px;padding:0}.message.message-warning ul li:last-child{margin-bottom:0}.message.message-warning code{background:transparent}.message.message-warning .message-inner{position:relative}.message.message-warning .message-tip:before{content:"";position:absolute;border-width:9px;border-style:solid;border-color:transparent}.message.message-warning .message-tip-top-center:before{top:-9px;left:50%;border-top-width:0;border-bottom-color:var(--yellow-300)}.message.message-warning .message-tip-left-top:before{top:0;left:-9px;border-bottom-width:0;border-right-width:0;border-top-color:var(--yellow-300)}.message.message-warning .message-tip-top-left:before{top:-9px;left:0;border-bottom-width:0;border-right-width:0;border-left-color:var(--yellow-300)}.message.message-warning .message-tip-left-bottom:before{bottom:0;left:-9px;border-bottom-width:0;border-left-width:0;border-right-color:var(--yellow-300)}.message.message-warning .message-tip-bottom-left:before{top:100%;left:0;border-bottom-width:0;border-left-width:0;border-top-color:var(--yellow-300)}.message.message-warning .message-tip-right-top:before{top:0;left:100%;border-bottom-width:0;border-left-width:0;border-top-color:var(--yellow-300)}.message.message-warning .message-tip-top-right:before{top:-9px;right:0;border-bottom-width:0;border-left-width:0;border-right-color:var(--yellow-300)}.message.message-warning .message-tip-right-bottom:before{bottom:0;left:100%;border-bottom-width:0;border-right-width:0;border-left-color:var(--yellow-300)}.message.message-warning .message-tip-bottom-right:before{top:100%;right:0;border-bottom-width:0;border-right-width:0;border-top-color:var(--yellow-300)}.message.message-warning .message-tip-bottom-center:before{top:100%;left:50%;border-bottom-width:0;border-top-color:var(--yellow-300)}.message.message-warning .message-text{padding:12px}.message.message-warning .message-close{box-sizing:border-box;float:right;margin-top:8px;margin-right:8px;width:24px;height:24px;background-color:transparent;text-align:center;font-family:var(--ff-sans);font-size:1.30769231rem;line-height:24px;font-weight:700;color:var(--blue-600) !important;transition:all 600ms cubic-bezier(.165, .84, .44, 1)}.message.message-warning .message-close:hover{background-color:var(--blue-600);border-color:var(--blue-600);color:var(--yellow-300) !important}.message.message-warning .popup-title-award{text-overflow:ellipsis;overflow:hidden;display:block}.message.message-config,.message.message-info.contributor-dropdown{z-index:3000;display:none;color:var(--black-600);background-color:var(--white);text-align:left;width:auto;font-family:var(--theme-body-font-family);font-size:13px;line-height:1.30769231}.message.message-config.message-dismissable,.message.message-info.contributor-dropdown.message-dismissable{cursor:pointer}.message.message-config a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn),.message.message-info.contributor-dropdown a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn){color:var(--black-800);text-decoration:underline}.message.message-config ul,.message.message-info.contributor-dropdown ul{margin:0 0 0 15px;padding:0}.message.message-config ul li,.message.message-info.contributor-dropdown ul li{margin:0 0 5px;padding:0}.message.message-config ul li:last-child,.message.message-info.contributor-dropdown ul li:last-child{margin-bottom:0}.message.message-config code,.message.message-info.contributor-dropdown code{background:transparent}.message.message-config .message-inner,.message.message-info.contributor-dropdown .message-inner{position:relative}.message.message-config .message-tip:before,.message.message-info.contributor-dropdown .message-tip:before{content:"";position:absolute;border-width:9px;border-style:solid;border-color:transparent}.message.message-config .message-tip-top-center:before,.message.message-info.contributor-dropdown .message-tip-top-center:before{top:-9px;left:50%;border-top-width:0;border-bottom-color:var(--white)}.message.message-config .message-tip-left-top:before,.message.message-info.contributor-dropdown .message-tip-left-top:before{top:0;left:-9px;border-bottom-width:0;border-right-width:0;border-top-color:var(--white)}.message.message-config .message-tip-top-left:before,.message.message-info.contributor-dropdown .message-tip-top-left:before{top:-9px;left:0;border-bottom-width:0;border-right-width:0;border-left-color:var(--white)}.message.message-config .message-tip-left-bottom:before,.message.message-info.contributor-dropdown .message-tip-left-bottom:before{bottom:0;left:-9px;border-bottom-width:0;border-left-width:0;border-right-color:var(--white)}.message.message-config .message-tip-bottom-left:before,.message.message-info.contributor-dropdown .message-tip-bottom-left:before{top:100%;left:0;border-bottom-width:0;border-left-width:0;border-top-color:var(--white)}.message.message-config .message-tip-right-top:before,.message.message-info.contributor-dropdown .message-tip-right-top:before{top:0;left:100%;border-bottom-width:0;border-left-width:0;border-top-color:var(--white)}.message.message-config .message-tip-top-right:before,.message.message-info.contributor-dropdown .message-tip-top-right:before{top:-9px;right:0;border-bottom-width:0;border-left-width:0;border-right-color:var(--white)}.message.message-config .message-tip-right-bottom:before,.message.message-info.contributor-dropdown .message-tip-right-bottom:before{bottom:0;left:100%;border-bottom-width:0;border-right-width:0;border-left-color:var(--white)}.message.message-config .message-tip-bottom-right:before,.message.message-info.contributor-dropdown .message-tip-bottom-right:before{top:100%;right:0;border-bottom-width:0;border-right-width:0;border-top-color:var(--white)}.message.message-config .message-tip-bottom-center:before,.message.message-info.contributor-dropdown .message-tip-bottom-center:before{top:100%;left:50%;border-bottom-width:0;border-top-color:var(--white)}.message.message-config .message-text,.message.message-info.contributor-dropdown .message-text{padding:12px}.message.message-config .message-close,.message.message-info.contributor-dropdown .message-close{box-sizing:border-box;float:right;margin-top:8px;margin-right:8px;width:24px;height:24px;background-color:transparent;text-align:center;font-family:var(--ff-sans);font-size:1.30769231rem;line-height:24px;font-weight:700;color:var(--black-800) !important;transition:all 600ms cubic-bezier(.165, .84, .44, 1)}.message.message-config .message-close:hover,.message.message-info.contributor-dropdown .message-close:hover{background-color:var(--black-800);border-color:var(--black-800);color:var(--white) !important}.message.message-config .popup-title-award,.message.message-info.contributor-dropdown .popup-title-award{text-overflow:ellipsis;overflow:hidden;display:block}.message.message-config .message-close,.message.message-info.contributor-dropdown .message-close{margin-top:2px;margin-right:2px}.message.message-success{z-index:3000;display:none;color:var(--green-025);background-color:var(--green-500);text-align:left;width:auto;font-family:var(--theme-body-font-family);font-size:13px;line-height:1.30769231}.message.message-success.message-dismissable{cursor:pointer}.message.message-success a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn){color:var(--white);text-decoration:underline}.message.message-success ul{margin:0 0 0 15px;padding:0}.message.message-success ul li{margin:0 0 5px;padding:0}.message.message-success ul li:last-child{margin-bottom:0}.message.message-success code{background:transparent}.message.message-success .message-inner{position:relative}.message.message-success .message-tip:before{content:"";position:absolute;border-width:9px;border-style:solid;border-color:transparent}.message.message-success .message-tip-top-center:before{top:-9px;left:50%;border-top-width:0;border-bottom-color:var(--green-500)}.message.message-success .message-tip-left-top:before{top:0;left:-9px;border-bottom-width:0;border-right-width:0;border-top-color:var(--green-500)}.message.message-success .message-tip-top-left:before{top:-9px;left:0;border-bottom-width:0;border-right-width:0;border-left-color:var(--green-500)}.message.message-success .message-tip-left-bottom:before{bottom:0;left:-9px;border-bottom-width:0;border-left-width:0;border-right-color:var(--green-500)}.message.message-success .message-tip-bottom-left:before{top:100%;left:0;border-bottom-width:0;border-left-width:0;border-top-color:var(--green-500)}.message.message-success .message-tip-right-top:before{top:0;left:100%;border-bottom-width:0;border-left-width:0;border-top-color:var(--green-500)}.message.message-success .message-tip-top-right:before{top:-9px;right:0;border-bottom-width:0;border-left-width:0;border-right-color:var(--green-500)}.message.message-success .message-tip-right-bottom:before{bottom:0;left:100%;border-bottom-width:0;border-right-width:0;border-left-color:var(--green-500)}.message.message-success .message-tip-bottom-right:before{top:100%;right:0;border-bottom-width:0;border-right-width:0;border-top-color:var(--green-500)}.message.message-success .message-tip-bottom-center:before{top:100%;left:50%;border-bottom-width:0;border-top-color:var(--green-500)}.message.message-success .message-text{padding:12px}.message.message-success .message-close{box-sizing:border-box;float:right;margin-top:8px;margin-right:8px;width:24px;height:24px;background-color:transparent;text-align:center;font-family:var(--ff-sans);font-size:1.30769231rem;line-height:24px;font-weight:700;color:var(--white) !important;transition:all 600ms cubic-bezier(.165, .84, .44, 1)}.message.message-success .message-close:hover{background-color:var(--white);border-color:var(--white);color:var(--green-500) !important}.message.message-success .popup-title-award{text-overflow:ellipsis;overflow:hidden;display:block}.message.toast{position:fixed;top:20px;right:30px;z-index:5051}#newsletter-ad ul{margin:1em 0 1em 1.5em}#newsletter-ad ul li{margin-bottom:5px}#newsletter-email-input{width:200px}#custom-header{display:none}.privilege-icon{display:inline-block;width:20px;height:16px;background-image:url('../../Img/share-sprite-new.png?v=e1b8bd67bc12');background-image:url('../../Img/share-sprite-new.svg?v=0e11bfd41fbc'),none;background-repeat:no-repeat;background-color:transparent;overflow:hidden;text-indent:-999em;outline:none;background-position-x:50px;margin-bottom:-3px;margin-right:6px}.privilege-icon.icon-milestone{background-position:-60px 0}.privilege-icon.icon-moderation{background-position:-80px 0}.privilege-icon.icon-communication{background-position:-100px 0}.privilege-icon.icon-creation{background-position:-120px 0}.privilege-icon.icon-documentation{background-position:-140px 0}.tools-index-subtabs{width:600px}.migrated.to{width:48px;height:48px;background-image:url('../../Img/fatarrows.png?v=ae7d0b13a3f3');display:inline-block;background-repeat:no-repeat;overflow:hidden;background-position:-48px 0}#mainbar-full h2.title{margin:20px 0}#rep-page-container #master-graph rect{stroke:none}sub sub sub sub,sup sup sup sup{font-size:101%;position:initial}.quality-warning{font-weight:bold;padding-top:15px}.tm-links .review-indicator span{float:left;color:var(--white);font-size:11px;padding:.2em .5em .25em;line-height:1.3;background-color:var(--blue-600);margin-right:5px;border-radius:2px;float:right;background-color:#cf7721;margin-right:0}.review-indicator span{color:hsl(0,0%,100%);display:inline;background-color:var(--blue-600);padding:.2em .5em .25em;margin-right:5px;font-size:11px;line-height:1.3;border-radius:2px;background-color:#cf7721;margin:0}.migrated.from{background-position:0 -464px !important}.migrated.to{background-position:-34px -464px !important}.migrated.from,.migrated.to{width:30px!important;height:28px!important;margin-right:15px}.mod-page #tabs-interval{width:400px}h4#h-linked{margin-top:15px}.flagged-post .answer-link{width:650px}#additional-notices{clear:both}#large-user-info:after{content:'';display:table;clear:both}.tools.close-stats h1{padding-top:15px}.tools.close-stats .header{font-weight:bold}.tools.close-stats .row{padding:3px 0}.tools.close-stats .row .col-4{width:30%;padding-right:10px}.tools.close-stats .close-reasons .inactive,.tools.close-stats .close-reasons .inactive a{opacity:.5}.tools.close-stats .closure-stats .row:nth-child(odd),.tools.close-stats .custom-reasons .row:nth-child(odd){background-color:var(--black-025)}.container.edit-tag-wiki .input-section{margin-bottom:15px}.container.edit-tag-wiki .input-section h3{margin-bottom:8px}.container.edit-tag-wiki .input-section .text-counter{display:block;height:15px;margin-top:5px}.convert-image-to-link{width:250px}.home-page #qlist-wrapper{clear:both}.dupe-hammer-message-hover{margin-left:4px;cursor:pointer}.dupe-hammer-message-hover .badge-tag{vertical-align:middle}.dupe-hammer-message{display:block;max-width:430px;line-height:22px}.realtime-post-deleted-notification{z-index:100;text-align:center}.realtime-post-deleted-notification p{margin-top:30px;padding:15px;font-size:1.15384615rem;background-color:var(--red-050)}.upload-image-warning{text-align:center;background-color:#fcf8e3;padding:10px 10px 5px;border:1px solid #fbeed5;margin-bottom:15px;border-radius:3px;color:#c09853;font-size:13px;line-height:1.3}.oauth-authorizebody{background:#EFF0F1}.oauth-authorize.app-has-icon .app-icon-container{margin-top:18px}.oauth-authorize.app-has-icon .icons-container{margin-bottom:4px !important}.oauth-authorize .root{text-align:center;padding:40px}.oauth-authorize .root .app-authorization{display:inline-block;margin:auto;text-align:left;padding:40px;border:1px solid #D6D8DB;border-radius:2px;background:#fff}.oauth-authorize .root .app-authorization .icons-container{margin-bottom:25px;position:relative}.oauth-authorize .root .app-authorization .icons-container .enterprise-sub-icon{position:absolute;bottom:-7px;left:29px}.oauth-authorize .root .app-authorization .icons-container .app-icon-container{display:flex;flex-direction:row;justify-content:flex-start}.oauth-authorize .root .app-authorization .icons-container .app-icon-container .app-icon-large{height:50px;vertical-align:top}.oauth-authorize .root .app-authorization .icons-container .app-icon-container .no-icon{visibility:hidden}.oauth-authorize .root .app-authorization .authorize-text{font-size:1.30769231rem;margin-bottom:.5em}.oauth-authorize .root .app-authorization .authorize-text .app-name{font-weight:bold}.oauth-authorize .root .app-authorization .authorizing-scopes{margin-bottom:0;font-size:1.15384615rem}.oauth-authorize .root .app-authorization .authorizing-scopes li{margin:12px 0}.oauth-authorize .root .app-authorization .authorizing-scopes li .channel-name{text-decoration:underline}.oauth-authorize .root .app-authorization .auth-buttons{margin-top:20px}.dropdown-questions-filters{top:42px;right:6px}.MathJax_SVG_Display,.MathJax_Display{overflow:auto hidden}.post-notice blockquote{position:relative;padding:6px 12px 6px 16px;background-color:inherit;margin-bottom:0;border-left:none;margin-top:4px}.post-notice blockquote:before{content:"";display:block;position:absolute;top:0;bottom:0;left:0;width:4px;border-radius:8px;background:var(--powder-400)}.post-notice blockquote div{margin-bottom:8px}.post-notice blockquote *:last-child{margin-bottom:0}.blink{animation-name:blinking;animation-duration:3.5s}@keyframes blinking{from{background:#f4a83d}to{background:rgba(244,168,61,0)}}.community-wiki-link a{display:flex;gap:4px}.community-wiki-link br{content:'';white-space:pre;margin-left:-4px}body .mp-results{top:var(--top-bar-allocated-space)}.af-bar{display:none}.af-bar__shown{display:block}.af-bar__shown.af-bar--smol{display:flex}.af-theme-button{--af-btn-outline-color:transparent;--af-btn-focus-outline-color:var(--theme-primary-color);--af-btn-selected-outline-color:var(--white);background-color:var(--black-700);display:inline-flex;width:36px;height:36px;border-radius:50%;align-items:center;justify-content:center;outline:solid 3px var(--af-btn-outline-color);overflow:hidden}.af-theme-button:hover,input[type="radio"]:focus+.af-theme-button{outline-color:var(--af-btn-focus-outline-color)}.af-theme-button img{width:100%;height:100%;object-fit:cover}input[type="radio"]:checked+.af-theme-button{width:44px;height:44px;outline-color:var(--af-btn-selected-outline-color)}@keyframes wipe{0%{clip-path:polygon(-50% -1%, 0% -1%, -50% 101%, -100% 101%)}20%,100%{clip-path:polygon(150% -1%, 200% -1%, 150% 101%, 100% 101%)}}.af-theme-image,.af-theme-image-base{filter:none !important}.af-theme-image{animation-name:wipe;animation-duration:6s;animation-iteration-count:infinite;animation-timing-function:linear;position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%}#af-theme-1{animation-delay:-2000ms}#af-theme-2{animation-delay:-4000ms}#af-theme-3{animation-delay:-6000ms}@media screen and (prefers-reduced-motion){.af-theme-image{animation-play-state:paused}}@media (prefers-color-scheme:dark){body.theme-system .af-logo-img{filter:invert(1)}}body.theme-dark .af-logo-img,.theme-dark__forced .af-logo-img{filter:invert(1)}body.theme-custom{--theme-question-title-color:var(--theme-body-color);--theme-question-title-font-family:var(--theme-body-font-family);--theme-question-body-font-family:var(--theme-body-font-family);--theme-question-title-color:var(--theme-link-color);--theme-question-title-color-hover:var(--theme-link-color-hover);--theme-question-title-color-visited:var(--theme-link-color-visited)}body.theme-custom .s-btn__muted{color:var(--fc-light)}body.theme-custom .s-btn__muted:hover,body.theme-custom .s-btn__muted:focus,body.theme-custom .s-btn__muted:active{color:var(--fc-medium);background-color:var(--black-025)}body.theme-custom .s-btn__muted:active{background:var(--black-025)}body.theme-custom .s-btn__muted.is-selected{color:var(--fc-medium);background-color:var(--black-075)}body.theme-custom .s-btn__muted.s-btn__outlined{border-color:var(--black-300)}body.theme-custom .s-btn__muted.s-btn__outlined.is-selected{border-color:var(--black-400)}body.theme-custom .s-btn__muted.s-btn__filled{color:var(--fc-medium);background-color:var(--black-100)}body.theme-custom .s-btn__muted.s-btn__filled:hover,body.theme-custom .s-btn__muted.s-btn__filled:focus,body.theme-custom .s-btn__muted.s-btn__filled:active{color:var(--fc-medium);background-color:var(--black-150)}body.theme-custom .s-btn__muted.s-btn__filled:active{background-color:var(--black-200)}body.theme-custom .s-btn__muted.s-btn__filled.is-selected{color:var(--fc-dark);background-color:var(--black-350)}body.theme-custom .s-sidebarwidget{--sidebarwidget-outer-border-color:var(--bc-medium);--sidebarwidget-content-separator-color:var(--bc-light);--sidebarwidget-header-background-color:var(--black-025);--sidebarwidget-background-color:var(--white);border:1px solid var(--sidebarwidget-outer-border-color);background-color:var(--sidebarwidget-background-color)}body.theme-custom .s-sidebarwidget:not(.s-anchors) a:not(.button):not(.s-btn):not(.post-tag):not(.s-sidebarwidget--action):not(.s-user-card--link),body.theme-custom .s-sidebarwidget:not(.s-anchors) a:not(.button):not(.s-btn):not(.post-tag):not(.s-sidebarwidget--action):not(.s-user-card--link):visited{color:var(--fc-light)}body.theme-custom .s-sidebarwidget:after{border-top:1px solid var(--sidebarwidget-outer-border-color)}@supports ((-webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)) or (clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%))) or (-webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)){body.theme-custom .s-sidebarwidget:after{border:1px solid var(--sidebarwidget-outer-border-color)}}body.theme-custom .s-sidebarwidget .s-sidebarwidget--header,body.theme-custom .s-sidebarwidget .s-sidebarwidget--content{border-top:1px solid var(--sidebarwidget-content-separator-color)}body.theme-custom .s-sidebarwidget .s-sidebarwidget--header{background:var(--sidebarwidget-header-background-color);color:var(--fc-medium)}body.theme-custom .s-sidebarwidget .s-sidebarwidget--action{color:var(--theme-link-color)}body.theme-custom .s-sidebarwidget .s-sidebarwidget--item,body.theme-custom .s-sidebarwidget .s-sidebarwidget--item>:first-child{color:var(--fc-dark)}body.theme-custom .s-sidebarwidget .s-sidebarwidget--subnav[aria-current="true"],body.theme-custom .s-sidebarwidget .s-sidebarwidget--subnav[aria-current="page"]{color:var(--fc-dark)}body.theme-custom .s-sidebarwidget__yellow,body.theme-custom .s-sidebarwidget__blue,body.theme-custom .s-sidebarwidget__green{border-color:var(--sidebarwidget-outer-border-color);background-color:var(--sidebarwidget-background-color)}body.theme-custom .s-sidebarwidget__yellow .s-sidebarwidget--header,body.theme-custom .s-sidebarwidget__blue .s-sidebarwidget--header,body.theme-custom .s-sidebarwidget__green .s-sidebarwidget--header{background-color:var(--sidebarwidget-background-color);color:var(--fc-medium)}body.theme-custom .s-sidebarwidget__yellow .s-sidebarwidget--header,body.theme-custom .s-sidebarwidget__blue .s-sidebarwidget--header,body.theme-custom .s-sidebarwidget__green .s-sidebarwidget--header,body.theme-custom .s-sidebarwidget__yellow .s-sidebarwidget--content,body.theme-custom .s-sidebarwidget__blue .s-sidebarwidget--content,body.theme-custom .s-sidebarwidget__green .s-sidebarwidget--content{border-color:var(--sidebarwidget-outer-border-color)}body.theme-custom .s-sidebarwidget__yellow:after,body.theme-custom .s-sidebarwidget__blue:after,body.theme-custom .s-sidebarwidget__green:after{border-color:var(--sidebarwidget-outer-border-color)}body.theme-custom .s-breadcrumbs{color:var(--fc-light)}body.theme-custom .s-breadcrumbs .s-breadcrumbs--link{color:var(--fc-light)}body.theme-custom .s-breadcrumbs .s-breadcrumbs--link:hover{color:var(--fc-medium)}body.theme-custom #question-header .question-hyperlink{color:var(--theme-body-font-color)}body.theme-custom .s-topbar--item:hover .-badges *{color:inherit !important}body.theme-custom .js-zone-container,body.theme-custom #hireme,body.theme-custom .mixed-site-content,body.theme-custom .js-consent-banner,body.theme-custom #onetrust-banner-sdk,body.theme-custom .js-zone-container *,body.theme-custom #hireme *,body.theme-custom .mixed-site-content *,body.theme-custom .js-consent-banner *,body.theme-custom #onetrust-banner-sdk *{filter:none !important}body.theme-custom.theme-win31{--theme-base-primary-color-h:243;--theme-base-primary-color-s:93.2%;--theme-base-primary-color-l:34.7%;--theme-base-primary-color-r:15;--theme-base-primary-color-g:6;--theme-base-primary-color-b:171;--theme-base-secondary-color-h:243;--theme-base-secondary-color-s:93.2%;--theme-base-secondary-color-l:34.7%;--theme-base-secondary-color-r:15;--theme-base-secondary-color-g:6;--theme-base-secondary-color-b:171;--theme-background-color:#c0c4c8;--theme-button-active-background-color:#f1f2f3;--theme-button-color:#000000;--theme-button-hover-background-color:#fafafb;--theme-button-hover-color:#000000;--theme-button-selected-background-color:#e9eaec;--theme-button-selected-color:#000000;--theme-button-filled-active-background-color:#e9eaec;--theme-button-filled-active-border-color:#c0c4c8;--theme-button-filled-background-color:#fafafb;--theme-button-filled-border-color:#2a2a2a;--theme-button-filled-color:#000000;--theme-button-filled-hover-background-color:#f1f2f3;--theme-button-filled-hover-color:#000000;--theme-button-filled-selected-background-color:#d6d9db;--theme-button-filled-selected-border-color:#b2b7bc;--theme-button-filled-selected-color:#000000;--theme-button-outlined-border-color:#d6d9db;--theme-button-outlined-selected-border-color:#2a2a2a;--theme-button-primary-active-background-color:#c0c4c8;--theme-button-primary-background-color:#c0c4c8;--theme-button-primary-color:#000000;--theme-button-primary-hover-background-color:#b2b7bc;--theme-button-primary-hover-color:#000000;--theme-button-primary-number-color:#79828a;--theme-button-primary-selected-background-color:#959ba2;--theme-content-border-color:#2a2a2a;--theme-link-color:#0e06ab;--theme-link-color-hover:#3f38bc;--theme-link-color-visited:#0c0592;--theme-header-background-color:#0e06ab;--theme-header-link-color:#0e06ab;--theme-post-owner-background-color:#f6f6f7;--theme-tag-background-color:#f6f6f7;--theme-tag-color:#878f96;--theme-tag-hover-background-color:#f1f2f3;--theme-tag-hover-color:#79828a;--theme-body-font-family:Arial, sans;--theme-footer-background-color:transparent;--shadow-inactive:inset -1px -1px #84888c, inset 1px 1px #F0F0F0, inset -2px -2px #85898d, inset 2px 2px #dfdfdf !important;--element-bg:#c0c0c0;--theme-topbar-background-color:transparent;--theme-topbar-accent-border:none;--theme-topbar-select-background:#ffffff;--theme-topbar-item-color:#ffffff;--theme-topbar-item-color-hover:#000000}body.theme-custom.theme-win31 *{-webkit-font-smoothing:none;image-rendering:pixelated}body.theme-custom.theme-win31 a:not(.s-btn),body.theme-custom.theme-win31 a:not(.s-btn):hover,body.theme-custom.theme-win31 .s-link,body.theme-custom.theme-win31 .s-link:hover{text-decoration:underline;text-decoration-skip-ink:none}body.theme-custom.theme-win31 .s-topbar .s-user-card .-badges,body.theme-custom.theme-win31 .s-topbar--item .-badges *{color:inherit !important}body.theme-custom.theme-win31 *{border-radius:0 !important;box-shadow:none !important;scrollbar-color:var(--element-bg) !important}body.theme-custom.theme-win31 .s-topbar--container{background-color:var(--theme-primary-color);color:var(--white);border:4px solid var(--theme-primary-color);border-bottom-width:0}body.theme-custom.theme-win31 .s-topbar--logo .-img._glyph{filter:invert(.5) brightness(2)}body.theme-custom.theme-win31 .s-topbar--logo:hover .-img._glyph{filter:invert(.5) brightness(0)}body.theme-custom.theme-win31 .s-topbar .s-select{margin-right:4px}body.theme-custom.theme-win31 a:focus,body.theme-custom.theme-win31 .s-link:focus,body.theme-custom.theme-win31 .s-btn.s-btn__link:focus{outline:1px dotted #000000;outline-offset:0}body.theme-custom.theme-win31 .s-btn:not(.s-btn__icon){border-radius:1px !important;color:var(--theme-button-primary-color);font-weight:bold}body.theme-custom.theme-win31 .s-btn:focus:not(:active){outline:1px dotted #000000;outline-offset:-0.8em}body.theme-custom.theme-win31 .s-btn__primary{border:1px solid var(--theme-button-outlined-border-color);box-shadow:inset -1px -1px #84888c,inset 1px 1px #F0F0F0,inset -2px -2px #85898d,inset 2px 2px #dfdfdf !important}body.theme-custom.theme-win31 .s-btn__primary:active,body.theme-custom.theme-win31 .s-btn__filled:active,body.theme-custom.theme-win31 .s-input,body.theme-custom.theme-win31 .s-textarea,body.theme-custom.theme-win31 .s-select select{box-shadow:inset -1px -1px #f0f0f0,inset 1px 1px #151515,inset -2px -2px #dfdfdf,inset 2px 2px #85898d !important}body.theme-custom.theme-win31 .s-btn__primary::first-letter{text-decoration:underline;text-decoration-thickness:.15em;text-decoration-skip-ink:none}body.theme-custom.theme-win31 .container{border:4px solid var(--theme-primary-color);border-top-width:0;border-bottom-width:0}body.theme-custom.theme-win31 .site-footer--container,body.theme-custom.theme-win31 .site-footer--extra{background-color:var(--theme-content-background-color);border:4px solid var(--theme-primary-color)}body.theme-custom.theme-win31 #left-sidebar{background-color:var(--theme-content-background-color)}body.theme-custom.theme-win31 .nav-links .youarehere .nav-links--link,body.theme-custom.theme-win31 .nav-links .youarehere .nav-links--link .svg-icon{background-color:var(--theme-primary-color);color:var(--white) !important}body.theme-custom.theme-win31 .s-checkbox,body.theme-custom.theme-win31 .s-radio{border-color:black;background:white;box-shadow:inset -1px -1px #c0c4c8,inset 1px 1px #151515,inset -1px -1px #dfdfdf,inset 1px 1px #85898d !important}body.theme-custom.theme-win31 .s-radio{border-radius:50% !important}body.theme-custom.theme-win31 .s-radio:checked,body.theme-custom.theme-win31 .s-checkbox:checked{border:0;background:var(--white);position:relative}body.theme-custom.theme-win31 .s-radio:checked::after{content:"";width:50%;height:50%;background-color:black;position:absolute;top:25%;left:25%;border-radius:50% !important}body.theme-custom.theme-win31 .s-checkbox:checked::before,body.theme-custom.theme-win31 .s-checkbox:checked::after{content:"";width:2px;height:11px;background-color:black;position:absolute;left:.5px;top:1px;transform:translateX(5px) rotate(45deg);border-radius:1px}body.theme-custom.theme-win31 .s-checkbox:checked::after{transform:translateX(5px) rotate(-45deg)}body.theme-custom.theme-win31 input:focus,body.theme-custom.theme-win31 select:focus,body.theme-custom.theme-win31 textarea:focus,body.theme-custom.theme-win31 input.has-focus,body.theme-custom.theme-win31 select.has-focus,body.theme-custom.theme-win31 textarea.has-focus{outline:2px solid black !important;border-color:transparent}body.theme-custom.theme-win31 .s-select::before{display:none}body.theme-custom.theme-win31 .s-select::after{border:0;background-image:url("../../Img/april-fools-2022/assets/arrowdrop.png?v=e5987784d591");content:"";width:20px;height:20px;background-size:50% auto;background-repeat:no-repeat;background-position:center;top:50%;right:4px;transform:translateY(-50%)}body.theme-custom.theme-win31::-webkit-scrollbar,body.theme-custom.theme-win31 *::-webkit-scrollbar{width:20px !important;height:20px !important;background-color:transparent !important;border:1px solid black !important}body.theme-custom.theme-win31::-webkit-scrollbar-track,body.theme-custom.theme-win31 *::-webkit-scrollbar-track{border-radius:0 !important;background-color:var(--element-bg) !important;border:1px solid black !important}body.theme-custom.theme-win31::-webkit-scrollbar-thumb,body.theme-custom.theme-win31 *::-webkit-scrollbar-thumb{border-radius:0 !important;background-color:var(--element-bg) !important;border:1px solid black !important;box-shadow:var(--shadow-inactive)}body.theme-custom.theme-win31::-webkit-scrollbar-corner,body.theme-custom.theme-win31 *::-webkit-scrollbar-corner{background-color:var(--element-bg) !important;border:1px solid black !important}body.theme-custom.theme-win31::-webkit-scrollbar-button,body.theme-custom.theme-win31 *::-webkit-scrollbar-button{background-color:var(--element-bg) !important;border:1px solid black !important;box-shadow:var(--shadow-inactive);height:20px;width:20px;display:block;background-position:center;background-repeat:no-repeat;background-size:50%;background-image:url("../../Img/april-fools-2022/assets/arrowup.png?v=4329a69b4efb")}body.theme-custom.theme-win31::-webkit-scrollbar-button:vertical:increment,body.theme-custom.theme-win31 *::-webkit-scrollbar-button:vertical:increment{background-image:url("../../Img/april-fools-2022/assets/arrowdown.png?v=21fb3f6ec3e7")}body.theme-custom.theme-win31::-webkit-scrollbar-button:horizontal:decrement,body.theme-custom.theme-win31 *::-webkit-scrollbar-button:horizontal:decrement{background-image:url("../../Img/april-fools-2022/assets/arrowleft.png?v=5794723486b1")}body.theme-custom.theme-win31::-webkit-scrollbar-button:horizontal:increment,body.theme-custom.theme-win31 *::-webkit-scrollbar-button:horizontal:increment{background-image:url("../../Img/april-fools-2022/assets/arrowright.png?v=79d712516e17")}body.theme-custom.theme-win31::-webkit-scrollbar-button:vertical:start:increment,body.theme-custom.theme-win31 *::-webkit-scrollbar-button:vertical:start:increment,body.theme-custom.theme-win31::-webkit-scrollbar-button:vertical:end:decrement,body.theme-custom.theme-win31 *::-webkit-scrollbar-button:vertical:end:decrement,body.theme-custom.theme-win31::-webkit-scrollbar-button:horizontal:start:increment,body.theme-custom.theme-win31 *::-webkit-scrollbar-button:horizontal:start:increment,body.theme-custom.theme-win31::-webkit-scrollbar-button:horizontal:end:decrement,body.theme-custom.theme-win31 *::-webkit-scrollbar-button:horizontal:end:decrement{display:none}body.theme-custom.theme-win31.theme-hotdog{--theme-base-primary-color-h:0;--theme-base-primary-color-s:100%;--theme-base-primary-color-l:47.5%;--theme-base-primary-color-r:242;--theme-base-primary-color-g:0;--theme-base-primary-color-b:0;--theme-base-secondary-color-h:0;--theme-base-secondary-color-s:100%;--theme-base-secondary-color-l:47.5%;--theme-base-secondary-color-r:242;--theme-base-secondary-color-g:0;--theme-base-secondary-color-b:0;--theme-background-color:#fbfb00;--theme-button-active-background-color:#f1f2f3;--theme-button-color:#000000;--theme-button-hover-background-color:#fafafb;--theme-button-hover-color:#000000;--theme-button-selected-background-color:#e9eaec;--theme-button-selected-color:#000000;--theme-button-filled-active-background-color:#e9eaec;--theme-button-filled-active-border-color:#c0c4c8;--theme-button-filled-background-color:#fafafb;--theme-button-filled-border-color:#2a2a2a;--theme-button-filled-color:#000000;--theme-button-filled-hover-background-color:#f1f2f3;--theme-button-filled-hover-color:#000000;--theme-button-filled-selected-background-color:#d6d9db;--theme-button-filled-selected-border-color:#b2b7bc;--theme-button-filled-selected-color:#000000;--theme-button-outlined-border-color:#d6d9db;--theme-button-outlined-selected-border-color:#2a2a2a;--theme-button-primary-active-background-color:#c0c4c8;--theme-button-primary-background-color:#c0c4c8;--theme-button-primary-color:#000000;--theme-button-primary-hover-background-color:#b2b7bc;--theme-button-primary-hover-color:#000000;--theme-button-primary-number-color:#79828a;--theme-button-primary-selected-background-color:#959ba2;--theme-content-background-color:#fbfb00;--theme-content-border-color:#2a2a2a;--theme-footer-background-color:#000000;--theme-link-color:#0e06ab;--theme-link-color-hover:#3f38bc;--theme-link-color-visited:#0c0592;--theme-header-background-color:#0e06ab;--theme-header-link-color:#0e06ab;--theme-post-owner-background-color:#f6f6f7;--theme-tag-background-color:#f6f6f7;--theme-tag-color:#878f96;--theme-tag-hover-background-color:#f1f2f3;--theme-tag-hover-color:#79828a}body.theme-custom.theme-dark.theme-terminal{--theme-base-primary-color-h:120;--theme-base-primary-color-s:100%;--theme-base-primary-color-l:50%;--theme-base-primary-color-r:0;--theme-base-primary-color-g:255;--theme-base-primary-color-b:0;--theme-base-secondary-color-h:120;--theme-base-secondary-color-s:100%;--theme-base-secondary-color-l:50%;--theme-base-secondary-color-r:0;--theme-base-secondary-color-g:255;--theme-base-secondary-color-b:0;--theme-background-color:#000111;--theme-body-font-color:var(--theme-primary-color);--theme-button-primary-color:#000000;--theme-button-primary-hover-color:#000000;--theme-button-primary-selected-color:#000000;--theme-content-background-color:#000111;--theme-content-border-color:var(--theme-primary-color);--theme-link-color-hover:#ffffff;--theme-link-color-visited:var(--fc-dark);--theme-body-font-family:VT323, monospace;--theme-topbar-background-color:var(--theme-content-background-color);--theme-topbar-item-background-hover:var(--theme-secondary-color);--theme-topbar-item-border-current:var(--theme-secondary-color);--theme-topbar-item-color:var(--theme-secondary-color);--theme-topbar-item-color-hover:var(--theme-content-background-color);--theme-topbar-search-border-focus:var(--theme-secondary-color);--fc-dark:var(--theme-secondary-300);--fc-medium:var(--theme-secondary-500);--fc-light:var(--theme-secondary-600);--bc-lightest:var(--fc-light);--bc-lighter:var(--fc-light);--bc-light:var(--fc-medium);--bc-medium:var(--fc-medium);--bc-dark:var(--fc-dark);--bc-darker:var(--fc-dark);font-size-adjust:.5}body.theme-custom.theme-dark.theme-terminal *{-webkit-font-smoothing:none;image-rendering:pixelated}body.theme-custom.theme-dark.theme-terminal a:not(.s-btn),body.theme-custom.theme-dark.theme-terminal a:not(.s-btn):hover,body.theme-custom.theme-dark.theme-terminal .s-link,body.theme-custom.theme-dark.theme-terminal .s-link:hover{text-decoration:underline;text-decoration-skip-ink:none}body.theme-custom.theme-dark.theme-terminal .s-topbar .s-user-card .-badges,body.theme-custom.theme-dark.theme-terminal .s-topbar--item .-badges *{color:inherit !important}body.theme-custom.theme-dark.theme-terminal *{border-radius:0 !important}body.theme-custom.theme-dark.theme-terminal .s-topbar--logo .-img._glyph{filter:invert(.5) brightness(2) sepia(1) brightness(1) contrast(1) saturate(100) hue-rotate(45deg)}body.theme-custom.theme-dark.theme-terminal [class*="gravatar-wrapper-"],body.theme-custom.theme-dark.theme-terminal .s-avatar,body.theme-custom.theme-dark.theme-terminal .js-usermini-avatar-container{background:var(--theme-primary-color)}body.theme-custom.theme-dark.theme-terminal [class*="gravatar-wrapper-"] img,body.theme-custom.theme-dark.theme-terminal .s-avatar img,body.theme-custom.theme-dark.theme-terminal .js-usermini-avatar-container img{filter:grayscale(1) contrast(200%);mix-blend-mode:multiply}body.theme-custom.theme-dark.theme-terminal [class*="user-gravatar"]{background:var(--theme-primary-color)}body.theme-custom.theme-dark.theme-terminal [class*="user-gravatar"] span{display:inline-block;width:100%;height:100%;filter:grayscale(1);mix-blend-mode:multiply}body.theme-custom.theme-dark.theme-terminal .s-btn__primary{color:var(--theme-button-primary-color) !important}body.theme-custom.theme-dark.theme-terminal #question-header .question-hyperlink{color:var(--theme-body-font-color)}body.theme-custom.theme-dark.theme-terminal .flush-left{border-top-color:var(--bc-medium)}body.theme-custom.theme-dark.theme-terminal .af-bar{background-color:var(--theme-background-color) !important;color:var(--theme-body-font-color) !important}body.theme-custom.theme-dark.theme-terminal .af-bar .af-logo-img{filter:invert(.5) brightness(2) sepia(1) brightness(1) contrast(1) saturate(100) hue-rotate(45deg)}body.theme-custom.theme-dark.theme-terminal .af-bar .af-theme-button{--af-btn-outline-color:var(--theme-primary-color);--af-btn-focus-outline-color:var(--red-500);--af-btn-selected-outline-color:#ffffff;background:var(--theme-background-color);border-radius:50% !important}body.theme-custom.theme-topsecret{--theme-body-font-family:Courier, serif;--ff-mono:var(--theme-body-font-family);--theme-question-body-font-family:#232629;--theme-question-title-font-family:var(--theme-body-font-family);--theme-body-font-color:#000000;--theme-content-border-color:var(--bc-darker);--theme-topbar-background-color:white;--theme-topbar-select-background:white;--theme-button-active-background-color:#ffffff;--theme-button-background-color:#ffffff;--theme-button-color:var(--fc-medium);--theme-button-hover-background-color:#ffffff;--theme-button-hover-color:var(--fc-dark);--theme-button-selected-background-color:#ffffff;--theme-button-selected-color:var(--fc-dark);--theme-button-filled-active-background-color:#ffffff;--theme-button-filled-active-border-color:var(--fc-dark);--theme-button-filled-background-color:#ffffff;--theme-button-filled-border-color:var(--fc-medium);--theme-button-filled-color:var(--fc-medium);--theme-button-filled-hover-background-color:#ffffff;--theme-button-filled-hover-color:var(--fc-dark);--theme-button-filled-selected-background-color:#ffffff;--theme-button-filled-selected-border-color:var(--fc-dark);--theme-button-filled-selected-color:var(--fc-dark);--theme-button-outlined-border-color:var(--fc-medium);--theme-button-outlined-selected-border-color:var(--fc-dark);--topsecret-image:url("../../Img/april-fools-2022/assets/confidential.svg?v=eb675da66cdd");--fc-dark:#0c0d0e;--fc-medium:#3b4045;--fc-light:#6a737c;--bc-lightest:var(--fc-light);--bc-lighter:var(--fc-light);--bc-light:var(--fc-medium);--bc-medium:var(--fc-medium);--bc-dark:var(--fc-dark);--bc-darker:var(--fc-dark);--bs-sm:var(--bs-lg);--bs-md:var(--bs-lg);--bs-xl:var(--bs-lg)}body.theme-custom.theme-topsecret a:not(.s-btn),body.theme-custom.theme-topsecret a:not(.s-btn):hover,body.theme-custom.theme-topsecret .s-link,body.theme-custom.theme-topsecret .s-link:hover{text-decoration:underline;text-decoration-skip-ink:none}body.theme-custom.theme-topsecret .s-topbar .s-user-card .-badges,body.theme-custom.theme-topsecret .s-topbar--item .-badges *{color:inherit !important}body.theme-custom.theme-topsecret .s-topbar--logo .-img{filter:invert(.5) brightness(0)}body.theme-custom.theme-topsecret #content::before{content:"";background:var(--topsecret-image) no-repeat center;background-size:contain;transform:rotate(-18deg);width:150px;height:150px;pointer-events:none;position:absolute;top:0px;left:150px;z-index:5000}@media screen and (max-width:640px){html.html__responsive body.theme-custom.theme-topsecret #content::before{width:100px;height:100px;left:0}}@media print{body.theme-custom.theme-topsecret #content::before{width:100px;height:100px;left:0}}body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n),body.theme-custom.theme-topsecret #questions>:nth-child(2n),body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n){font-family:'Flow Block',serif !important}body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n),body.theme-custom.theme-topsecret #questions>:nth-child(2n),body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n),body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n) *,body.theme-custom.theme-topsecret #questions>:nth-child(2n) *,body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n) *{text-decoration:none !important}body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n):hover,body.theme-custom.theme-topsecret #questions>:nth-child(2n):hover,body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n):hover,body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n):focus,body.theme-custom.theme-topsecret #questions>:nth-child(2n):focus,body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n):focus,body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n):active,body.theme-custom.theme-topsecret #questions>:nth-child(2n):active,body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n):active{font-family:revert !important}body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n),body.theme-custom.theme-topsecret .post-layout :nth-child(5n){font-family:'Flow Block',serif !important}body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n),body.theme-custom.theme-topsecret .post-layout :nth-child(5n),body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n) *,body.theme-custom.theme-topsecret .post-layout :nth-child(5n) *{text-decoration:none !important}body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n):hover,body.theme-custom.theme-topsecret .post-layout :nth-child(5n):hover,body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n):focus,body.theme-custom.theme-topsecret .post-layout :nth-child(5n):focus,body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n):active,body.theme-custom.theme-topsecret .post-layout :nth-child(5n):active{font-family:revert !important}body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a{font-family:'Flow Block',serif !important}body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a,body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a *{text-decoration:none !important}body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a:hover,body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a:focus,body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a:active{font-family:revert !important}body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n){font-family:'Flow Block',serif !important}body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n),body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n) *{text-decoration:none !important}body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n):hover,body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n):focus,body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n):active{font-family:revert !important}body.theme-custom.theme-topsecret .js-zone-container,body.theme-custom.theme-topsecret #hireme,body.theme-custom.theme-topsecret .mixed-site-content,body.theme-custom.theme-topsecret .js-consent-banner,body.theme-custom.theme-topsecret #onetrust-banner-sdk,body.theme-custom.theme-topsecret .js-zone-container *,body.theme-custom.theme-topsecret #hireme *,body.theme-custom.theme-topsecret .mixed-site-content *,body.theme-custom.theme-topsecret .js-consent-banner *,body.theme-custom.theme-topsecret #onetrust-banner-sdk *{font-family:var(--theme-body-font-family) !important}body.theme-custom.theme-topsecret .s-badge.s-badge__staff{font-weight:bolder;background:linear-gradient(104deg, rgba(244,130,37,0) .9%, #f48225 2.4%, rgba(244,130,37,0.5) 5.8%, rgba(244,130,37,0.1) 93%, rgba(244,130,37,0.7) 96%, rgba(244,130,37,0) 98%),linear-gradient(183deg, rgba(244,130,37,0) 0%, rgba(244,130,37,0.3) 7.9%, rgba(244,130,37,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(244,130,37,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .s-badge.s-badge__moderator{font-weight:bolder;background:linear-gradient(104deg, rgba(217,234,247,0) .9%, #d9eaf7 2.4%, rgba(217,234,247,0.5) 5.8%, rgba(217,234,247,0.1) 93%, rgba(217,234,247,0.7) 96%, rgba(217,234,247,0) 98%),linear-gradient(183deg, rgba(217,234,247,0) 0%, rgba(217,234,247,0.3) 7.9%, rgba(217,234,247,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(217,234,247,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .s-post-summary--stats-item.has-accepted-answer{font-weight:bolder;background:linear-gradient(104deg, rgba(72,168,104,0) .9%, #48a868 2.4%, rgba(72,168,104,0.5) 5.8%, rgba(72,168,104,0.1) 93%, rgba(72,168,104,0.7) 96%, rgba(72,168,104,0) 98%),linear-gradient(183deg, rgba(72,168,104,0) 0%, rgba(72,168,104,0.3) 7.9%, rgba(72,168,104,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(72,168,104,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .s-post-summary.s-post-summary__watched{font-weight:bolder;background:linear-gradient(104deg, rgba(255,255,40,0) .9%, #ffff28 2.4%, rgba(255,255,40,0.5) 5.8%, rgba(255,255,40,0.1) 93%, rgba(255,255,40,0.7) 96%, rgba(255,255,40,0) 98%),linear-gradient(183deg, rgba(255,255,40,0) 0%, rgba(255,255,40,0.3) 7.9%, rgba(255,255,40,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(255,255,40,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .s-post-summary.s-post-summary__deleted{background-color:transparent}body.theme-custom.theme-topsecret .s-post-summary.s-post-summary__deleted .s-post-summary--stats-item.is-deleted{font-weight:bolder;background:linear-gradient(104deg, rgba(208,57,62,0) .9%, #d0393e 2.4%, rgba(208,57,62,0.5) 5.8%, rgba(208,57,62,0.1) 93%, rgba(208,57,62,0.7) 96%, rgba(208,57,62,0) 98%),linear-gradient(183deg, rgba(208,57,62,0) 0%, rgba(208,57,62,0.3) 7.9%, rgba(208,57,62,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(208,57,62,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .nav-links .youarehere{font-weight:bolder;background:linear-gradient(104deg, rgba(255,255,40,0) .9%, #ffff28 2.4%, rgba(255,255,40,0.5) 5.8%, rgba(255,255,40,0.1) 93%, rgba(255,255,40,0.7) 96%, rgba(255,255,40,0) 98%),linear-gradient(183deg, rgba(255,255,40,0) 0%, rgba(255,255,40,0.3) 7.9%, rgba(255,255,40,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(255,255,40,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .nav-links .youarehere .nav-links--link{border:0;background:transparent}body.theme-custom.theme-topsecret .s-navigation--item.is-selected{font-weight:bolder;background:linear-gradient(104deg, rgba(244,130,37,0) .9%, #f48225 2.4%, rgba(244,130,37,0.5) 5.8%, rgba(244,130,37,0.1) 93%, rgba(244,130,37,0.7) 96%, rgba(244,130,37,0) 98%),linear-gradient(183deg, rgba(244,130,37,0) 0%, rgba(244,130,37,0.3) 7.9%, rgba(244,130,37,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(244,130,37,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .s-btn-group .s-btn{border-top:0;border-bottom:0;border-radius:0}body.theme-custom.theme-topsecret .s-btn-group .is-selected{font-weight:bolder;background:linear-gradient(104deg, rgba(130,255,173,0) .9%, #82ffad 2.4%, rgba(130,255,173,0.5) 5.8%, rgba(130,255,173,0.1) 93%, rgba(130,255,173,0.7) 96%, rgba(130,255,173,0) 98%),linear-gradient(183deg, rgba(130,255,173,0) 0%, rgba(130,255,173,0.3) 7.9%, rgba(130,255,173,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(130,255,173,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .subtabs a,body.theme-custom.theme-topsecret .filter a{border:0}body.theme-custom.theme-topsecret .subtabs a.youarehere,body.theme-custom.theme-topsecret .filter a.youarehere,body.theme-custom.theme-topsecret .subtabs a.active,body.theme-custom.theme-topsecret .filter a.active{font-weight:bolder;background:linear-gradient(104deg, rgba(244,130,37,0) .9%, #f48225 2.4%, rgba(244,130,37,0.5) 5.8%, rgba(244,130,37,0.1) 93%, rgba(244,130,37,0.7) 96%, rgba(244,130,37,0) 98%),linear-gradient(183deg, rgba(244,130,37,0) 0%, rgba(244,130,37,0.3) 7.9%, rgba(244,130,37,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(244,130,37,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret .s-pagination{border:0}body.theme-custom.theme-topsecret .s-pagination .is-selected{font-weight:bolder;background:linear-gradient(104deg, rgba(244,130,37,0) .9%, #f48225 2.4%, rgba(244,130,37,0.5) 5.8%, rgba(244,130,37,0.1) 93%, rgba(244,130,37,0.7) 96%, rgba(244,130,37,0) 98%),linear-gradient(183deg, rgba(244,130,37,0) 0%, rgba(244,130,37,0.3) 7.9%, rgba(244,130,37,0) 15%);-webkit-box-decoration-break:clone;margin:0;border-radius:7.5px;text-shadow:-12px 12px 9.8px rgba(244,130,37,0.7),21px -18.1px 7.3px #fff,-18.1px -27.3px 30px #fff;border-color:transparent;color:var(--fc-dark)}body.theme-custom.theme-topsecret img,body.theme-custom.theme-topsecret svg:not(.s-avatar--badge){filter:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeColorMatrix type='matrix' values='-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='colormatrix'/%3E%3CfeGaussianBlur stdDeviation='0' x='0%25' y='0%25' width='100%25' height='100%25' in='colormatrix' edgeMode='none' result='blur'/%3E%3CfeBlend mode='color-dodge' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' in2='blur' result='blend'/%3E%3CfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='blend' result='colormatrix1'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeConvolveMatrix order='3 3' kernelMatrix='-1 -1 -1 -1 5 -1 -1 -1 -1' divisor='1' bias='1' targetX='0' targetY='0' edgeMode='duplicate' preserveAlpha='true' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='convolveMatrix'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") invert(0)}body.theme-custom.theme-topsecret [class*="gravatar-wrapper-"] img,body.theme-custom.theme-topsecret .s-avatar img,body.theme-custom.theme-topsecret .js-usermini-avatar-container img{filter:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeColorMatrix type='matrix' values='-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='colormatrix'/%3E%3CfeGaussianBlur stdDeviation='20' x='0%25' y='0%25' width='100%25' height='100%25' in='colormatrix' edgeMode='none' result='blur'/%3E%3CfeBlend mode='color-dodge' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' in2='blur' result='blend'/%3E%3CfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='blend' result='colormatrix1'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeConvolveMatrix order='3 3' kernelMatrix='-1 -1 -1 -1 8 -1 -1 -1 -1' divisor='1' bias='1' targetX='0' targetY='0' edgeMode='duplicate' preserveAlpha='true' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='convolveMatrix'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") invert(0)}body.theme-custom.theme-topsecret [class*="user-gravatar"] span{display:inline-block;filter:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeColorMatrix type='matrix' values='-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='colormatrix'/%3E%3CfeGaussianBlur stdDeviation='20' x='0%25' y='0%25' width='100%25' height='100%25' in='colormatrix' edgeMode='none' result='blur'/%3E%3CfeBlend mode='color-dodge' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' in2='blur' result='blend'/%3E%3CfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='blend' result='colormatrix1'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeConvolveMatrix order='3 3' kernelMatrix='-1 -1 -1 -1 8 -1 -1 -1 -1' divisor='1' bias='1' targetX='0' targetY='0' edgeMode='duplicate' preserveAlpha='true' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='convolveMatrix'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") invert(0)}body.theme-custom.theme-topsecret .s-sidebarwidget:first-child{transform:rotate(.1deg)}body.theme-custom.theme-topsecret .s-sidebarwidget:nth-child(2){transform:rotate(-0.3deg)}body.theme-custom.theme-topsecret .af-bar{background-color:white !important;color:var(--fc-dark) !important;box-shadow:var(--bs-lg);border:1px solid var(--bc-dark)}body.theme-custom.theme-topsecret .af-bar svg,body.theme-custom.theme-topsecret .af-bar img:not(.af-logo-img){filter:none !important}body.theme-custom.theme-topsecret .af-bar .af-logo-img{filter:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeColorMatrix type='matrix' values='-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='colormatrix'/%3E%3CfeGaussianBlur stdDeviation='20' x='0%25' y='0%25' width='100%25' height='100%25' in='colormatrix' edgeMode='none' result='blur'/%3E%3CfeBlend mode='color-dodge' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' in2='blur' result='blend'/%3E%3CfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='blend' result='colormatrix1'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeConvolveMatrix order='3 3' kernelMatrix='-1 -1 -1 -1 8 -1 -1 -1 -1' divisor='1' bias='1' targetX='0' targetY='0' edgeMode='duplicate' preserveAlpha='true' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='convolveMatrix'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") invert(1)}body.theme-custom.theme-topsecret .af-bar .af-theme-button{--af-btn-outline-color:var(--bc-dark);--af-btn-selected-outline-color:var(--theme-primary-color);background:white !important}body.theme-custom.theme-frisa{--theme-base-primary-color-h:25;--theme-base-primary-color-s:69.3%;--theme-base-primary-color-l:55.3%;--theme-base-primary-color-r:220;--theme-base-primary-color-g:128;--theme-base-primary-color-b:62;--theme-base-secondary-color-h:339;--theme-base-secondary-color-s:63.2%;--theme-base-secondary-color-l:54.1%;--theme-base-secondary-color-r:212;--theme-base-secondary-color-g:64;--theme-base-secondary-color-b:115;--theme-wintergreen:#4fad80;--theme-light-purplish:#706fae;--theme-dark-purplish:#454690;--theme-button-active-background-color:var(--theme-button-filled-background-color);--theme-button-color:var(--theme-button-filled-background-color);--theme-button-hover-background-color:var(--theme-link-color);--theme-button-hover-color:var(--theme-button-filled-color);--theme-button-selected-background-color:var(--theme-button-filled-background-color);--theme-button-selected-color:var(--theme-button-filled-selected-color);--theme-button-filled-active-background-color:var(--theme-button-filled-background-color);--theme-button-filled-active-border-color:var(--theme-button-filled-background-color);--theme-button-filled-background-color:#88bf56;--theme-button-filled-border-color:var(--theme-button-filled-background-color);--theme-button-filled-color:var(--theme-button-filled-color);--theme-button-filled-hover-background-color:var(--theme-link-color);--theme-button-filled-hover-color:var(--theme-button-filled-color);--theme-button-filled-selected-background-color:var(--theme-button-filled-background-color);--theme-button-filled-selected-border-color:var(--theme-button-filled-background-color);--theme-button-filled-selected-color:#50ab58;--theme-button-outlined-border-color:var(--theme-button-filled-background-color);--theme-button-outlined-selected-border-color:var(--theme-button-filled-background-color);--theme-button-primary-active-background-color:var(--theme-secondary-color);--theme-button-primary-background-color:var(--theme-secondary-color);--theme-button-primary-hover-background-color:var(--theme-light-purplish);--theme-button-primary-number-color:var(--theme-button-filled-color);--theme-button-primary-selected-background-color:var(--theme-secondary-color);--theme-content-background-color:#ffffff;--theme-content-border-color:#ffffff;--theme-footer-background-color:var(--theme-dark-purplish);--theme-footer-divider-color:var(--theme-dark-purplish);--theme-footer-link-caret-color:var(--theme-dark-purplish);--theme-footer-link-color:#ffffff;--theme-footer-link-color-hover:#e0ec77;--theme-footer-text-color:#ababab;--theme-footer-title-color:#be87bd;--theme-link-color:#439ad5;--theme-link-color-hover:#4fb1a8;--theme-link-color-visited:#3969b6;--theme-header-background-color:var(--theme-secondary-color);--theme-header-link-color:#ffffff;--theme-post-owner-background-color:var(--theme-footer-link-color-hover);--theme-post-owner-new-background-color:var(--theme-footer-link-color-hover);--theme-question-title-color:#e16b56;--theme-question-title-color-hover:var(--theme-secondary-color);--theme-question-title-color-visited:var(--theme-dark-purplish);--theme-tag-background-color:var(--theme-light-purplish);--theme-tag-border-color:var(--theme-light-purplish);--theme-tag-color:#ffffff;--theme-tag-hover-background-color:var(--theme-wintergreen);--theme-tag-hover-border-color:var(--theme-wintergreen);--theme-tag-hover-color:#ffffff;--theme-background-color:var(--theme-link-color);--theme-background-size:50% auto, cover;--theme-background-repeat:repeat, no-repeat;--theme-background-attachment:fixed;--theme-background-position:0 0;--theme-topbar-accent-border:none;--theme-topbar-background-color:#ffffff;--theme-topbar-item-background-hover:var(--theme-secondary-color);--theme-topbar-item-border-current:var(--theme-secondary-color);--theme-topbar-item-color:var(--theme-secondary-color);--theme-topbar-item-color-current:#ffffff;--theme-topbar-item-color-hover:#ffffff;--theme-topbar-search-border-focus:var(--theme-secondary-color);font-family:'Nunito',sans-serif;font-size:15px;background-image:url("../../Img/april-fools-2022/assets/frisa-bg.png?v=3d424b05383e"),linear-gradient(135deg, #f5e256 0%, #dc803e 33%, #d44073 66%, #454690 100%)}body.theme-custom.theme-frisa .s-topbar{padding-top:4px}body.theme-custom.theme-frisa .s-topbar::before{content:"";position:absolute;top:0;left:0;width:100%;height:4px;background:linear-gradient(90deg, #f5e256 0%, #dc803e 33%, #d44073 66%, #454690 100%)}body.theme-custom.theme-frisa .s-topbar .s-topbar--logo:hover .-img._glyph{filter:invert(.5) brightness(2)}body.theme-custom.theme-frisa .container{max-width:1312px}html.html__unpinned-leftnav body.theme-custom.theme-frisa .container{max-width:1148px}body.theme-custom.theme-frisa .s-topbar .s-topbar--container{width:1312px}body.theme-custom.theme-frisa #content{margin:24px;border-radius:16px}body.theme-custom.theme-frisa .nav-links .fc-black-500{color:#fff !important}body.theme-custom.theme-frisa .nav-links .nav-links--link,body.theme-custom.theme-frisa .nav-links .nav-links--link:visited{border-radius:20px;margin:8px 0;color:#ffffff;background:rgba(212,64,115,0.4)}body.theme-custom.theme-frisa .nav-links .youarehere .nav-links--link{background:#fff;color:var(--theme-secondary-color);border-right:none}body.theme-custom.theme-frisa .nav-links .nav-links--link.-link__with-icon .svg-icon,body.theme-custom.theme-frisa .nav-links .nav-links--link:hover .svg-icon{color:#fff !important}body.theme-custom.theme-frisa .nav-links .nav-links--link:hover{color:#fff;background:var(--theme-secondary-color)}body.theme-custom.theme-frisa .nav-links .youarehere .nav-links--link .svg-icon{color:currentColor !important}body.theme-custom.theme-frisa .nav-links .fs-fine{color:#ffffff !important;text-shadow:1px 1px 1px var(--theme-dark-purplish);font-weight:bold}body.theme-custom.theme-frisa .s-btn__filled:hover,body.theme-custom.theme-frisa .s-btn__filled:focus,body.theme-custom.theme-frisa .s-btn__filled:active{border-color:#439AD5}body.theme-custom.theme-frisa .s-btn{border-radius:20px}body.theme-custom.theme-frisa .s-input,body.theme-custom.theme-frisa .s-textarea{border-radius:8px}body.theme-custom.theme-frisa .owner{border-radius:8px}body.theme-custom.theme-frisa .gravatar-wrapper-24{border-radius:12px}body.theme-custom.theme-frisa .post-tag,body.theme-custom.theme-frisa .s-tag{border-radius:6px}body.theme-custom.theme-frisa .s-sidebarwidget{border-radius:12px;box-shadow:none;overflow:hidden}body.theme-custom.theme-frisa .s-sidebarwidget--header:first-child{border-top:none}body.theme-custom.theme-frisa .s-post-summary{padding:24px 16px}body.theme-custom.theme-frisa .s-post-summary--content .s-post-summary--content-title,body.theme-custom.theme-frisa .s-post-summary--content .s-post-summary--content-title .s-link{font-weight:bold}body.theme-custom.theme-frisa .s-post-summary--stats{margin-right:12px}body.theme-custom.theme-frisa .s-post-summary--stats .s-post-summary--stats-item.has-answers{color:var(--theme-wintergreen);border-color:var(--theme-wintergreen);border-radius:6px;padding:4px 8px}body.theme-custom.theme-frisa .s-post-summary--stats .s-post-summary--stats-item.has-answers.has-accepted-answer{background-color:var(--theme-wintergreen);color:#ffffff}body.theme-custom.theme-frisa .js-freemium-cta>div:last-child{background-color:var(--white)}body.theme-custom.theme-frisa .af-bar__big{background:var(--theme-footer-background-color) !important}body.theme-custom.theme-plumber{--sky:#8b7fff;--brick:#8c3300;--brick-hit:#4e0d00;--pipe:#2b8000;--item-block:#c89d02;--bar-height:60px;--theme-base-primary-color-h:99.84375;--theme-base-primary-color-s:100%;--theme-base-primary-color-l:25.09803922%;--theme-base-primary-color-r:43;--theme-base-primary-color-g:128;--theme-base-primary-color-b:0;--theme-base-secondary-color-h:21.85714286;--theme-base-secondary-color-s:100%;--theme-base-secondary-color-l:27.45098039%;--theme-base-secondary-color-r:140;--theme-base-secondary-color-g:51;--theme-base-secondary-color-b:0;--theme-background-color:var(--sky);--theme-content-background-color:rgba(255,255,255,0.9);--theme-button-primary-background-color:var(--item-block);--theme-button-primary-hover-background-color:var(--brick-hit);--theme-topbar-background-color:var(--sky);--theme-topbar-item-color:var(--white);--theme-topbar-item-color-hover:var(--black);background:url("../../Img/april-fools-2022/assets/cloud.svg?v=817468d1c875") -2% 110px/118px auto no-repeat,url("../../Img/april-fools-2022/assets/cloud.svg?v=817468d1c875") 6% 260px/118px auto no-repeat,url("../../Img/april-fools-2022/assets/cloud.svg?v=817468d1c875") 101% 220px/118px auto no-repeat,url("../../Img/april-fools-2022/assets/cloud.svg?v=817468d1c875") 90% 110px/118px auto no-repeat,url("../../Img/april-fools-2022/assets/blocks-left.svg?v=e515c1d7c7d9") 0 calc(100% - var(--bar-height))/15% auto no-repeat,url("../../Img/april-fools-2022/assets/blocks-right.svg?v=ff2a999b5c52") 100% calc(100% - var(--bar-height))/15% auto no-repeat,var(--theme-background-color);background-attachment:fixed}body.theme-custom.theme-plumber *{-webkit-font-smoothing:none;image-rendering:pixelated}body.theme-custom.theme-plumber .s-topbar .s-user-card .-badges,body.theme-custom.theme-plumber .s-topbar--item .-badges *{color:inherit !important}body.theme-custom.theme-plumber .s-topbar--logo .-img._glyph{filter:invert(.5) brightness(2)}body.theme-custom.theme-plumber .s-topbar--logo:hover .-img._glyph{filter:invert(.5) brightness(0)}body.theme-custom.theme-plumber .s-btn__primary::before,body.theme-custom.theme-plumber .s-btn__filled::before{content:"";width:48px;height:48px;border-radius:100%;position:absolute;top:0;left:50%;transform:translateX(-50%);display:none;background:url("../../Img/april-fools-2022/assets/coin.png?v=ca0d5083f7c7") no-repeat;background-size:contain;image-rendering:pixelated}body.theme-custom.theme-plumber .s-btn__primary:hover::before,body.theme-custom.theme-plumber .s-btn__filled:hover::before{bottom:calc(100% + 4px);top:auto;display:block}body.theme-custom.theme-plumber #left-sidebar{background:var(--theme-content-background-color)}body.theme-custom.theme-plumber .nav-links .nav-links--link,body.theme-custom.theme-plumber .nav-links .nav-links--link:visited{color:var(--fc-medium)}body.theme-custom.theme-plumber .af-bar__big{background:url("../../Img/april-fools-2022/assets/brick.png?v=fed5f69efacc") repeat !important;border:0 !important;height:var(--bar-height)}body.theme-custom.theme-plumber .af-bar__big .af-author-container,body.theme-custom.theme-plumber .af-bar__big .af-logo-container,body.theme-custom.theme-plumber .af-bar__big .af-minimize-bar-container{background:rgba(0,0,0,0.5);border-radius:2px}body.theme-custom.theme-bookface{--theme-base-primary-color-h:221;--theme-base-primary-color-s:42.3%;--theme-base-primary-color-l:30.6%;--theme-base-primary-color-r:45;--theme-base-primary-color-g:66;--theme-base-primary-color-b:111;--theme-background-color:#eaebef;--theme-button-primary-background-color:#4e629d;--theme-footer-background-color:var(--theme-primary-color);--theme-footer-link-color:#cad6e2;--theme-footer-link-color-hover:#ffffff;--theme-footer-text-color:#cad6e2;--theme-footer-title-color:#a4ccf4;--theme-header-background-color:var(--theme-primary-color);--theme-header-link-color:var(--theme-primary-color);--theme-post-owner-background-color:#eeedf2;--theme-topbar-background-color:#3b5999;--theme-topbar-item-background-hover:var(--theme-primary-color);--theme-topbar-item-color:#1c3163;--theme-topbar-item-color-hover:#a8bcee;--theme-tag-background-color:#eeedf2}body.theme-custom.theme-bookface .s-topbar .s-user-card,body.theme-custom.theme-bookface .s-topbar .s-navigation .s-navigation--item{color:#fff}body.theme-custom.theme-bookface .s-topbar--logo .-img{filter:invert(.5) brightness(2)}body.theme-custom.theme-bookface .user-details a{color:#4a6cbd;font-weight:bold}body.theme-custom.theme-bookface .js-voting-container{color:#6b7179 !important}body.theme-custom.theme-bookface .af-bar{background:var(--theme-footer-background-color) !important;background-color:var(--black-800)}body.theme-custom.theme-bookface .af-theme-button{--af-btn-focus-outline-color:var(--white)}body.theme-custom.theme-3d{--theme-topbar-background-color:var(--theme-background-color);--theme-topbar-accent-border:none;--theme-topbar-item-color-hover:black}body.theme-custom.theme-3d img.s-avatar--image,body.theme-custom.theme-3d .gravatar-wrapper-24,body.theme-custom.theme-3d img{filter:grayscale(80%) brightness(1.75) drop-shadow(4px 0 0 red) drop-shadow(-4px 0 0 cyan) !important;opacity:.75}body.theme-custom.theme-3d svg,body.theme-custom.theme-3d .icon-bg,body.theme-custom.theme-3d .wmd-button,body.theme-custom.theme-3d input[type=radio],body.theme-custom.theme-3d input[type=checkbox]{filter:grayscale(80%) saturate(.1) drop-shadow(-4px 0 0 cyan) drop-shadow(4px 0 0 red)}body.theme-custom.theme-3d h1,body.theme-custom.theme-3d h2,body.theme-custom.theme-3d h3,body.theme-custom.theme-3d h4,body.theme-custom.theme-3d h5,body.theme-custom.theme-3d h6,body.theme-custom.theme-3d p,body.theme-custom.theme-3d a,body.theme-custom.theme-3d li,body.theme-custom.theme-3d span,body.theme-custom.theme-3d label,body.theme-custom.theme-3d button,body.theme-custom.theme-3d div,body.theme-custom.theme-3d input,body.theme-custom.theme-3d select,body.theme-custom.theme-3d textarea,body.theme-custom.theme-3d ::before,body.theme-custom.theme-3d ::after{text-overflow:clip;letter-spacing:3px;text-shadow:-3px 0 1px cyan,3px 0 1px red}body.theme-custom.theme-3d .s-topbar--logo .-img._glyph,body.theme-custom.theme-3d .site-footer--logo a{filter:grayscale(80%) saturate(.1) drop-shadow(4px 0 0 red) drop-shadow(-4px 0 0 cyan);opacity:.75}body.theme-custom.theme-3d .s-topbar--logo:hover{background-color:transparent}body.theme-custom.theme-3d .s-topbar--logo:hover .-img._glyph{opacity:1}body.theme-custom.theme-3d .site-footer--logo svg{filter:drop-shadow(-4px 0 0 cyan)}body.theme-custom.theme-3d .nav-links span,body.theme-custom.theme-3d .nav-links div,body.theme-custom.theme-3d .nav-links a,body.theme-custom.theme-3d .post-signature *,body.theme-custom.theme-3d .mdhelp-tabs *{letter-spacing:0 !important}body.theme-custom.theme-3d .af-bar *{filter:none !important;text-shadow:none !important;letter-spacing:initial !important;opacity:1}body.theme-custom.theme-3d .js-zone-container,body.theme-custom.theme-3d #hireme,body.theme-custom.theme-3d .mixed-site-content,body.theme-custom.theme-3d .js-consent-banner,body.theme-custom.theme-3d #onetrust-banner-sdk,body.theme-custom.theme-3d .js-zone-container *,body.theme-custom.theme-3d #hireme *,body.theme-custom.theme-3d .mixed-site-content *,body.theme-custom.theme-3d .js-consent-banner *,body.theme-custom.theme-3d #onetrust-banner-sdk *{filter:none !important;text-shadow:none !important;letter-spacing:initial !important;opacity:1}.vote-up-off,.vote-up-on,.vote-down-off,.vote-down-on{height:30px}.vote-down-off,.vote-down-on{margin-bottom:10px}.s-topbar .s-topbar--logo .-img{background-image:url("../../Img/unified/sprites.svg?v=fcc0ea44ba27")}#tabs a,.tabs a{position:relative;padding:13px 10px;background-color:var(--theme-content-background-color);border:1px solid transparent;font-size:12px}#tabs a:before,.tabs a:before{content:"";position:absolute;top:-1px;left:-1px;right:-1px;height:2px;background-color:transparent}#tabs a:focus,.tabs a:focus{background-color:var(--black-025);border-bottom-color:transparent}#tabs a:hover:not(.youarehere),.tabs a:hover:not(.youarehere),#tabs a:focus:not(.youarehere),.tabs a:focus:not(.youarehere){border-color:var(--black-075);border-bottom-color:transparent}#tabs a.youarehere,.tabs a.youarehere{padding-bottom:14px;font-weight:400;border-color:var(--black-075);border-bottom-color:transparent;cursor:default}#tabs a.youarehere:before,.tabs a.youarehere:before{background-color:var(--theme-primary-color)}#tabs a.external,.tabs a.external{color:var(--theme-link-color)}#tabs a.external:hover,.tabs a.external:hover{color:var(--theme-link-color-hover);border-color:transparent;border-bottom-color:var(--theme-primary-color);background-color:hsl(180,7%,97%);box-shadow:inset 0 -1px 0 0 hsl(0,0%,100%)}#tabs #tab-switch{display:inline-block;color:hsl(210,8%,45%);border:1px solid hsl(210,8%,85%);font-size:12px;padding:3px 6px;border-radius:2px;margin:7px auto 5px 5px;background-color:transparent;transition:all,.15s,ease}#tabs #tab-switch:hover{border-color:#bdcdd7}#sidebar h4{color:var(--black-700);font-size:1.46153846rem;font-weight:400}#sidebar .related,#sidebar .linked{font-size:13px}#sidebar .related a,#sidebar .linked a{font-size:13px}#sidebar .aside-cta{margin-bottom:1em;text-align:right}#sidebar #questions-count{display:flex;flex-flow:row nowrap;justify-content:space-between}#sidebar #questions-count .-main-cta{padding-left:20px}#sidebar #questions-count .-main-cta .btn{white-space:nowrap}.post-tag,.geo-tag,.container .chosen-choices .search-choice,.container .chosen-container-multi .chosen-choices li.search-choice{font-size:12px}.-flair>span:not(.reputation-score){margin-right:3px;margin-left:2px}.badge{transition:background .1s ease}.badge1,.badge2,.badge3{margin-right:3px;margin-left:2px;width:6px}.badge1{background-position:-102px -398px}.badge2{background-position:-82px -398px}.badge3{background-position:-62px -398px}.badgecount{padding-left:0}body:not(.unified-theme) .narrow .mini-counts{margin-bottom:2px}body:not(.unified-theme) .narrow .votes,body:not(.unified-theme) .narrow .status,body:not(.unified-theme) .narrow .views{padding:8px 5px;line-height:1}.narrow .status{color:var(--black-400)}.answered,.answered-accepted{border:1px solid transparent}.status.answered{border-color:var(--green-400)}.status.answered,.status.answered .mini-counts,.status.answered strong{color:var(--green-500)}.status.answered-accepted,.status.answered-accepted .mini-counts,.status.answered-accepted .minicounts span{color:hsl(0,0%,100%)}.status.unanswered .mini-counts span{color:inherit}body:not(.unified-theme) .question-summary{padding:12px 0;border-bottom:1px solid var(--black-075)}#question-header{display:flex;flex-flow:row nowrap;justify-content:space-between}#question-header .-main-cta{padding-left:20px}#question-header .-main-cta .btn{white-space:nowrap}#question-header .question-hyperlink{color:var(--black-700)}.comment-text,.flag-action-card-text{font-size:13px;line-height:1.4}input[type="text"]:not(.s-input):not(.s-textarea):focus,input[type="email"]:not(.s-input):not(.s-textarea):focus,input[type="password"]:not(.s-input):not(.s-textarea):focus,textarea:not(.s-input):not(.s-textarea):focus{outline:0;border:1px solid hsl(206,90%,69.5%)}input[type="text"]:not(.s-input),textarea:not(.wmd-input):not(.s-textarea),input[type="url"],input[type="datetime"],input[type="datetime-local"],input[type="date"],.tag-editor:not(.s-input){box-shadow:0 1px 2px hsla(210,8%,5%,0.1) inset}.error-page h1{margin-bottom:24px}.error-page p{font-size:1.15384615rem}html,body{min-width:1264px}html.html__unpinned-leftnav,html.html__unpinned-leftnav body{min-width:1100px}html.html__responsive,html.html__responsive body{min-width:auto}body{padding-top:50px}@media print{body{padding-top:0px}}body .s-topbar~.container,body .s-topbar~#announcement-banner{margin-top:0}body>.container{max-width:1264px;width:100%;background:none;display:flex;justify-content:space-between;margin:0 auto}html.html__unpinned-leftnav body>.container{max-width:1100px}body>.container:after,body>.container:before{display:none}body.floating-content>.container{justify-content:center;margin:0;background-color:var(--black-050)}body.floating-content>.container,html.html__unpinned-leftnav body.floating-content>.container{max-width:100%}body.floating-content>.container #left-sidebar{display:none}#content{max-width:1100px;width:calc(100% - 164px);background-color:var(--theme-content-background-color);border-radius:0;border:1px solid var(--theme-content-border-color);border-top-width:0;border-bottom-width:0;border-left-width:1px;border-right-width:0;padding:24px;box-sizing:border-box}@media screen and (max-width:640px){html.html__responsive #content{border-left:0;border-right:0}}@media print{#content{border-left:0;border-right:0}}body.theme-highcontrast #content{border-left:1px solid currentColor}html.html__unpinned-leftnav #content{width:100%}html.html__unpinned-leftnav #content{border-left-width:0}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) #content{padding-left:16px;padding-right:16px}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav #content{padding-left:16px;padding-right:16px}}@media print{#content{padding-left:16px;padding-right:16px}}@media screen and (max-width:640px){html.html__responsive #content{padding-left:12px;padding-right:12px;width:100%}}@media print{#content{padding-left:12px;padding-right:12px;width:100%}}body.floating-content #content{width:100%;max-width:1264px;margin:0;background-color:transparent;border-left:0;border-right:0}#sidebar,.sidebar{margin-left:24px}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) #sidebar,html.html__responsive:not(.html__unpinned-leftnav) .sidebar{float:none;clear:both;margin:0 auto;width:100%}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav #sidebar,html.html__responsive.html__unpinned-leftnav .sidebar{float:none;clear:both;margin:0 auto;width:100%}}@media print{#sidebar,.sidebar{float:none;clear:both;margin:0 auto;width:100%}}.site-footer.site-footer--container,.site-footer.site-footer--extra{max-width:1264px}body>.container.container__full{max-width:100%}body>.container.container__full .left-sidebar{display:none}body>.container.container__full #content{padding:0;max-width:100%}body>.container .container--inner{max-width:1264px;padding:0 24px;margin:0 auto}#mainbar,.mainbar{width:calc(100% - 300px - 24px)}#mainbar.ask-mainbar,.mainbar.ask-mainbar{width:calc(100% - 365px - 24px)}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) #mainbar,html.html__responsive:not(.html__unpinned-leftnav) .mainbar{width:100%;float:none}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav #mainbar,html.html__responsive.html__unpinned-leftnav .mainbar{width:100%;float:none}}@media print{#mainbar,.mainbar{width:100%;float:none}}#questions,#answers{width:auto;float:none}.answer,.post-editor,#answers-header{width:100%}.subheader{box-sizing:content-box}.site-header{box-sizing:border-box;background-color:var(--theme-header-background-color);background-image:none;background-position:var(--theme-header-background-position);background-repeat:var(--theme-header-background-repeat);background-size:var(--theme-header-background-size);border-bottom:var(--theme-header-background-border-bottom)}.site-header .site-header--container{width:100%;min-height:70px;max-width:1264px;margin:0 auto;padding:0 8px;display:flex;align-items:center;justify-content:space-between;background-color:var(--theme-header-foreground-color);background-image:none;background-position:var(--theme-header-foreground-position);background-repeat:var(--theme-header-foreground-repeat);background-size:var(--theme-header-foreground-size)}html.html__unpinned-leftnav .site-header .site-header--container{max-width:1100px}body.floating-content .site-header .site-header--container,html.html__unpinned-leftnav body.floating-content .site-header .site-header--container{max-width:1264px}@media screen and (max-width:640px){html.html__responsive .site-header .site-header--container{background-image:none}}@media print{.site-header .site-header--container{background-image:none}}.site-header .site-header--link{color:var(--theme-header-link-color)}.site-header .site-header--sponsored{color:var(--theme-header-sponsored-color);font-size:10px}.s-banner button,.s-banner a{text-decoration:underline}.s-banner button:hover,.s-banner a:hover{text-decoration:underline}.s-banner__danger button,.s-banner__danger a{color:white}.s-banner__danger button:hover,.s-banner__danger a:hover{color:white}.left-sidebar{width:164px;flex-shrink:0;z-index:1000;box-shadow:0 0 0 hsla(210,8%,5%,0.05);transition:box-shadow ease-in-out .1s,transform ease-in-out .1s;transform:translateZ(0)}.left-sidebar,.left-sidebar *,.left-sidebar *:after,.left-sidebar *:before{box-sizing:border-box}.left-sidebar .nav{position:sticky;position:-webkit-sticky;position:-moz-sticky;top:24px;padding-bottom:12px}.left-sidebar .-label{font-weight:bold;padding-left:12px;color:var(--black-400);padding-bottom:4px;font-size:12px}.left-sidebar--sticky-container{position:fixed;width:164px;padding-top:24px}@supports (position: sticky) or (position: -webkit-sticky){.left-sidebar--sticky-container:not(.left-sidebar__fake-sticky){position:-webkit-sticky;position:sticky;width:auto;top:0;margin-bottom:8px;max-height:calc(100vh);overflow-y:auto;scrollbar-color:var(--scrollbar) transparent;top:var(--top-bar-allocated-space);max-height:calc(100vh - var(--top-bar-allocated-space))}.left-sidebar--sticky-container:not(.left-sidebar__fake-sticky)::-webkit-scrollbar{width:10px;height:10px;background-color:transparent}.left-sidebar--sticky-container:not(.left-sidebar__fake-sticky)::-webkit-scrollbar-track{border-radius:10px;background-color:transparent}.left-sidebar--sticky-container:not(.left-sidebar__fake-sticky)::-webkit-scrollbar-thumb{border-radius:10px;background-color:var(--scrollbar)}.left-sidebar--sticky-container:not(.left-sidebar__fake-sticky)::-webkit-scrollbar-corner{background-color:transparent;border-color:transparent}html.html__unpinned-leftnav .left-sidebar--sticky-container:not(.left-sidebar__fake-sticky){max-height:calc(100vh - 50px)}}.leftnav-dialog .left-sidebar--sticky-container{position:static;width:auto}html.html__unpinned-leftnav .container .left-sidebar{display:none}.activity-indicator{width:10px;height:10px}.nav-links{padding:0;margin:0 0 12px;list-style:none}.nav-links .nav-links--link{display:block;padding:4px;padding-left:30px;line-height:2;font-size:13px}.nav-links .nav-links--link,.nav-links .nav-links--link:visited{color:var(--black-600)}.nav-links .nav-links--link:hover,.nav-links .nav-links--link:focus,.nav-links .nav-links--link:active{color:var(--black-900)}.nav-links .nav-links--link.-link__with-icon{display:flex;padding:8px 6px 8px 0}.nav-links .nav-links--link.-link__with-icon .svg-icon{flex-shrink:0;margin-top:-1px;margin-right:4px;color:var(--black-400)}.nav-links .nav-links--link.-link__with-icon:hover .svg-icon,.nav-links .nav-links--link.-link__with-icon:focus .svg-icon,.nav-links .nav-links--link.-link__with-icon:active .svg-icon{color:var(--black-900)}.nav-links .nav-links--link .-link--channel-name{line-height:1.30769231}.nav-links .youarehere .nav-links--link{font-weight:bold;background:var(--black-050);color:var(--black-900);border-right:3px solid var(--theme-primary-color)}.nav-links .youarehere .nav-links--link .svg-icon{color:var(--black-900)}.left-sidebar-improvements .nav-links .nav-links--link{padding-left:30px}.left-sidebar-toggle{display:none;padding-top:3px;height:100%;width:44px;flex-shrink:0}.left-sidebar-toggle span{width:18px;height:2px;background-color:var(--black-400)}.left-sidebar-toggle span:before,.left-sidebar-toggle span:after{position:absolute;content:'';width:18px;height:2px;left:0;background:var(--black-400);top:-5px;transition:all ease-in-out .1s}.left-sidebar-toggle span:after{top:5px}@media screen and (max-width:640px){html.html__responsive .left-sidebar-toggle{display:flex}}@media print{.left-sidebar-toggle{display:flex}}html.html__unpinned-leftnav .left-sidebar-toggle{display:flex}.left-sidebar-toggle.topbar-icon-on span{background-color:transparent}.left-sidebar-toggle.topbar-icon-on span:before,.left-sidebar-toggle.topbar-icon-on span:after{top:0;transform:rotate(-45deg)}.left-sidebar-toggle.topbar-icon-on span:after{transform:rotate(45deg)}.flush-left{margin-left:-24px;border-top:1px solid var(--black-100)}body.theme-highcontrast .flush-left{border-top-color:currentColor}.flush-left .question-summary{width:100%;padding-left:8px;box-sizing:border-box}.flush-left .flush-left,.flush-left .mixed-question-list{border-top:none}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) .flush-left{margin-left:-16px;margin-right:-16px;width:calc(100% + 2*16px)}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav .flush-left{margin-left:-16px;margin-right:-16px;width:calc(100% + 2*16px)}}@media print{.flush-left{margin-left:-16px;margin-right:-16px;width:calc(100% + 2*16px)}}@media screen and (max-width:640px){html.html__responsive .flush-left{margin-left:-12px;margin-right:-12px;width:calc(100% + 2*12px)}}@media print{.flush-left{margin-left:-12px;margin-right:-12px;width:calc(100% + 2*12px)}}.question-summary{display:flex;padding:12px 8px;float:none;width:100%}.question-summary .stats,.question-summary .stats+.views{margin-left:0}.question-summary h3,.question-summary .excerpt{overflow-wrap:break-word;word-wrap:break-word;word-break:break-word}.statscontainer{margin-right:16px;width:58px;float:none}.summary,.narrow .summary{flex:1 auto;width:auto;float:none;margin:0;overflow:hidden}.cp,.narrow .cp{float:none;display:flex;flex-wrap:nowrap;align-items:flex-start;margin-right:0;padding:0 8px 0 0;box-sizing:content-box;flex-shrink:0}.narrow .started{white-space:normal}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav) #tabs a,html.html__responsive:not(.html__unpinned-leftnav) .tabs a{margin-right:0;padding-left:8px;padding-right:8px}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav #tabs a,html.html__responsive.html__unpinned-leftnav .tabs a{margin-right:0;padding-left:8px;padding-right:8px}}@media print{#tabs a,.tabs a{margin-right:0;padding-left:8px;padding-right:8px}}._with-left-nav~.container .col-sidebar{margin-right:32px}.user-page ._with-left-nav~.container .settings-page{margin:0 0 0 32px !important}#add-login-page,#login-page,#signup-page{box-sizing:content-box}.fc-theme-body-font{color:var(--theme-body-font-color) !important}.timeline-wrapper .timeline{width:798px}.timeline-wrapper .timeline-sidebar{margin-left:24px}.user-page .row{max-width:1100px}#profile-side{margin-right:24px}*[data-can-be]{display:none}@media screen and (max-width:640px){html.html__responsive  *[data-is-here-when]:not([data-is-here-when~="sm"]){display:none}}@media print{*[data-is-here-when]:not([data-is-here-when~="sm"]){display:none}}@media screen and (max-width:980px) and (min-width:640.1px){html.html__responsive:not(.html__unpinned-leftnav)  *[data-is-here-when]:not([data-is-here-when~="md"]){display:none}}@media screen and (max-width:816px) and (min-width:640.1px){html.html__responsive.html__unpinned-leftnav  *[data-is-here-when]:not([data-is-here-when~="md"]){display:none}}@media screen and (min-width:980.1px){html.html__responsive:not(.html__unpinned-leftnav)  *[data-is-here-when]:not([data-is-here-when~="lg"]){display:none}}@media screen and (min-width:816.1px){html.html__responsive.html__unpinned-leftnav  *[data-is-here-when]:not([data-is-here-when~="lg"]){display:none}}@media screen and (max-width:640px){html.html__responsive  .statscontainer{margin-left:0;margin-right:12px}html.html__responsive  .question-summary{padding-left:12px !important;padding-right:12px !important}html.html__responsive  .question-summary.narrow{flex-direction:column}html.html__responsive  .narrow .cp{width:100%;float:none;padding-bottom:8px !important;padding-left:0 !important;padding-right:0 !important}html.html__responsive  .narrow .votes,html.html__responsive  .narrow .status,html.html__responsive  .narrow .views{padding:4px 0;line-height:1;box-sizing:border-box;width:auto;height:auto;border-radius:3px;min-width:auto;text-align:left;margin:0 4px 0 0}html.html__responsive  .narrow .votes>div,html.html__responsive  .narrow .status>div,html.html__responsive  .narrow .views>div{display:inline-block;font-size:12px;margin-bottom:0}html.html__responsive  .narrow .votes>div.mini-counts,html.html__responsive  .narrow .status>div.mini-counts,html.html__responsive  .narrow .views>div.mini-counts{font-weight:bold}html.html__responsive  .narrow .status{margin-top:-1px;padding:4px 8px}html.html__responsive  .narrow .summary{width:100%;float:none}}@media print{.statscontainer{margin-left:0;margin-right:12px}.question-summary{padding-left:12px !important;padding-right:12px !important}.question-summary.narrow{flex-direction:column}.narrow .cp{width:100%;float:none;padding-bottom:8px !important;padding-left:0 !important;padding-right:0 !important}.narrow .votes,.narrow .status,.narrow .views{padding:4px 0;line-height:1;box-sizing:border-box;width:auto;height:auto;border-radius:3px;min-width:auto;text-align:left;margin:0 4px 0 0}.narrow .votes>div,.narrow .status>div,.narrow .views>div{display:inline-block;font-size:12px;margin-bottom:0}.narrow .votes>div.mini-counts,.narrow .status>div.mini-counts,.narrow .views>div.mini-counts{font-weight:bold}.narrow .status{margin-top:-1px;padding:4px 8px}.narrow .summary{width:100%;float:none}}html.html__responsive  .everyoneloves__top-leaderboard,html.html__responsive  .everyoneloves__mid-leaderboard,html.html__responsive  .everyoneloves__mid-second-leaderboard,html.html__responsive  .everyoneloves__bot-mid-leaderboard,html.html__responsive  .everyoneloves__tag-sponsorship{margin-left:0}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__inline-sidebar{display:block;width:300px}html.html__responsive:not(.html__unpinned-leftnav)  .zone-container-responsive{display:block}html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__top-sidebar{display:none}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav  .everyoneloves__inline-sidebar{display:block;width:300px}html.html__responsive.html__unpinned-leftnav  .zone-container-responsive{display:block}html.html__responsive.html__unpinned-leftnav  .everyoneloves__top-sidebar{display:none}}@media print{.everyoneloves__inline-sidebar{display:block;width:300px}.zone-container-responsive{display:block}.everyoneloves__top-sidebar{display:none}}@media screen and (max-width:1280px){html.html__responsive:not(.html__unpinned-leftnav)  .zone-container-main,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__top-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__mid-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__mid-second-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__bot-mid-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__tag-sponsorship{display:none}}@media screen and (max-width:1116px){html.html__responsive.html__unpinned-leftnav  .zone-container-main,html.html__responsive.html__unpinned-leftnav  .everyoneloves__top-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__mid-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__mid-second-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__bot-mid-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__tag-sponsorship{display:none}}@media print{.zone-container-main,.everyoneloves__top-leaderboard,.everyoneloves__mid-leaderboard,.everyoneloves__mid-second-leaderboard,.everyoneloves__bot-mid-leaderboard,.everyoneloves__tag-sponsorship{display:none}}@media screen and (max-width:980px){html.html__responsive:not(.html__unpinned-leftnav)  .zone-container-main,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__top-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__mid-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__sec-mid-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__bot-mid-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__tag-sponsorship{display:block}}@media screen and (max-width:816px){html.html__responsive.html__unpinned-leftnav  .zone-container-main,html.html__responsive.html__unpinned-leftnav  .everyoneloves__top-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__mid-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__sec-mid-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__bot-mid-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__tag-sponsorship{display:block}}@media print{.zone-container-main,.everyoneloves__top-leaderboard,.everyoneloves__mid-leaderboard,.everyoneloves__sec-mid-leaderboard,.everyoneloves__bot-mid-leaderboard,.everyoneloves__tag-sponsorship{display:block}}@media screen and (max-width:940px){html.html__responsive:not(.html__unpinned-leftnav)  .zone-container-main,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__top-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__mid-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__sec-mid-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__bot-mid-leaderboard,html.html__responsive:not(.html__unpinned-leftnav)  .everyoneloves__tag-sponsorship{display:none}}@media screen and (max-width:776px){html.html__responsive.html__unpinned-leftnav  .zone-container-main,html.html__responsive.html__unpinned-leftnav  .everyoneloves__top-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__mid-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__sec-mid-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__bot-mid-leaderboard,html.html__responsive.html__unpinned-leftnav  .everyoneloves__tag-sponsorship{display:none}}@media print{.zone-container-main,.everyoneloves__top-leaderboard,.everyoneloves__mid-leaderboard,.everyoneloves__sec-mid-leaderboard,.everyoneloves__bot-mid-leaderboard,.everyoneloves__tag-sponsorship{display:none}}@media screen and (min-width:1050px){.wide\:bg-image-ask-v2{background-image:url('../../Img/ask/background.svg?v=2e9a8205b368')}.wide\:h-ask-v2-background{height:130px}}.subcommunity-selected-tab{border-top-width:1px !important;border-top-color:transparent !important;border-left-width:1px !important;border-left-color:transparent !important;border-right-width:1px !important;border-right-color:transparent !important}.subcommunity-selected-tab:before{content:" ";width:0;height:0;border-left:8px solid transparent;border-right:8px solid transparent;border-top:8px solid var(--orange-400);left:50%;margin-left:-4px;position:absolute;top:100%}.themed.subcommunity-intel{--theme-base-primary-color-h:206.86567164;--theme-base-primary-color-s:100%;--theme-base-primary-color-l:26.2745098%;--theme-base-primary-color-r:0;--theme-base-primary-color-g:74;--theme-base-primary-color-b:134;--theme-dark-primary-color-h:192.80632411;--theme-dark-primary-color-s:100%;--theme-dark-primary-color-l:49.60784314%;--theme-dark-primary-color-r:0;--theme-dark-primary-color-g:199;--theme-dark-primary-color-b:253}.themed.subcommunity-audiobubble{--theme-base-primary-color-h:196.02094241;--theme-base-primary-color-s:80.5907173%;--theme-base-primary-color-l:53.52941176%;--theme-base-primary-color-r:41;--theme-base-primary-color-g:181;--theme-base-primary-color-b:232;--theme-dark-primary-color-h:16.02094241;--theme-dark-primary-color-s:80.5907173%;--theme-dark-primary-color-l:46.47058824%;--theme-dark-primary-color-r:214;--theme-dark-primary-color-g:74;--theme-dark-primary-color-b:23}.themed.subcommunity-google-cloud{--theme-base-primary-color-h:220.85889571;--theme-base-primary-color-s:66.53061224%;--theme-base-primary-color-l:51.96078431%;--theme-base-primary-color-r:51;--theme-base-primary-color-g:103;--theme-base-primary-color-b:214;--theme-dark-primary-color-h:0;--theme-dark-primary-color-s:0%;--theme-dark-primary-color-l:100%;--theme-dark-primary-color-r:255;--theme-dark-primary-color-g:255;--theme-dark-primary-color-b:255}.themed.subcommunity-go{--theme-base-primary-color-h:210;--theme-base-primary-color-s:28.84615385%;--theme-base-primary-color-l:20.39215686%;--theme-base-primary-color-r:37;--theme-base-primary-color-g:52;--theme-base-primary-color-b:67;--theme-dark-primary-color-h:191.27819549;--theme-dark-primary-color-s:69.63350785%;--theme-dark-primary-color-l:62.54901961%;--theme-dark-primary-color-r:93;--theme-dark-primary-color-g:201;--theme-dark-primary-color-b:226}.themed.subcommunity-gitlab{--theme-base-primary-color-h:264.80769231;--theme-base-primary-color-s:80%;--theme-base-primary-color-l:25.49019608%;--theme-base-primary-color-r:56;--theme-base-primary-color-g:13;--theme-base-primary-color-b:117;--theme-dark-primary-color-h:35.06849315;--theme-dark-primary-color-s:97.33333333%;--theme-dark-primary-color-l:55.88235294%;--theme-dark-primary-color-r:252;--theme-dark-primary-color-g:161;--theme-dark-primary-color-b:33}.themed.subcommunity-twilio{--theme-base-primary-color-h:352.92307692;--theme-base-primary-color-s:88.23529412%;--theme-base-primary-color-l:56.66666667%;--theme-base-primary-color-r:242;--theme-base-primary-color-g:47;--theme-base-primary-color-b:70;--theme-dark-primary-color-h:209.41176471;--theme-dark-primary-color-s:100%;--theme-dark-primary-color-l:80%;--theme-dark-primary-color-r:153;--theme-dark-primary-color-g:205;--theme-dark-primary-color-b:255}.subcommunity-avatar.s-avatar{background-image:url('Img/subcommunities/generic.svg?v=d212b4bfb0de')}@media (prefers-color-scheme:dark){body.theme-system  .subcommunity-avatar.s-avatar{background-image:url('Img/subcommunities/generic-dark.svg?v=afc23eaab8a5')}}body.theme-dark  .subcommunity-avatar.s-avatar,.theme-dark__forced  .subcommunity-avatar.s-avatar{background-image:url('Img/subcommunities/generic-dark.svg?v=afc23eaab8a5')}.subcommunity-background{background-image:url('Img/subcommunities/default-header.png?v=2578f8c2036f')}.subcommunity-intel.s-avatar{background-image:url('Img/subcommunities/intel.svg?v=0371bf2f3b96')}.subcommunity-intel.subcommunity-background{background-image:url('Img/subcommunities/intel-header.jpg?v=5df15f21a51e')}@media only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min--moz-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.subcommunity-intel.subcommunity-background{background:url('Img/subcommunities/intel-header.jpg?v=5df15f21a51e') no-repeat top left;background-size:1056px 256px}}@media (prefers-color-scheme:dark){body.theme-system  .subcommunity-intel.s-avatar{background-image:url('Img/subcommunities/intel-dark.svg?v=72ff93f7d507')}}body.theme-dark  .subcommunity-intel.s-avatar,.theme-dark__forced  .subcommunity-intel.s-avatar{background-image:url('Img/subcommunities/intel-dark.svg?v=72ff93f7d507')}.subcommunity-audiobubble.s-avatar{background-image:url('Img/subcommunities/audiobubble.svg?v=ae2f1f659f62')}.subcommunity-audiobubble.subcommunity-background{background-image:url('Img/subcommunities/default-header.png?v=2578f8c2036f')}@media only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min--moz-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.subcommunity-audiobubble.subcommunity-background{background:url('Img/subcommunities/default-header@2x.png?v=c3407e66edc0') no-repeat top left;background-size:1056px 256px}}@media (prefers-color-scheme:dark){body.theme-system  .subcommunity-audiobubble.s-avatar{background-image:url('Img/subcommunities/audiobubble-dark.svg?v=879efc1e2c3b')}}body.theme-dark  .subcommunity-audiobubble.s-avatar,.theme-dark__forced  .subcommunity-audiobubble.s-avatar{background-image:url('Img/subcommunities/audiobubble-dark.svg?v=879efc1e2c3b')}.subcommunity-google-cloud.s-avatar{background-image:url('Img/subcommunities/google-cloud.svg?v=5d10e4a96c5b')}.subcommunity-google-cloud.subcommunity-background{background-image:url('Img/subcommunities/default-header.png?v=2578f8c2036f')}@media only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min--moz-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.subcommunity-google-cloud.subcommunity-background{background:url('Img/subcommunities/default-header@2x.png?v=c3407e66edc0') no-repeat top left;background-size:1056px 256px}}@media (prefers-color-scheme:dark){body.theme-system  .subcommunity-google-cloud.s-avatar{background-image:url('Img/subcommunities/google-cloud-dark.svg?v=5d10e4a96c5b')}}body.theme-dark  .subcommunity-google-cloud.s-avatar,.theme-dark__forced  .subcommunity-google-cloud.s-avatar{background-image:url('Img/subcommunities/google-cloud-dark.svg?v=5d10e4a96c5b')}.subcommunity-go.s-avatar{background-image:url('Img/subcommunities/go.svg?v=4a0ccd527283')}.subcommunity-go.subcommunity-background{background-image:url('Img/subcommunities/go-header.jpg?v=d1c1d1b3d6c3')}@media only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min--moz-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.subcommunity-go.subcommunity-background{background:url('Img/subcommunities/go-header.jpg?v=d1c1d1b3d6c3') no-repeat top left;background-size:1056px 256px}}@media (prefers-color-scheme:dark){body.theme-system  .subcommunity-go.s-avatar{background-image:url('Img/subcommunities/go-dark.svg?v=ee6a739f1c3a')}}body.theme-dark  .subcommunity-go.s-avatar,.theme-dark__forced  .subcommunity-go.s-avatar{background-image:url('Img/subcommunities/go-dark.svg?v=ee6a739f1c3a')}.subcommunity-gitlab.s-avatar{background-image:url('Img/subcommunities/gitlab.svg?v=eec07a1769d1')}.subcommunity-gitlab.subcommunity-background{background-image:url('Img/subcommunities/gitlab-header.png?v=a89ab0043f4e')}@media only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min--moz-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.subcommunity-gitlab.subcommunity-background{background:url('Img/subcommunities/gitlab-header.png?v=a89ab0043f4e') no-repeat top left;background-size:1056px 256px}}@media (prefers-color-scheme:dark){body.theme-system  .subcommunity-gitlab.s-avatar{background-image:url('Img/subcommunities/gitlab-dark.svg?v=eec07a1769d1')}}body.theme-dark  .subcommunity-gitlab.s-avatar,.theme-dark__forced  .subcommunity-gitlab.s-avatar{background-image:url('Img/subcommunities/gitlab-dark.svg?v=eec07a1769d1')}.subcommunity-twilio.s-avatar{background-image:url('Img/subcommunities/twilio.svg?v=ab07490da974')}.subcommunity-twilio.subcommunity-background{background-image:url('Img/subcommunities/twilio-header.png?v=07a8e45752d6')}@media only screen and (-webkit-min-device-pixel-ratio:1.5),only screen and (min--moz-device-pixel-ratio:1.5),only screen and (min-device-pixel-ratio:1.5){.subcommunity-twilio.subcommunity-background{background:url('Img/subcommunities/twilio-header.png?v=07a8e45752d6') no-repeat top left;background-size:1056px 256px}}@media (prefers-color-scheme:dark){body.theme-system  .subcommunity-twilio.s-avatar{background-image:url('Img/subcommunities/twilio-dark.svg?v=ecd751ea2049')}}body.theme-dark  .subcommunity-twilio.s-avatar,.theme-dark__forced  .subcommunity-twilio.s-avatar{background-image:url('Img/subcommunities/twilio-dark.svg?v=ecd751ea2049')}
+@media (prefers-color-scheme:dark) {}
+
+@media (prefers-color-scheme:dark) {}
+
+body {
+    --theme-base-primary-color-h: 27;
+    --theme-base-primary-color-s: 90%;
+    --theme-base-primary-color-l: 55%;
+    --theme-base-primary-color-r: 243.525;
+    --theme-base-primary-color-g: 129.9225;
+    --theme-base-primary-color-b: 36.975;
+    --theme-button-color: var(--blue-600);
+    --theme-button-hover-color: var(--blue-700);
+    --theme-button-hover-background-color: var(--blue-050);
+    --theme-button-active-background-color: var(--blue-100);
+    --theme-button-selected-color: var(--blue-900);
+    --theme-button-selected-background-color: var(--blue-200);
+    --theme-button-filled-color: var(--powder-700);
+    --theme-button-filled-background-color: var(--powder-100);
+    --theme-button-filled-border-color: var(--powder-500);
+    --theme-button-filled-hover-color: var(--powder-800);
+    --theme-button-filled-hover-background-color: var(--powder-300);
+    --theme-button-filled-active-background-color: var(--powder-400);
+    --theme-button-filled-active-border-color: var(--powder-600);
+    --theme-button-filled-selected-color: var(--powder-900);
+    --theme-button-filled-selected-background-color: var(--powder-500);
+    --theme-button-filled-selected-border-color: var(--powder-700);
+    --theme-button-outlined-border-color: var(--blue-400);
+    --theme-button-outlined-selected-border-color: var(--blue-600);
+    --theme-button-primary-background-color: var(--blue-500);
+    --theme-button-primary-hover-background-color: var(--blue-600);
+    --theme-button-primary-active-background-color: var(--blue-700);
+    --theme-button-primary-selected-background-color: var(--blue-800);
+    --theme-background-color: var(--white);
+    --theme-background-position: top left;
+    --theme-background-repeat: repeat;
+    --theme-background-size: auto;
+    --theme-background-attachment: auto;
+    --theme-content-background-color: var(--white);
+    --theme-content-border-color: var(--black-100);
+    --theme-header-background-color: var(--theme-primary-color);
+    --theme-header-background-position: center left;
+    --theme-header-background-repeat: repeat;
+    --theme-header-background-size: auto;
+    --theme-header-background-border-bottom: 0;
+    --theme-header-link-color: var(--theme-primary-color);
+    --theme-header-sponsored-color: hsla(0, 0%, 100%, 0.4);
+    --theme-header-foreground-color: transparent;
+    --theme-header-foreground-position: bottom right;
+    --theme-header-foreground-repeat: no-repeat;
+    --theme-header-foreground-size: auto;
+    --theme-footer-background-color: hsl(210, 8%, 15%);
+    --theme-footer-background-position: top left;
+    --theme-footer-background-repeat: no-repeat;
+    --theme-footer-background-size: auto;
+    --theme-footer-background-border-top: 0;
+    --theme-footer-title-color: hsl(210, 8%, 75%);
+    --theme-footer-text-color: hsl(210, 8%, 45%);
+    --theme-footer-link-color: hsl(210, 8%, 55%);
+    --theme-footer-link-color-hover: hsl(210, 8%, 65%);
+    --theme-footer-link-color-active: hsl(27, 90%, 55%);
+    --theme-footer-link-caret-color: var(--theme-footer-background-color);
+    --theme-footer-divider-color: hsl(210, 8%, 25%);
+    --theme-footer-padding-top: 0;
+    --theme-footer-padding-bottom: 0;
+    --theme-link-color: var(--blue-600);
+    --theme-link-color-hover: var(--blue-500);
+    --theme-link-color-visited: var(--blue-700);
+    --theme-tag-color: var(--powder-700);
+    --theme-tag-background-color: var(--powder-100);
+    --theme-tag-border-color: transparent;
+    --theme-tag-hover-color: var(--powder-800);
+    --theme-tag-hover-background-color: var(--powder-200);
+    --theme-tag-hover-border-color: transparent;
+    --theme-body-font-family: var(--ff-sans);
+    --theme-body-font-color: var(--black-800);
+    --theme-post-title-font-family: var(--ff-sans);
+    --theme-post-title-color: var(--theme-link-color);
+    --theme-post-title-color-hover: var(--theme-link-color-hover);
+    --theme-post-title-color-visited: var(--theme-link-color-visited);
+    --theme-post-body-font-family: var(--ff-sans);
+    --theme-post-owner-background-color: var(--theme-secondary-075);
+    --theme-post-owner-new-background-color: var(--powder-200)
+}
+
+html, body {
+    color: var(--theme-body-font-color);
+    font-family: var(--theme-body-font-family);
+    font-size: 13px;
+    line-height: 1.30769231
+}
+
+@media (max-width:640px) {
+    html.html__responsive:not(.html__unpinned-leftnav), html.html__responsive:not(.html__unpinned-leftnav) body {
+        font-size: 11px
+    }
+}
+
+@media (max-width:640px) {
+    html.html__responsive.html__unpinned-leftnav, html.html__responsive.html__unpinned-leftnav body {
+        font-size: 11px
+    }
+}
+
+body {
+    box-sizing: border-box;
+    min-height: 100%;
+    background-color: var(--white)
+}
+
+body *, body *:before, body *:after {
+    box-sizing: inherit
+}
+
+.s-banner__body-pt {
+    padding-top: 93px
+}
+
+.s-banner {
+    position: fixed;
+    z-index: 5049;
+    top: 0;
+    right: 0;
+    left: 0;
+    width: 100%;
+    padding: 12px;
+    border-top: 1px solid transparent;
+    border-bottom: 1px solid transparent;
+    border-radius: 0;
+    box-shadow: none;
+    color: var(--fc-medium);
+    font-size: 13px
+}
+
+.s-banner[aria-hidden="true"] {
+    visibility: hidden;
+    opacity: 0;
+    -webkit-transform: translate3d(0, -50px, 0);
+    transform: translate3d(0, -50px, 0)
+}
+
+.s-banner[aria-hidden="false"] {
+    visibility: visible;
+    opacity: 1;
+    -webkit-transform: translate3d(0, 49px, 0);
+    transform: translate3d(0, 49px, 0)
+}
+
+.s-banner.is-pinned {
+    z-index: 5051;
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0)
+}
+
+.s-banner.s-banner__important {
+    border-color: transparent;
+    color: var(--white)
+}
+
+.s-banner--container {
+    position: relative;
+    width: 100%;
+    max-width: 1060px;
+    margin: 0 auto
+}
+
+.s-btn {
+    position: relative;
+    display: inline-block;
+    padding: .8em;
+    color: var(--theme-button-color);
+    border: 1px solid transparent;
+    border-radius: 3px;
+    background-color: transparent;
+    outline: none;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: normal;
+    line-height: 1.15384615;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+    user-select: none
+}
+
+body.theme-highcontrast .s-btn {
+    border-color: currentColor
+}
+
+body.theme-highcontrast .s-btn:not(.s-btn__link):not(.s-btn__unset) {
+    text-decoration: none
+}
+
+button .s-btn, button[type="submit"] .s-btn, button[type="reset"] .s-btn {
+    -webkit-appearance: button
+}
+
+.s-btn.grid {
+    display: flex
+}
+
+.s-btn:hover, .s-btn:focus, .s-btn:active {
+    color: var(--theme-button-hover-color);
+    background: var(--theme-button-hover-background-color);
+    text-decoration: none
+}
+
+.s-btn:active {
+    background: var(--theme-button-active-background-color)
+}
+
+.s-btn:focus {
+    outline: none;
+    box-shadow: 0 0 0 4px var(--focus-ring)
+}
+
+.s-btn[disabled] {
+    opacity: .5;
+    pointer-events: none;
+    box-shadow: none !important
+}
+
+.s-btn.is-selected {
+    color: var(--theme-button-selected-color);
+    background: var(--theme-button-selected-background-color);
+    box-shadow: none
+}
+
+.s-btn.is-selected:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring)
+}
+
+.s-btn.s-btn__dropdown {
+    padding-right: 2em
+}
+
+.s-btn.s-btn__dropdown:after {
+    content: "";
+    position: absolute;
+    z-index: 30;
+    top: calc(50% - 2px);
+    right: .8em;
+    border-style: solid;
+    border-width: 4px;
+    border-top-width: 4px;
+    border-bottom-width: 0;
+    border-color: currentColor transparent;
+    pointer-events: none
+}
+
+.s-btn.s-btn__xs {
+    padding: .6em;
+    font-size: 11px
+}
+
+.s-btn.s-btn__xs.s-btn__dropdown {
+    padding-right: 1.5em
+}
+
+.s-btn.s-btn__xs.s-btn__dropdown:after {
+    top: calc(50% - 2px);
+    right: .6em;
+    border-width: 3px;
+    border-top-width: 3px;
+    border-bottom-width: 0
+}
+
+.s-btn.s-btn__sm {
+    font-size: 12px
+}
+
+.s-btn.s-btn__sm.s-btn__dropdown {
+    padding-right: 2.05em
+}
+
+.s-btn.s-btn__md {
+    padding: .7em;
+    border-radius: 4px;
+    font-size: 1.30769231rem
+}
+
+.s-btn.s-btn__md.s-btn__dropdown {
+    padding-right: 1.8em
+}
+
+.s-btn.s-btn__md.s-btn__dropdown:after {
+    top: calc(50% - 2px);
+    right: .7em;
+    border-width: 5px;
+    border-top-width: 5px;
+    border-bottom-width: 0
+}
+
+.s-btn .s-btn--badge {
+    opacity: .5;
+    display: inline-block;
+    border-radius: 3px;
+    padding: 2px 3px;
+    font-size: 12px;
+    line-height: 1;
+    background-color: currentColor
+}
+
+body.theme-highcontrast .s-btn .s-btn--badge {
+    opacity: .8
+}
+
+.s-btn .s-btn--number {
+    color: var(--white)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-btn__primary:not(.is-selected) .s-btn--number, body.theme-system .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number {
+        color: var(--white)
+    }
+}
+
+body.theme-dark .s-btn__primary:not(.is-selected) .s-btn--number, body.theme-dark .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number, .theme-dark__forced .s-btn__primary:not(.is-selected) .s-btn--number, .theme-dark__forced .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number {
+    color: var(--white)
+}
+
+body.theme-highcontrast .s-btn__primary:not(.is-selected) .s-btn--number, body.theme-highcontrast .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number {
+    color: var(--black)
+}
+
+.s-btn__outlined {
+    border-color: var(--theme-button-outlined-border-color)
+}
+
+.s-btn__outlined.is-selected {
+    border-color: var(--theme-button-outlined-selected-border-color)
+}
+
+.s-btn__filled {
+    color: var(--theme-button-filled-color);
+    background-color: var(--theme-button-filled-background-color);
+    border-color: var(--theme-button-filled-border-color);
+    box-shadow: inset 0 1px 0 0 hsla(0, 0%, 100%, 0.7)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-btn__filled {
+        box-shadow: none
+    }
+}
+
+body.theme-dark .s-btn__filled, .theme-dark__forced .s-btn__filled {
+    box-shadow: none
+}
+
+.s-btn__filled:hover, .s-btn__filled:focus, .s-btn__filled:active {
+    color: var(--theme-button-filled-hover-color);
+    background-color: var(--theme-button-filled-hover-background-color)
+}
+
+.s-btn__filled:active {
+    background-color: var(--theme-button-filled-active-background-color);
+    border-color: var(--theme-button-filled-active-border-color);
+    box-shadow: none
+}
+
+body.theme-highcontrast .s-btn__filled:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring)
+}
+
+.s-btn__filled.is-selected {
+    color: var(--theme-button-filled-selected-color);
+    background-color: var(--theme-button-filled-selected-background-color);
+    border-color: var(--theme-button-filled-selected-border-color);
+    box-shadow: none
+}
+
+.s-btn__muted {
+    color: var(--black-500)
+}
+
+body.theme-highcontrast .s-btn__muted.s-btn__filled {
+    border-color: transparent
+}
+
+.s-btn__muted:hover, .s-btn__muted:focus, .s-btn__muted:active {
+    color: var(--black-600);
+    background-color: var(--black-025)
+}
+
+.s-btn__muted:active {
+    background: var(--black-050)
+}
+
+.s-btn__muted:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+.s-btn__muted.is-selected {
+    color: var(--black-700);
+    background-color: var(--black-075)
+}
+
+.s-btn__muted.is-selected:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+.s-btn__muted.s-btn__outlined {
+    border-color: var(--black-300)
+}
+
+.s-btn__muted.s-btn__outlined.is-selected {
+    border-color: var(--black-400)
+}
+
+.s-btn__muted.s-btn__filled {
+    color: var(--black-700);
+    background-color: var(--black-100);
+    border-color: transparent;
+    box-shadow: inset 0 1px 0 0 hsla(0, 0%, 100%, 0.4)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-btn__muted.s-btn__filled {
+        box-shadow: none
+    }
+}
+
+body.theme-dark .s-btn__muted.s-btn__filled, .theme-dark__forced .s-btn__muted.s-btn__filled {
+    box-shadow: none
+}
+
+body.theme-highcontrast .s-btn__muted.s-btn__filled {
+    background-color: var(--black-400);
+    border-color: transparent;
+    color: var(--white)
+}
+
+body.theme-highcontrast .s-btn__muted.s-btn__filled .s-btn--number {
+    color: var(--black)
+}
+
+.s-btn__muted.s-btn__filled:hover, .s-btn__muted.s-btn__filled:focus, .s-btn__muted.s-btn__filled:active {
+    color: var(--black-700);
+    background-color: var(--black-150)
+}
+
+.s-btn__muted.s-btn__filled:active {
+    background-color: var(--black-200);
+    box-shadow: none
+}
+
+.s-btn__muted.s-btn__filled:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+body.theme-highcontrast .s-btn__muted.s-btn__filled:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+.s-btn__muted.s-btn__filled.is-selected {
+    color: var(--black-800);
+    background-color: var(--black-350);
+    box-shadow: none
+}
+
+body.theme-highcontrast .s-btn__muted.s-btn__filled.is-selected {
+    background-color: var(--black-700)
+}
+
+body.theme-highcontrast .s-btn__muted.s-btn__filled.is-selected .s-btn--number {
+    color: var(--black)
+}
+
+.s-btn__muted.s-btn__filled.is-selected:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+.s-btn__danger {
+    color: var(--red-600)
+}
+
+body.theme-highcontrast .s-btn__danger.s-btn__filled {
+    border-color: transparent
+}
+
+.s-btn__danger:hover, .s-btn__danger:focus, .s-btn__danger:active {
+    color: var(--red-700);
+    background-color: var(--red-050)
+}
+
+.s-btn__danger:active {
+    background-color: var(--red-100)
+}
+
+.s-btn__danger:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-error)
+}
+
+body.theme-highcontrast .s-btn__danger:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-error)
+}
+
+.s-btn__danger.is-selected {
+    color: var(--red-900);
+    background-color: var(--red-200)
+}
+
+.s-btn__danger.is-selected:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-error)
+}
+
+.s-btn__danger.s-btn__outlined {
+    border-color: var(--red-500)
+}
+
+.s-btn__danger.s-btn__outlined.is-selected {
+    border-color: var(--red-600)
+}
+
+.s-btn__danger.s-btn__filled {
+    color: hsl(0, 0%, 100%);
+    background-color: var(--red-500);
+    border-color: transparent;
+    box-shadow: inset 0 1px 0 0 hsla(0, 0%, 100%, 0.4)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-btn__danger.s-btn__filled {
+        box-shadow: none
+    }
+}
+
+body.theme-dark .s-btn__danger.s-btn__filled, .theme-dark__forced .s-btn__danger.s-btn__filled {
+    box-shadow: none
+}
+
+body.theme-highcontrast .s-btn__danger.s-btn__filled {
+    color: var(--white)
+}
+
+body.theme-highcontrast .s-btn__danger.s-btn__filled:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-error)
+}
+
+body.theme-highcontrast .s-btn__danger.s-btn__filled .s-btn--number {
+    color: var(--black)
+}
+
+.s-btn__danger.s-btn__filled:hover, .s-btn__danger.s-btn__filled:focus, .s-btn__danger.s-btn__filled:active {
+    color: hsl(0, 0%, 100%);
+    background-color: var(--red-600)
+}
+
+.s-btn__danger.s-btn__filled:active {
+    background-color: var(--red-700);
+    box-shadow: none
+}
+
+.s-btn__danger.s-btn__filled:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-error)
+}
+
+.s-btn__danger.s-btn__filled.is-selected {
+    color: var(--white);
+    background-color: var(--red-800);
+    box-shadow: none
+}
+
+.s-btn__danger.s-btn__filled.is-selected:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-error)
+}
+
+body.theme-highcontrast .s-btn__danger.s-btn__filled.is-selected .s-btn--number {
+    color: var(--black)
+}
+
+.s-btn__danger.s-btn__filled .s-btn--number {
+    color: var(--black-900)
+}
+
+.s-btn__primary {
+    color: var(--theme-button-primary-color);
+    background-color: var(--theme-button-primary-background-color);
+    box-shadow: inset 0 1px 0 0 hsla(0, 0%, 100%, 0.4)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-btn__primary {
+        box-shadow: none
+    }
+
+    body.theme-system .s-btn__primary:not(.is-selected) {
+        color: var(--black)
+    }
+}
+
+body.theme-dark .s-btn__primary, .theme-dark__forced .s-btn__primary {
+    box-shadow: none
+}
+
+body.theme-dark .s-btn__primary:not(.is-selected), .theme-dark__forced .s-btn__primary:not(.is-selected) {
+    color: var(--black)
+}
+
+body.theme-highcontrast .s-btn__primary:not(.is-selected) {
+    border-color: transparent;
+    color: var(--white)
+}
+
+.s-btn__primary:hover, .s-btn__primary:focus, .s-btn__primary:active {
+    color: var(--theme-button-primary-hover-color);
+    background-color: var(--theme-button-primary-hover-background-color)
+}
+
+.s-btn__primary:active {
+    background-color: var(--theme-button-primary-active-background-color);
+    box-shadow: none
+}
+
+body.theme-highcontrast .s-btn__primary:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring)
+}
+
+.s-btn__primary.is-selected {
+    color: var(--theme-button-primary-selected-color);
+    background-color: var(--theme-button-primary-selected-background-color)
+}
+
+.s-btn__primary .s-btn--number {
+    color: var(--theme-button-primary-number-color)
+}
+
+.s-btn__google {
+    border-color: var(--bc-medium);
+    background-color: var(--white);
+    color: var(--black-700)
+}
+
+.s-btn__google:hover, .s-btn__google:focus {
+    border-color: var(--bc-darker);
+    background-color: var(--black-025);
+    color: var(--black-800)
+}
+
+.s-btn__google:active {
+    background-color: var(--black-050);
+    color: var(--black-900)
+}
+
+.s-btn__google:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+.s-btn__facebook {
+    border-color: transparent;
+    background-color: #385499;
+    color: #fff
+}
+
+body.theme-highcontrast .s-btn__facebook {
+    border-color: transparent
+}
+
+.s-btn__facebook:hover, .s-btn__facebook:focus {
+    background-color: #314a86;
+    color: #fff
+}
+
+.s-btn__facebook:active {
+    background-color: #2a4074;
+    color: #fff
+}
+
+.s-btn__github {
+    background-color: var(--black-750);
+    color: var(--white)
+}
+
+body.theme-highcontrast .s-btn__github {
+    border-color: transparent
+}
+
+.s-btn__github:hover, .s-btn__github:focus {
+    background-color: var(--black-800);
+    color: var(--white)
+}
+
+.s-btn__github:active {
+    background-color: var(--black-900);
+    color: var(--white)
+}
+
+.s-btn__github:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+.s-btn__unset, .s-btn__unset:hover, .s-btn__unset:active, .s-btn__unset:focus {
+    padding: 0;
+    border: none;
+    outline: none;
+    font: unset;
+    border-radius: 0;
+    color: unset;
+    background: none;
+    box-shadow: none;
+    cursor: default;
+    user-select: auto
+}
+
+.s-btn__link {
+    display: inline;
+    padding: 0;
+    border: none;
+    border-radius: 0;
+    outline: none;
+    font: inherit;
+    background: none;
+    box-shadow: none;
+    text-align: inherit;
+    text-decoration: none;
+    color: var(--theme-link-color);
+    cursor: pointer;
+    user-select: auto
+}
+
+body.theme-highcontrast .s-btn__link {
+    text-decoration: underline
+}
+
+.s-btn__link.s-link__visited:visited {
+    color: var(--theme-link-color-visited)
+}
+
+.s-btn__link:hover, .s-btn__link.s-link__visited:hover, .s-btn__link:active, .s-btn__link.s-link__visited:active {
+    color: var(--theme-link-color-hover)
+}
+
+.s-btn__link.s-link__grayscale {
+    color: var(--black-800)
+}
+
+.s-btn__link.s-link__grayscale.s-link__visited:visited {
+    color: var(--black-700)
+}
+
+.s-btn__link.s-link__grayscale:hover, .s-btn__link.s-link__grayscale.s-link__visited:hover, .s-btn__link.s-link__grayscale:active, .s-btn__link.s-link__grayscale.s-link__visited:active {
+    color: var(--black-900)
+}
+
+.s-btn__link.s-link__muted {
+    color: var(--black-500)
+}
+
+.s-btn__link.s-link__muted.s-link__visited:visited {
+    color: var(--black-700)
+}
+
+.s-btn__link.s-link__muted:hover, .s-btn__link.s-link__muted.s-link__visited:hover, .s-btn__link.s-link__muted:active, .s-btn__link.s-link__muted.s-link__visited:active {
+    color: var(--black-600)
+}
+
+.s-btn__link.s-link__danger {
+    color: var(--red-500)
+}
+
+.s-btn__link.s-link__danger.s-link__visited:visited {
+    color: var(--red-600)
+}
+
+.s-btn__link.s-link__danger:hover, .s-btn__link.s-link__danger.s-link__visited:hover, .s-btn__link.s-link__danger:active, .s-btn__link.s-link__danger.s-link__visited:active {
+    color: var(--red-400)
+}
+
+.s-btn__link.s-link__inherit {
+    color: inherit !important
+}
+
+.s-btn__link.s-link__inherit:hover, .s-btn__link.s-link__inherit:active, .s-btn__link.s-link__inherit.s-link__visited:visited {
+    color: inherit !important
+}
+
+.s-btn__link.s-link__underlined {
+    text-decoration: underline !important
+}
+
+.s-btn__link.s-link__dropdown {
+    position: relative;
+    padding-right: .9em
+}
+
+.s-btn__link.s-link__dropdown:after {
+    content: "";
+    position: absolute;
+    z-index: 30;
+    top: calc(50% - 2px);
+    right: 0;
+    border-style: solid;
+    border-width: 4px;
+    border-top-width: 4px;
+    border-bottom-width: 0;
+    border-color: currentColor transparent;
+    pointer-events: none
+}
+
+.s-btn__link:hover, .s-btn__link:active, .s-btn__link:focus, .s-btn__link[disabled] {
+    background: none;
+    box-shadow: none
+}
+
+.s-btn__link.s-btn__dropdown {
+    padding-right: .9em
+}
+
+.s-btn__link.s-btn__dropdown:after {
+    right: 0
+}
+
+.s-btn__icon .svg-icon {
+    vertical-align: baseline;
+    margin-top: -0.3em;
+    margin-bottom: -0.3em;
+    transition: opacity 200ms cubic-bezier(.165, .84, .44, 1)
+}
+
+.s-btn.is-loading {
+    padding-left: 2.2em
+}
+
+.s-btn.is-loading:before {
+    content: "";
+    position: absolute;
+    opacity: .3;
+    left: .6em;
+    top: calc(50% - .6em);
+    width: 1.23076923em;
+    height: 1.23076923em;
+    border-width: 2px;
+    border-style: solid;
+    border-color: currentColor;
+    border-radius: 50%
+}
+
+.s-btn.is-loading:after {
+    content: "";
+    position: absolute;
+    left: .6em;
+    top: calc(50% - .6em);
+    width: 1.23076923em;
+    height: 1.23076923em;
+    border-width: 2px;
+    border-style: solid;
+    border-color: transparent;
+    border-left-color: currentColor;
+    border-radius: 50%;
+    animation: s-spinner-rotate .9s infinite cubic-bezier(.5, .1, .5, .9);
+    filter: invert(0);
+    transform-origin: 50% 50% 1px
+}
+
+.s-btn.is-loading .svg-icon:first-child {
+    margin-left: -23px;
+    opacity: 0
+}
+
+a, .s-link {
+    text-decoration: none;
+    color: var(--theme-link-color);
+    cursor: pointer;
+    user-select: auto
+}
+
+body.theme-highcontrast a, body.theme-highcontrast .s-link {
+    text-decoration: underline
+}
+
+a.s-link__visited:visited, .s-link.s-link__visited:visited {
+    color: var(--theme-link-color-visited)
+}
+
+a:hover, .s-link:hover, a.s-link__visited:hover, .s-link.s-link__visited:hover, a:active, .s-link:active, a.s-link__visited:active, .s-link.s-link__visited:active {
+    color: var(--theme-link-color-hover)
+}
+
+a.s-link__grayscale, .s-link.s-link__grayscale {
+    color: var(--black-800)
+}
+
+a.s-link__grayscale.s-link__visited:visited, .s-link.s-link__grayscale.s-link__visited:visited {
+    color: var(--black-700)
+}
+
+a.s-link__grayscale:hover, .s-link.s-link__grayscale:hover, a.s-link__grayscale.s-link__visited:hover, .s-link.s-link__grayscale.s-link__visited:hover, a.s-link__grayscale:active, .s-link.s-link__grayscale:active, a.s-link__grayscale.s-link__visited:active, .s-link.s-link__grayscale.s-link__visited:active {
+    color: var(--black-900)
+}
+
+a.s-link__muted, .s-link.s-link__muted {
+    color: var(--black-500)
+}
+
+a.s-link__muted.s-link__visited:visited, .s-link.s-link__muted.s-link__visited:visited {
+    color: var(--black-700)
+}
+
+a.s-link__muted:hover, .s-link.s-link__muted:hover, a.s-link__muted.s-link__visited:hover, .s-link.s-link__muted.s-link__visited:hover, a.s-link__muted:active, .s-link.s-link__muted:active, a.s-link__muted.s-link__visited:active, .s-link.s-link__muted.s-link__visited:active {
+    color: var(--black-600)
+}
+
+a.s-link__danger, .s-link.s-link__danger {
+    color: var(--red-500)
+}
+
+a.s-link__danger.s-link__visited:visited, .s-link.s-link__danger.s-link__visited:visited {
+    color: var(--red-600)
+}
+
+a.s-link__danger:hover, .s-link.s-link__danger:hover, a.s-link__danger.s-link__visited:hover, .s-link.s-link__danger.s-link__visited:hover, a.s-link__danger:active, .s-link.s-link__danger:active, a.s-link__danger.s-link__visited:active, .s-link.s-link__danger.s-link__visited:active {
+    color: var(--red-400)
+}
+
+a.s-link__inherit, .s-link.s-link__inherit {
+    color: inherit !important
+}
+
+a.s-link__inherit:hover, .s-link.s-link__inherit:hover, a.s-link__inherit:active, .s-link.s-link__inherit:active, a.s-link__inherit.s-link__visited:visited, .s-link.s-link__inherit.s-link__visited:visited {
+    color: inherit !important
+}
+
+a.s-link__underlined, .s-link.s-link__underlined {
+    text-decoration: underline !important
+}
+
+a.s-link__dropdown, .s-link.s-link__dropdown {
+    position: relative;
+    padding-right: .9em
+}
+
+a.s-link__dropdown:after, .s-link.s-link__dropdown:after {
+    content: "";
+    position: absolute;
+    z-index: 30;
+    top: calc(50% - 2px);
+    right: 0;
+    border-style: solid;
+    border-width: 4px;
+    border-top-width: 4px;
+    border-bottom-width: 0;
+    border-color: currentColor transparent;
+    pointer-events: none
+}
+
+button.s-link {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    line-height: inherit;
+    user-select: auto;
+    font-family: inherit
+}
+
+button.s-link:focus {
+    outline: none
+}
+
+.s-anchors.s-anchors__underlined a:not(.s-link), .s-anchors.s-anchors__underlined .s-btn.s-btn__link {
+    text-decoration: underline
+}
+
+.s-anchors.s-anchors__default a:not(.s-link), .s-anchors .s-anchors.s-anchors__default a:not(.s-link), .s-anchors.s-anchors__default .s-btn.s-btn__link, .s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link {
+    color: var(--theme-link-color)
+}
+
+.s-anchors.s-anchors__default a:not(.s-link):hover, .s-anchors .s-anchors.s-anchors__default a:not(.s-link):hover, .s-anchors.s-anchors__default .s-btn.s-btn__link:hover, .s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:hover, .s-anchors.s-anchors__default a:not(.s-link):active, .s-anchors .s-anchors.s-anchors__default a:not(.s-link):active, .s-anchors.s-anchors__default .s-btn.s-btn__link:active, .s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:active {
+    color: var(--theme-link-color-hover)
+}
+
+.s-anchors.s-anchors__default a:not(.s-link):visited, .s-anchors .s-anchors.s-anchors__default a:not(.s-link):visited, .s-anchors.s-anchors__default .s-btn.s-btn__link:visited, .s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:visited {
+    color: var(--theme-link-color)
+}
+
+.s-anchors.s-anchors__default a:not(.s-link):visited:hover, .s-anchors .s-anchors.s-anchors__default a:not(.s-link):visited:hover, .s-anchors.s-anchors__default .s-btn.s-btn__link:visited:hover, .s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:visited:hover, .s-anchors.s-anchors__default a:not(.s-link):visited:active, .s-anchors .s-anchors.s-anchors__default a:not(.s-link):visited:active, .s-anchors.s-anchors__default .s-btn.s-btn__link:visited:active, .s-anchors .s-anchors.s-anchors__default .s-btn.s-btn__link:visited:active {
+    color: var(--theme-link-color-hover)
+}
+
+.s-anchors.s-anchors__grayscale a:not(.s-link), .s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link), .s-anchors.s-anchors__grayscale .s-btn.s-btn__link, .s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link {
+    color: var(--black-700)
+}
+
+.s-anchors.s-anchors__grayscale a:not(.s-link):hover, .s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):hover, .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:hover, .s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:hover, .s-anchors.s-anchors__grayscale a:not(.s-link):active, .s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):active, .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:active, .s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:active {
+    color: var(--black-600)
+}
+
+.s-anchors.s-anchors__grayscale a:not(.s-link):visited, .s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):visited, .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited, .s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited {
+    color: var(--black-700)
+}
+
+.s-anchors.s-anchors__grayscale a:not(.s-link):visited:hover, .s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):visited:hover, .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited:hover, .s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited:hover, .s-anchors.s-anchors__grayscale a:not(.s-link):visited:active, .s-anchors .s-anchors.s-anchors__grayscale a:not(.s-link):visited:active, .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited:active, .s-anchors .s-anchors.s-anchors__grayscale .s-btn.s-btn__link:visited:active {
+    color: var(--black-600)
+}
+
+.s-anchors.s-anchors__inherit a:not(.s-link), .s-anchors .s-anchors.s-anchors__inherit a:not(.s-link), .s-anchors.s-anchors__inherit .s-btn.s-btn__link, .s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link {
+    color: inherit
+}
+
+.s-anchors.s-anchors__inherit a:not(.s-link):hover, .s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):hover, .s-anchors.s-anchors__inherit .s-btn.s-btn__link:hover, .s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:hover, .s-anchors.s-anchors__inherit a:not(.s-link):active, .s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):active, .s-anchors.s-anchors__inherit .s-btn.s-btn__link:active, .s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:active {
+    color: inherit
+}
+
+.s-anchors.s-anchors__inherit a:not(.s-link):visited, .s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):visited, .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited, .s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited {
+    color: inherit
+}
+
+.s-anchors.s-anchors__inherit a:not(.s-link):visited:hover, .s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):visited:hover, .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited:hover, .s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited:hover, .s-anchors.s-anchors__inherit a:not(.s-link):visited:active, .s-anchors .s-anchors.s-anchors__inherit a:not(.s-link):visited:active, .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited:active, .s-anchors .s-anchors.s-anchors__inherit .s-btn.s-btn__link:visited:active {
+    color: inherit
+}
+
+.s-anchors.s-anchors__muted a:not(.s-link), .s-anchors .s-anchors.s-anchors__muted a:not(.s-link), .s-anchors.s-anchors__muted .s-btn.s-btn__link, .s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link {
+    color: var(--black-500)
+}
+
+.s-anchors.s-anchors__muted a:not(.s-link):hover, .s-anchors .s-anchors.s-anchors__muted a:not(.s-link):hover, .s-anchors.s-anchors__muted .s-btn.s-btn__link:hover, .s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:hover, .s-anchors.s-anchors__muted a:not(.s-link):active, .s-anchors .s-anchors.s-anchors__muted a:not(.s-link):active, .s-anchors.s-anchors__muted .s-btn.s-btn__link:active, .s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:active {
+    color: var(--black-400)
+}
+
+.s-anchors.s-anchors__muted a:not(.s-link):visited, .s-anchors .s-anchors.s-anchors__muted a:not(.s-link):visited, .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited, .s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited {
+    color: var(--black-500)
+}
+
+.s-anchors.s-anchors__muted a:not(.s-link):visited:hover, .s-anchors .s-anchors.s-anchors__muted a:not(.s-link):visited:hover, .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited:hover, .s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited:hover, .s-anchors.s-anchors__muted a:not(.s-link):visited:active, .s-anchors .s-anchors.s-anchors__muted a:not(.s-link):visited:active, .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited:active, .s-anchors .s-anchors.s-anchors__muted .s-btn.s-btn__link:visited:active {
+    color: var(--black-400)
+}
+
+.s-anchors.s-anchors__danger a:not(.s-link), .s-anchors .s-anchors.s-anchors__danger a:not(.s-link), .s-anchors.s-anchors__danger .s-btn.s-btn__link, .s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link {
+    color: var(--red-500)
+}
+
+.s-anchors.s-anchors__danger a:not(.s-link):hover, .s-anchors .s-anchors.s-anchors__danger a:not(.s-link):hover, .s-anchors.s-anchors__danger .s-btn.s-btn__link:hover, .s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:hover, .s-anchors.s-anchors__danger a:not(.s-link):active, .s-anchors .s-anchors.s-anchors__danger a:not(.s-link):active, .s-anchors.s-anchors__danger .s-btn.s-btn__link:active, .s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:active {
+    color: var(--red-400)
+}
+
+.s-anchors.s-anchors__danger a:not(.s-link):visited, .s-anchors .s-anchors.s-anchors__danger a:not(.s-link):visited, .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited, .s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited {
+    color: var(--red-500)
+}
+
+.s-anchors.s-anchors__danger a:not(.s-link):visited:hover, .s-anchors .s-anchors.s-anchors__danger a:not(.s-link):visited:hover, .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited:hover, .s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited:hover, .s-anchors.s-anchors__danger a:not(.s-link):visited:active, .s-anchors .s-anchors.s-anchors__danger a:not(.s-link):visited:active, .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited:active, .s-anchors .s-anchors.s-anchors__danger .s-btn.s-btn__link:visited:active {
+    color: var(--red-400)
+}
+
+.s-block-link {
+    display: block;
+    width: 100%;
+    color: var(--black-600);
+    padding: 6px 12px;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    border-radius: 0;
+    text-align: left;
+    line-height: inherit;
+    font-family: inherit
+}
+
+.s-block-link:hover, .s-block-link:active {
+    color: var(--black-800)
+}
+
+.s-block-link:focus:not(:focus-visible) {
+    outline: none;
+    box-shadow: none
+}
+
+.s-block-link:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+.s-block-link.is-selected {
+    color: var(--black-800);
+    font-weight: bold;
+    background-color: var(--black-050)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-block-link.is-selected {
+        background-color: var(--black-025)
+    }
+}
+
+body.theme-dark .s-block-link.is-selected, .theme-dark__forced .s-block-link.is-selected {
+    background-color: var(--black-025)
+}
+
+.s-block-link.is-selected.s-block-link__right {
+    box-shadow: inset -3px 0 0 var(--theme-primary-color)
+}
+
+.s-block-link.is-selected.s-block-link__left {
+    box-shadow: inset 3px 0 0 var(--theme-primary-color)
+}
+
+.s-block-link.s-block-link__danger {
+    color: var(--red-500)
+}
+
+.s-block-link.s-block-link__danger:hover, .s-block-link.s-block-link__danger:active {
+    color: var(--red-700)
+}
+
+.s-link-preview {
+    border: 1px solid var(--bc-medium);
+    border-radius: 3px;
+    text-align: left;
+    box-shadow: var(--bs-sm)
+}
+
+.s-link-preview--header {
+    display: flex;
+    background: var(--black-025);
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    border-bottom: 1px solid var(--bc-medium);
+    padding: 12px 8px
+}
+
+.s-link-preview--icon {
+    margin-right: 8px;
+    color: var(--black-800)
+}
+
+.s-link-preview--title {
+    font-size: 1.30769231rem;
+    font-weight: bold;
+    color: var(--black-900)
+}
+
+a.s-link-preview--title {
+    text-decoration: none;
+    color: var(--theme-link-color);
+    cursor: pointer
+}
+
+a.s-link-preview--title.s-link__visited:visited {
+    color: var(--theme-link-color);
+    text-decoration: none
+}
+
+body.theme-highcontrast a.s-link-preview--title.s-link__visited:visited {
+    text-decoration: underline
+}
+
+a.s-link-preview--title:hover, a.s-link-preview--title.s-link__visited:hover, a.s-link-preview--title:active, a.s-link-preview--title.s-link__visited:active {
+    color: var(--theme-link-color-hover);
+    text-decoration: none
+}
+
+body.theme-highcontrast a.s-link-preview--title:hover, body.theme-highcontrast a.s-link-preview--title.s-link__visited:hover, body.theme-highcontrast a.s-link-preview--title:active, body.theme-highcontrast a.s-link-preview--title.s-link__visited:active {
+    text-decoration: underline
+}
+
+.s-link-preview--details {
+    font-size: 12px;
+    color: var(--black-500);
+    margin-top: 2px
+}
+
+@media (max-width:640px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .s-link-preview--details {
+        margin-top: 4px
+    }
+}
+
+@media (max-width:640px) {
+    html.html__responsive.html__unpinned-leftnav .s-link-preview--details {
+        margin-top: 4px
+    }
+}
+
+.s-link-preview--body {
+    padding: 12px;
+    font-size: 1.15384615rem
+}
+
+.s-link-preview--body *:last-child {
+    margin-bottom: 0
+}
+
+.s-link-preview--code pre {
+    border-radius: 0 !important;
+    margin: 0;
+    max-height: 400px
+}
+
+.s-link-preview--footer {
+    display: flex;
+    justify-content: space-between;
+    background: var(--black-025);
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+    border-top: 1px solid var(--bc-medium);
+    padding: 12px;
+    font-size: 12px
+}
+
+@media (max-width:640px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .s-link-preview--footer {
+        flex-direction: column
+    }
+}
+
+@media (max-width:640px) {
+    html.html__responsive.html__unpinned-leftnav .s-link-preview--footer {
+        flex-direction: column
+    }
+}
+
+.s-link-preview--url {
+    overflow: hidden;
+    max-width: 100%;
+    text-overflow: ellipsis !important;
+    white-space: nowrap
+}
+
+.s-link-preview--misc {
+    color: var(--black-500);
+    padding-left: 4px
+}
+
+@media (max-width:640px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .s-link-preview--misc {
+        padding-left: 0;
+        padding-top: 2px
+    }
+}
+
+@media (max-width:640px) {
+    html.html__responsive.html__unpinned-leftnav .s-link-preview--misc {
+        padding-left: 0;
+        padding-top: 2px
+    }
+}
+
+.s-link-preview--details a, .s-link-preview--footer a {
+    text-decoration: none;
+    cursor: pointer;
+    color: var(--black-500)
+}
+
+.s-link-preview--details a:visited, .s-link-preview--footer a:visited {
+    color: var(--black-700)
+}
+
+.s-link-preview--details a:hover, .s-link-preview--footer a:hover, .s-link-preview--details a:active, .s-link-preview--footer a:active, .s-link-preview--details a:focus, .s-link-preview--footer a:focus {
+    color: var(--black-600)
+}
+
+.s-notice {
+    padding: 16px;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    color: var(--fc-medium);
+    font-size: 13px
+}
+
+.s-toast .s-notice {
+    max-width: 44rem;
+    width: 100%;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    box-shadow: var(--bs-sm);
+    pointer-events: all
+}
+
+.s-notice .s-notice--btn {
+    color: var(--fc-dark);
+    padding: 8px
+}
+
+.s-notice__info, .s-banner__info {
+    border-color: var(--theme-secondary-150);
+    background-color: var(--theme-secondary-050)
+}
+
+.s-notice__info.s-notice__important, .s-banner__info.s-notice__important, .s-notice__info.s-banner__important, .s-banner__info.s-banner__important {
+    background-color: var(--theme-secondary-400)
+}
+
+.s-notice__info .s-notice--btn:focus, .s-banner__info .s-notice--btn:focus, .s-notice__info .s-notice--btn:hover, .s-banner__info .s-notice--btn:hover {
+    background-color: var(--theme-secondary-300)
+}
+
+.s-notice__info .s-notice--btn:active, .s-banner__info .s-notice--btn:active {
+    background-color: var(--theme-secondary-400)
+}
+
+.s-notice__info code, .s-banner__info code {
+    background-color: var(--theme-secondary-150)
+}
+
+.s-notice__success, .s-banner__success {
+    border-color: var(--green-200);
+    background-color: var(--green-050)
+}
+
+body.theme-highcontrast .s-notice__success, body.theme-highcontrast .s-banner__success {
+    background-color: var(--green-200);
+    border-color: var(--green-400)
+}
+
+.s-notice__success.s-notice__important, .s-banner__success.s-notice__important, .s-notice__success.s-banner__important, .s-banner__success.s-banner__important {
+    background-color: var(--green-400);
+    color: var(--black-900)
+}
+
+body.theme-highcontrast .s-notice__success.s-notice__important, body.theme-highcontrast .s-banner__success.s-notice__important, body.theme-highcontrast .s-notice__success.s-banner__important, body.theme-highcontrast .s-banner__success.s-banner__important {
+    background-color: var(--green-500);
+    color: var(--white);
+    border-color: transparent
+}
+
+.s-notice__success .s-notice--btn:focus, .s-banner__success .s-notice--btn:focus, .s-notice__success .s-notice--btn:hover, .s-banner__success .s-notice--btn:hover {
+    background-color: var(--green-100)
+}
+
+.s-notice__success .s-notice--btn:active, .s-banner__success .s-notice--btn:active {
+    background-color: var(--green-200)
+}
+
+.s-notice__warning, .s-banner__warning {
+    border-color: var(--yellow-300);
+    background-color: var(--yellow-050)
+}
+
+body.theme-highcontrast .s-notice__warning, body.theme-highcontrast .s-banner__warning {
+    background-color: var(--yellow-200);
+    border-color: var(--yellow-700)
+}
+
+.s-notice__warning.s-notice__important, .s-banner__warning.s-notice__important, .s-notice__warning.s-banner__important, .s-banner__warning.s-banner__important {
+    background-color: var(--yellow-400);
+    color: var(--black-900)
+}
+
+body.theme-highcontrast .s-notice__warning.s-notice__important, body.theme-highcontrast .s-banner__warning.s-notice__important, body.theme-highcontrast .s-notice__warning.s-banner__important, body.theme-highcontrast .s-banner__warning.s-banner__important {
+    background-color: var(--yellow-500);
+    color: var(--white);
+    border-color: transparent
+}
+
+.s-notice__warning .s-notice--btn:focus, .s-banner__warning .s-notice--btn:focus, .s-notice__warning .s-notice--btn:hover, .s-banner__warning .s-notice--btn:hover {
+    background-color: var(--yellow-200)
+}
+
+.s-notice__warning .s-notice--btn:active, .s-banner__warning .s-notice--btn:active {
+    background-color: var(--yellow-300)
+}
+
+.s-notice__warning code, .s-banner__warning code {
+    background-color: var(--yellow-200)
+}
+
+.s-notice__danger, .s-banner__danger {
+    border-color: var(--red-200);
+    background-color: var(--red-050)
+}
+
+body.theme-highcontrast .s-notice__danger, body.theme-highcontrast .s-banner__danger {
+    background-color: var(--red-200);
+    border-color: var(--red-500)
+}
+
+body.theme-highcontrast .s-notice__danger.s-notice__important, body.theme-highcontrast .s-banner__danger.s-notice__important, body.theme-highcontrast .s-notice__danger.s-banner__important, body.theme-highcontrast .s-banner__danger.s-banner__important {
+    background-color: var(--red-500)
+}
+
+.s-notice__danger.s-notice__important, .s-banner__danger.s-notice__important, .s-notice__danger.s-banner__important, .s-banner__danger.s-banner__important {
+    background-color: var(--red-400)
+}
+
+.s-notice__danger .s-notice--btn:focus, .s-banner__danger .s-notice--btn:focus, .s-notice__danger .s-notice--btn:hover, .s-banner__danger .s-notice--btn:hover {
+    background-color: var(--red-100)
+}
+
+.s-notice__danger .s-notice--btn:active, .s-banner__danger .s-notice--btn:active {
+    background-color: var(--red-200)
+}
+
+.s-notice__important {
+    border-color: transparent;
+    background-color: var(--black-700);
+    color: var(--white)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-notice__info, body.theme-system .s-notice__success, body.theme-system .s-notice__warning, body.theme-system .s-notice__danger {
+        border-color: transparent
+    }
+}
+
+body.theme-dark .s-notice__info, body.theme-dark .s-notice__success, body.theme-dark .s-notice__warning, body.theme-dark .s-notice__danger, .theme-dark__forced .s-notice__info, .theme-dark__forced .s-notice__success, .theme-dark__forced .s-notice__warning, .theme-dark__forced .s-notice__danger {
+    border-color: transparent
+}
+
+body.theme-highcontrast .s-notice__info, body.theme-highcontrast .s-notice__success, body.theme-highcontrast .s-notice__warning, body.theme-highcontrast .s-notice__danger {
+    border-color: currentColor
+}
+
+.s-toast {
+    visibility: hidden;
+    position: fixed;
+    display: flex;
+    justify-content: center;
+    top: 16px;
+    left: 8px;
+    right: 8px;
+    opacity: 0;
+    z-index: 9001;
+    transform: translate3d(0, -66px, 0);
+    transition: transform 100ms cubic-bezier(.25, .46, .45, .94) 0s, opacity 60ms cubic-bezier(.25, .46, .45, .94) 0ms, visibility 0s 150ms;
+    pointer-events: none
+}
+
+.s-toast[aria-hidden="false"] {
+    visibility: visible;
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+    transition: visibility 0s 0s, opacity 100ms cubic-bezier(.165, .84, .44, 1) 0s, transform 100ms cubic-bezier(.165, .84, .44, 1) 0s
+}
+
+@media (prefers-reduced-motion) {
+    .s-toast {
+        transform: none
+    }
+}
+
+.s-tag {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    padding-left: 4px;
+    padding-right: 4px;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 3px;
+    font-size: 12px;
+    line-height: 1.84615385;
+    text-decoration: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    border-color: var(--theme-tag-border-color);
+    background-color: var(--theme-tag-background-color);
+    color: var(--theme-tag-color)
+}
+
+body.theme-highcontrast .s-tag {
+    border-color: currentColor
+}
+
+.s-tag .s-tag--dismiss {
+    color: inherit;
+    background-color: transparent
+}
+
+.s-tag .s-tag--dismiss:hover {
+    color: var(--theme-tag-background-color);
+    background-color: var(--theme-tag-color)
+}
+
+body.theme-highcontrast .s-tag .s-tag--dismiss:hover {
+    color: var(--white)
+}
+
+body.theme-highcontrast .s-tag {
+    text-decoration: none
+}
+
+.s-tag.is-selected {
+    border-color: transparent;
+    background-color: var(--theme-secondary-200);
+    color: var(--theme-secondary-900)
+}
+
+body.theme-highcontrast .s-tag.is-selected {
+    border-color: currentColor
+}
+
+.s-tag.s-tag__xs {
+    font-size: 11px;
+    line-height: 1.4;
+    padding-left: 2px;
+    padding-right: 2px
+}
+
+.s-tag.s-tag__sm {
+    font-size: 12px;
+    line-height: 1.5
+}
+
+.s-tag.s-tag__md {
+    padding-left: 6px;
+    padding-right: 6px;
+    font-size: 1.15384615rem;
+    line-height: 1.73333333
+}
+
+.s-tag.s-tag__lg {
+    padding-left: 6px;
+    padding-right: 6px;
+    border-radius: 4px;
+    font-size: 1.46153846rem;
+    line-height: 1.68421053
+}
+
+a.s-tag:not(.is-selected):hover, a.s-tag:not(.is-selected):focus, a.s-tag:not(.is-selected):active, body.theme-custom .post-tag:not(.is-selected):hover, body.theme-custom .post-tag:not(.is-selected):focus, body.theme-custom .post-tag:not(.is-selected):active {
+    border-color: var(--theme-tag-hover-border-color);
+    background-color: var(--theme-tag-hover-background-color);
+    color: var(--theme-tag-hover-color)
+}
+
+body.theme-highcontrast a.s-tag:not(.is-selected):hover, body.theme-highcontrast a.s-tag:not(.is-selected):focus, body.theme-highcontrast a.s-tag:not(.is-selected):active, body.theme-highcontrast body.theme-custom .post-tag:not(.is-selected):hover, body.theme-highcontrast body.theme-custom .post-tag:not(.is-selected):focus, body.theme-highcontrast body.theme-custom .post-tag:not(.is-selected):active {
+    border-color: currentColor
+}
+
+.s-tag--dismiss {
+    display: flex;
+    align-content: center;
+    align-self: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    margin-left: 4px;
+    padding: 1px;
+    border-radius: 3px;
+    cursor: pointer
+}
+
+.s-tag--dismiss:hover {
+    color: var(--white)
+}
+
+.s-tag--sponsor {
+    display: inline-flex;
+    align-self: center;
+    margin: -3px 4px -2px -2px;
+    max-width: 18px;
+    border-radius: 2px
+}
+
+.s-tag--sponsor .svg-icon, .s-tag--sponsor img {
+    width: 100%;
+    height: 100%
+}
+
+.s-tag__required {
+    border-color: var(--bc-darker);
+    background-color: var(--black-075);
+    color: var(--black-700)
+}
+
+body.theme-highcontrast .s-tag__required {
+    border-color: currentColor
+}
+
+.s-tag__required .s-tag--dismiss {
+    color: inherit;
+    background-color: transparent
+}
+
+.s-tag__required .s-tag--dismiss:hover {
+    color: var(--black-075);
+    background-color: var(--black-700)
+}
+
+body.theme-highcontrast .s-tag__required .s-tag--dismiss:hover {
+    color: var(--white)
+}
+
+.s-tag__required.is-selected {
+    border-color: var(--black-500);
+    background-color: var(--black-200);
+    color: var(--black-900)
+}
+
+body.theme-highcontrast .s-tag__required.is-selected {
+    border-color: currentColor
+}
+
+a.s-tag__required:not(.is-selected):hover, a.s-tag__required:not(.is-selected):focus, a.s-tag__required:not(.is-selected):active, body.theme-custom .required-tag:not(.is-selected):hover, body.theme-custom .required-tag:not(.is-selected):focus, body.theme-custom .required-tag:not(.is-selected):active {
+    border-color: var(--black-300);
+    background-color: var(--black-100);
+    color: var(--black-800)
+}
+
+body.theme-highcontrast a.s-tag__required:not(.is-selected):hover, body.theme-highcontrast a.s-tag__required:not(.is-selected):focus, body.theme-highcontrast a.s-tag__required:not(.is-selected):active, body.theme-highcontrast body.theme-custom .required-tag:not(.is-selected):hover, body.theme-highcontrast body.theme-custom .required-tag:not(.is-selected):focus, body.theme-highcontrast body.theme-custom .required-tag:not(.is-selected):active {
+    border-color: currentColor
+}
+
+.s-tag__moderator {
+    border-color: var(--red-200);
+    background-color: var(--red-050);
+    color: var(--red-800)
+}
+
+body.theme-highcontrast .s-tag__moderator {
+    border-color: currentColor
+}
+
+.s-tag__moderator .s-tag--dismiss {
+    color: inherit;
+    background-color: transparent
+}
+
+.s-tag__moderator .s-tag--dismiss:hover {
+    color: var(--red-050);
+    background-color: var(--red-800)
+}
+
+body.theme-highcontrast .s-tag__moderator .s-tag--dismiss:hover {
+    color: var(--white)
+}
+
+.s-tag__moderator.is-selected {
+    border-color: var(--red-400);
+    background-color: var(--red-200);
+    color: var(--red-800)
+}
+
+body.theme-highcontrast .s-tag__moderator.is-selected {
+    border-color: currentColor
+}
+
+a.s-tag__moderator:not(.is-selected):hover, a.s-tag__moderator:not(.is-selected):focus, a.s-tag__moderator:not(.is-selected):active, body.theme-custom .moderator-tag:not(.is-selected):hover, body.theme-custom .moderator-tag:not(.is-selected):focus, body.theme-custom .moderator-tag:not(.is-selected):active {
+    border-color: var(--red-300);
+    background-color: var(--red-100);
+    color: var(--red-900)
+}
+
+body.theme-highcontrast a.s-tag__moderator:not(.is-selected):hover, body.theme-highcontrast a.s-tag__moderator:not(.is-selected):focus, body.theme-highcontrast a.s-tag__moderator:not(.is-selected):active, body.theme-highcontrast body.theme-custom .moderator-tag:not(.is-selected):hover, body.theme-highcontrast body.theme-custom .moderator-tag:not(.is-selected):focus, body.theme-highcontrast body.theme-custom .moderator-tag:not(.is-selected):active {
+    border-color: currentColor
+}
+
+.s-tag__muted {
+    border-color: transparent;
+    background-color: var(--black-075);
+    color: var(--black-700)
+}
+
+body.theme-highcontrast .s-tag__muted {
+    border-color: currentColor
+}
+
+.s-tag__muted .s-tag--dismiss {
+    color: inherit;
+    background-color: transparent
+}
+
+.s-tag__muted .s-tag--dismiss:hover {
+    color: var(--black-075);
+    background-color: var(--black-700)
+}
+
+body.theme-highcontrast .s-tag__muted .s-tag--dismiss:hover {
+    color: var(--white)
+}
+
+.s-tag__muted.is-selected {
+    border-color: transparent;
+    background-color: var(--black-200);
+    color: var(--black-900)
+}
+
+body.theme-highcontrast .s-tag__muted.is-selected {
+    border-color: currentColor
+}
+
+a.s-tag__muted:not(.is-selected):hover, a.s-tag__muted:not(.is-selected):focus, a.s-tag__muted:not(.is-selected):active {
+    border-color: transparent;
+    background-color: var(--black-100);
+    color: var(--black-800)
+}
+
+body.theme-highcontrast a.s-tag__muted:not(.is-selected):hover, body.theme-highcontrast a.s-tag__muted:not(.is-selected):focus, body.theme-highcontrast a.s-tag__muted:not(.is-selected):active {
+    border-color: currentColor
+}
+
+.s-tag__watched, .s-tag__ignored {
+    position: relative;
+    padding-left: 22px
+}
+
+.s-tag__watched:before, .s-tag__ignored:before {
+    content: "";
+    display: block;
+    width: 14px;
+    height: 14px;
+    margin-right: 2px;
+    background-color: currentColor;
+    position: absolute;
+    left: 4px;
+    top: calc(50% - 7px);
+    -webkit-mask: var(--s-tag-icon) no-repeat center;
+    mask: var(--s-tag-icon) no-repeat center;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.s-tag__watched {
+    --s-tag-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E")
+}
+
+.s-tag__ignored {
+    --s-tag-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E")
+}
+
+.s-pagination {
+    display: flex;
+    flex-wrap: wrap;
+    margin-left: -2px;
+    margin-right: -2px
+}
+
+.s-pagination--item {
+    margin-left: 2px;
+    margin-right: 2px;
+    padding: 0 8px;
+    background-color: transparent;
+    border-radius: 3px;
+    border: 1px solid var(--bc-medium);
+    font-size: 13px;
+    line-height: 1.92307692;
+    color: var(--fc-medium)
+}
+
+body.theme-highcontrast .s-pagination--item {
+    text-decoration: none
+}
+
+.s-pagination--item:hover {
+    border-color: var(--bc-darker);
+    background-color: var(--black-100);
+    color: var(--fc-dark)
+}
+
+.s-pagination--item.is-selected {
+    border-color: transparent;
+    background-color: var(--theme-primary-color);
+    color: var(--white)
+}
+
+.s-pagination--item.s-pagination--item__clear, .s-pagination--item.s-pagination--item__clear:hover {
+    color: inherit;
+    border-color: transparent;
+    background-color: transparent
+}
+
+.s-sidebarwidget--item[aria-current="true"]:before, .s-sidebarwidget--item>:first-child[aria-current="true"]:before, .s-sidebarwidget--item[aria-current="page"]:before, .s-sidebarwidget--item>:first-child[aria-current="page"]:before {
+    border-left-color: var(--theme-primary-color)
+}
+
+.s-sidebarwidget--subnav li[aria-current="true"], .s-sidebarwidget--subnav li[aria-current="page"] {
+    background-image: url("data:image/svg+xml,%3C?xml%20version%3D%221.0%22%20encoding%3D%22UTF-8%22?%3E%3Csvg%20version%3D%221.1%22%20viewBox%3D%220%200%207%2010%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cpath%20d%3D%22m0.72153%200.68446%204.1336%204.3077-4.1336%204.3077%22%20fill%3D%22none%22%20stroke%3D%22var%28--theme-primary-color%29%22%20stroke-width%3D%222%22/%3E%3C/svg%3E")
+}
+
+.row {
+    max-width: 1080px;
+    width: 100%
+}
+
+.row::before, .row::after {
+    display: table;
+    content: " "
+}
+
+.row::after {
+    clear: both
+}
+
+.col-1 {
+    width: 8.33333333%;
+    float: left
+}
+
+.col-1.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-1.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-1.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-2 {
+    width: 16.66666667%;
+    float: left
+}
+
+.col-2.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-2.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-2.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-3 {
+    width: 25%;
+    float: left
+}
+
+.col-3.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-3.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-3.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-4 {
+    width: 33.33333333%;
+    float: left
+}
+
+.col-4.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-4.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-4.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-5 {
+    width: 41.66666667%;
+    float: left
+}
+
+.col-5.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-5.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-5.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-6 {
+    width: 50%;
+    float: left
+}
+
+.col-6.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-6.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-6.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-7 {
+    width: 58.33333333%;
+    float: left
+}
+
+.col-7.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-7.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-7.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-8 {
+    width: 66.66666667%;
+    float: left
+}
+
+.col-8.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-8.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-8.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-9 {
+    width: 75%;
+    float: left
+}
+
+.col-9.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-9.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-9.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-10 {
+    width: 83.33333333%;
+    float: left
+}
+
+.col-10.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-10.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-10.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-11 {
+    width: 91.66666667%;
+    float: left
+}
+
+.col-11.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-11.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-11.with-padding:last-child {
+    padding-right: 0
+}
+
+.col-12 {
+    width: 100%;
+    float: left
+}
+
+.col-12.with-padding {
+    padding-left: 10px;
+    padding-right: 10px
+}
+
+.col-12.with-padding:first-child {
+    padding-left: 0
+}
+
+.col-12.with-padding:last-child {
+    padding-right: 0
+}
+
+.svg-icon {
+    vertical-align: bottom
+}
+
+.svg-icon:not(.native) * {
+    fill: currentColor
+}
+
+.icon-site, .icon-location, .icon-github, .icon-twitter, .icon-external-link, .icon-settings-off {
+    background-image: url("https://cdn.sstatic.net/Img/user-profile-sprite.png?v=6829b895a42c");
+    background-image: url("https://cdn.sstatic.net/Img/user-profile-sprite.svg?v=d88bb7069e3d"), none;
+    display: inline-block;
+    width: 12px;
+    height: 14px;
+    vertical-align: middle
+}
+
+.icon-site {
+    background-position: 0 -80px
+}
+
+.icon-location {
+    background-position: 0 -97px
+}
+
+.icon-github {
+    background-position: 0 -114px
+}
+
+.icon-twitter {
+    background-position: 0 -131px
+}
+
+.icon-settings-off {
+    height: 12px;
+    width: 11px;
+    background-position: 0 -355px
+}
+
+.icon-settings-off.hover:hover {
+    background-position: 0 -370px
+}
+
+.icon-external-link {
+    width: 14px;
+    height: 14px;
+    background-position: -49px -369px
+}
+
+.input-icon {
+    position: relative
+}
+
+.input-icon .svg-icon {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 99;
+    pointer-events: none
+}
+
+.input-icon .icon {
+    position: absolute;
+    z-index: 99;
+    pointer-events: none;
+    top: 50%;
+    margin-top: -7px;
+    left: 12px
+}
+
+.input-icon input {
+    padding-left: 30px !important
+}
+
+.icon-check-on, .icon-check-off, .item-select-table .item input[type="checkbox"]:checked+.check, .item-select-table .item .check {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 16px;
+    height: 16px;
+    display: inline-block
+}
+
+.icon-check-off, .item-select-table .item .check {
+    background-position: -51px -58px
+}
+
+.icon-check-on, .item-select-table .item input[type="checkbox"]:checked+.check {
+    background-position: -74px -58px
+}
+
+.icon-check-small-on, .icon-check-small-off {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 13px;
+    height: 10px;
+    display: inline-block
+}
+
+.icon-check-small-on {
+    background-position: -51px -40px
+}
+
+.icon-check-small-off {
+    background-position: -74px -40px
+}
+
+.icon-privacy-public, .icon-privacy-private, .icon-privacy-public-btn, .icon-privacy-private-btn {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 11px;
+    height: 11px;
+    display: inline-block
+}
+
+.icon-privacy-public {
+    background-position: -52px 0
+}
+
+.icon-privacy-private {
+    background-position: -76px 0
+}
+
+.icon-privacy-public-btn {
+    background-position: -52px -20px
+}
+
+.icon-privacy-private-btn {
+    background-position: -76px -20px
+}
+
+.icon-i, .icon-i-orange {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 14px;
+    height: 14px;
+    display: inline-block;
+    background-position: -54px -94px
+}
+
+.icon-i-orange {
+    background-position: -54px -134px;
+    width: 12px;
+    height: 12px
+}
+
+.icon-warning-orange, .icon-warning-label:before {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 13px;
+    height: 11px;
+    display: inline-block
+}
+
+.icon-warning-orange, .icon-warning-label:before {
+    background-position: -55px -114px
+}
+
+.icon-warning-label {
+    display: inline-block;
+    background: #faeed6;
+    border-radius: 3px;
+    padding: 2px 4px;
+    cursor: pointer
+}
+
+.icon-warning-label:before {
+    content: ''
+}
+
+#location-home-item, .needs-visa {
+    position: relative;
+    padding-left: 1.8em !important
+}
+
+#location-home-item .visa-icon, .needs-visa .visa-icon, #location-home-item .home-icon, .needs-visa .home-icon {
+    position: absolute;
+    left: .4em;
+    top: 50%;
+    transform: translate(0%, -50%)
+}
+
+.home-icon {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 12px;
+    height: 12px;
+    display: inline-block;
+    background-position: -76px -132px
+}
+
+.visa-icon {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 12px;
+    height: 12px;
+    display: inline-block;
+    background-position: -76px -114px
+}
+
+.geo-tag .visa-icon {
+    display: none
+}
+
+.geo-tag.needs-visa .visa-icon {
+    display: inline-block
+}
+
+.icon-image-upload {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 20px;
+    height: 19px;
+    display: inline-block;
+    background-position: 0 -360px
+}
+
+.icon-external-link {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 12px;
+    height: 10px;
+    display: inline-block;
+    background-position: 0 -430px
+}
+
+.icon-play-white {
+    background-image: url('https://cdn.sstatic.net/Img/share-sprite-new.png?v=e1b8bd67bc12');
+    background-image: url('https://cdn.sstatic.net/Img/share-sprite-new.svg?v=0e11bfd41fbc'), none;
+    width: 12px;
+    height: 12px;
+    display: inline-block;
+    background-position: 0 -258px
+}
+
+.btn .icon-play-white {
+    position: relative;
+    top: 1px
+}
+
+.icon-print {
+    background-image: url('https://cdn.sstatic.net/Img/developer-story/timeline.svg?v=d0477cf4f5f4'), none;
+    width: 12px;
+    height: 11px;
+    display: inline-block;
+    background-position: 0 -488px
+}
+
+.badge, .badge-tag {
+    padding: .4em .8em .4em .4em;
+    margin: 0 3px 3px 0;
+    color: hsl(0, 0%, 100%);
+    line-height: 1;
+    text-decoration: none;
+    white-space: nowrap;
+    font-size: 12px;
+    background-color: hsl(210, 8%, 25%);
+    border: 1px solid transparent;
+    display: inline-block;
+    border-radius: 4px
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .badge, body.theme-system .badge-tag {
+        background-color: hsl(210, 8%, 5%)
+    }
+}
+
+body.theme-dark .badge, body.theme-dark .badge-tag, .theme-dark__forced .badge, .theme-dark__forced .badge-tag {
+    background-color: hsl(210, 8%, 5%)
+}
+
+.badge:hover, .badge-tag:hover {
+    color: hsl(0, 0%, 100%);
+    text-decoration: none;
+    background-color: hsl(210, 8%, 5%)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .badge:hover, body.theme-system .badge-tag:hover {
+        background-color: #000
+    }
+}
+
+body.theme-dark .badge:hover, body.theme-dark .badge-tag:hover, .theme-dark__forced .badge:hover, .theme-dark__forced .badge-tag:hover {
+    background-color: #000
+}
+
+body.theme-highcontrast .badge {
+    border-color: hsl(210, 8%, 5%)
+}
+
+.badge-tag {
+    color: var(--black-600);
+    background-color: var(--black-050);
+    border-color: var(--black-100)
+}
+
+body.theme-highcontrast .badge-tag {
+    border-color: currentColor
+}
+
+.badge-tag:hover {
+    color: var(--black-700);
+    background-color: var(--black-075);
+    border-color: var(--black-150)
+}
+
+.badgecount {
+    font-size: 12px;
+    font-weight: bold;
+    padding-left: 2px;
+    color: var(--black-400)
+}
+
+.badge1, .badge2, .badge3 {
+    display: inline-block;
+    overflow: hidden;
+    line-height: inherit;
+    vertical-align: text-bottom;
+    width: 14px;
+    height: 14px
+}
+
+.badge1 {
+    background-position: -97px -398px
+}
+
+.badge2 {
+    background-position: -77px -398px
+}
+
+.badge3 {
+    background-position: -57px -398px
+}
+
+select, input, button, .button, a.button:link, .btn, [class*="btn-"] {
+    font-size: 100%
+}
+
+input[type="text"]:not(.s-input):not(.s-textarea), input[type="password"]:not(.s-input):not(.s-textarea), input[type="number"]:not(.s-input):not(.s-textarea), input[type="email"]:not(.s-input):not(.s-textarea), input[type="url"]:not(.s-input):not(.s-textarea), input[type="search"]:not(.s-input):not(.s-textarea), input[type="tel"]:not(.s-input):not(.s-textarea), input[type="datetime"]:not(.s-input):not(.s-textarea), input[type="datetime-local"]:not(.s-input):not(.s-textarea), input[type="date"]:not(.s-input):not(.s-textarea), textarea:not(.s-input):not(.s-textarea) {
+    padding: 8px 10px;
+    font-family: var(--theme-body-font-family);
+    font-size: 1.15384615rem;
+    color: hsl(210, 8%, 25%);
+    background: hsl(0, 0%, 100%);
+    border: 1px solid hsl(210, 8%, 80%)
+}
+
+input[type="text"]:not(.s-input):not(.s-textarea)[disabled], input[type="password"]:not(.s-input):not(.s-textarea)[disabled], input[type="number"]:not(.s-input):not(.s-textarea)[disabled], input[type="email"]:not(.s-input):not(.s-textarea)[disabled], input[type="url"]:not(.s-input):not(.s-textarea)[disabled], input[type="search"]:not(.s-input):not(.s-textarea)[disabled], input[type="tel"]:not(.s-input):not(.s-textarea)[disabled], input[type="datetime"]:not(.s-input):not(.s-textarea)[disabled], input[type="datetime-local"]:not(.s-input):not(.s-textarea)[disabled], input[type="date"]:not(.s-input):not(.s-textarea)[disabled], textarea:not(.s-input):not(.s-textarea)[disabled] {
+    background: hsla(210, 8%, 65%, 0.1);
+    cursor: not-allowed
+}
+
+input[type="text"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="password"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="number"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="email"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="url"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="search"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="tel"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="datetime"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="datetime-local"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, input[type="date"]:not(.s-input):not(.s-textarea)::-webkit-input-placeholder, textarea:not(.s-input):not(.s-textarea)::-webkit-input-placeholder {
+    color: hsl(210, 8%, 65%)
+}
+
+input[type="text"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="password"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="number"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="email"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="url"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="search"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="tel"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="datetime"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="datetime-local"]:not(.s-input):not(.s-textarea)::-moz-placeholder, input[type="date"]:not(.s-input):not(.s-textarea)::-moz-placeholder, textarea:not(.s-input):not(.s-textarea)::-moz-placeholder {
+    color: hsl(210, 8%, 65%);
+    opacity: 1
+}
+
+input[type="text"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="password"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="number"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="email"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="url"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="search"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="tel"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="datetime"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="datetime-local"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, input[type="date"]:not(.s-input):not(.s-textarea)::-ms-input-placeholder, textarea:not(.s-input):not(.s-textarea)::-ms-input-placeholder {
+    color: hsl(210, 8%, 65%)
+}
+
+input[type="text"]:not(.s-input):not(.s-textarea)::placeholder, input[type="password"]:not(.s-input):not(.s-textarea)::placeholder, input[type="number"]:not(.s-input):not(.s-textarea)::placeholder, input[type="email"]:not(.s-input):not(.s-textarea)::placeholder, input[type="url"]:not(.s-input):not(.s-textarea)::placeholder, input[type="search"]:not(.s-input):not(.s-textarea)::placeholder, input[type="tel"]:not(.s-input):not(.s-textarea)::placeholder, input[type="datetime"]:not(.s-input):not(.s-textarea)::placeholder, input[type="datetime-local"]:not(.s-input):not(.s-textarea)::placeholder, input[type="date"]:not(.s-input):not(.s-textarea)::placeholder, textarea:not(.s-input):not(.s-textarea)::placeholder {
+    color: hsl(210, 8%, 65%)
+}
+
+textarea.custom-reason-text {
+    width: 600px
+}
+
+input {
+    margin: 5px 0
+}
+
+input[type="checkbox"]:not(.s-checkbox), input[type="radio"]:not(.s-radio) {
+    border: none;
+    margin-right: 5px
+}
+
+.form-submit {
+    display: block;
+    padding: 10px 0 15px 0
+}
+
+.form-submit input:hover {
+    cursor: pointer
+}
+
+.form-submit input:active {
+    position: relative;
+    top: 1px
+}
+
+.privacy-wrapper {
+    position: relative
+}
+
+.privacy-wrapper .privacy-checkbox {
+    display: none;
+    width: auto;
+    padding: 3px 6px;
+    border-radius: 3px 3px 0px 0px;
+    position: absolute;
+    top: -8px;
+    right: 0;
+    font-size: 11px;
+    color: white;
+    background: hsl(206, 100%, 52%)
+}
+
+.privacy-wrapper .privacy-checkbox input[type="checkbox"] {
+    position: relative;
+    z-index: 1;
+    margin-right: 8px
+}
+
+.privacy-wrapper .privacy-checkbox:focus {
+    outline: 0
+}
+
+.privacy-wrapper .privacy-checkbox:before {
+    content: '';
+    display: inline-block;
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 24px;
+    background: hsl(206, 100%, 40%);
+    z-index: 0;
+    border-radius: 3px 0px 0px 0px
+}
+
+.has-error .textarea-with-counter textarea:not(:focus) {
+    border-color: hsl(358, 68%, 59%);
+    border-bottom: 0
+}
+
+.has-error .textarea-with-counter textarea:not(:focus)+.-counter {
+    border-color: hsl(358, 68%, 59%)
+}
+
+.textarea-with-counter {
+    margin: 5px 0
+}
+
+.textarea-with-counter+.help-text {
+    display: block;
+    margin-bottom: 5px !important
+}
+
+.textarea-with-counter textarea {
+    margin: 0 !important;
+    border-bottom: 0;
+    display: block
+}
+
+.textarea-with-counter textarea:focus {
+    border-bottom: 0
+}
+
+.textarea-with-counter textarea:focus+.-counter {
+    border-color: hsl(206, 100%, 52%)
+}
+
+.textarea-with-counter .-counter {
+    display: flex;
+    align-items: center;
+    background: hsl(205, 47%, 97%);
+    padding: 4px;
+    color: hsl(210, 8%, 55%);
+    font-size: 11px;
+    border-bottom: 1px solid hsl(210, 8%, 80%);
+    border-left: 1px solid hsl(210, 8%, 80%);
+    border-right: 1px solid hsl(210, 8%, 80%)
+}
+
+.textarea-with-counter .-counter.-fail .-dot, .textarea-with-counter .-counter.-success .-dot {
+    display: inline-block
+}
+
+.textarea-with-counter .-counter.-fail .-dot {
+    background: hsl(27, 90%, 70%)
+}
+
+.textarea-with-counter .-counter.-success {
+    color: var(--green-400)
+}
+
+.textarea-with-counter .-counter.-success .-dot {
+    background: hsl(140, 40%, 65%)
+}
+
+.textarea-with-counter .-dot {
+    display: none;
+    width: 8px;
+    height: 8px;
+    margin-right: 4px;
+    border-radius: 50%
+}
+
+.label-required {
+    display: inline-block;
+    margin-left: 2px;
+    color: hsl(210, 8%, 55%)
+}
+
+.double-input:before, .double-input:after {
+    content: "";
+    display: table
+}
+
+.double-input:after {
+    clear: both
+}
+
+.double-input input[type="text"], .double-input input[type="password"], .double-input input[type="email"], .double-input .separator {
+    float: left;
+    display: inline-block;
+    width: auto;
+    max-width: 155px
+}
+
+.double-input .separator {
+    background: hsl(210, 8%, 95%);
+    color: hsl(210, 8%, 55%);
+    font-size: 13px;
+    padding: 8px 10px;
+    margin: 5px 0 5px 0;
+    border-top: 1px solid hsl(210, 8%, 80%);
+    border-bottom: 1px solid hsl(210, 8%, 80%);
+    min-width: 12px;
+    text-align: center
+}
+
+.double-input.disabled {
+    pointer-events: none;
+    cursor: not-allowed;
+    opacity: .4
+}
+
+.double-input.flex {
+    display: flex;
+    margin-bottom: 18px
+}
+
+.double-input.flex .separator {
+    float: none;
+    flex-shrink: 0;
+    margin: 5px 0 0 0
+}
+
+.double-input.flex input[type="text"], .double-input.flex input[type="password"], .double-input.flex input[type="email"] {
+    float: none;
+    flex-grow: 1;
+    margin-bottom: 0 !important;
+    max-width: none
+}
+
+.switcher {
+    margin: 5px auto 8px auto;
+    display: inline-block;
+    border: 1px solid hsl(210, 8%, 90%);
+    border-radius: 3px;
+    overflow: hidden
+}
+
+.switcher:before, .switcher:after {
+    content: "";
+    display: table
+}
+
+.switcher:after {
+    clear: both
+}
+
+.switcher input[type="radio"] {
+    display: none
+}
+
+.switcher label {
+    background: hsl(0, 0%, 100%);
+    transition: background 300ms ease;
+    text-align: center;
+    color: hsl(210, 8%, 45%);
+    display: inline-block;
+    padding: 10px 8px;
+    min-width: 98px;
+    float: left;
+    cursor: pointer;
+    border-right: 1px solid hsl(210, 8%, 90%);
+    margin-top: 0
+}
+
+.switcher label:last-of-type {
+    border-right: 0
+}
+
+.switcher label:hover {
+    background: #F4F8FB
+}
+
+.switcher input[type="radio"]:checked+label {
+    background: #E1ECF4;
+    color: hsl(210, 8%, 25%);
+    pointer-events: none
+}
+
+.switcher.three-choices label {
+    width: 30.5%
+}
+
+.switcher.flex {
+    display: flex;
+    overflow: inherit
+}
+
+.switcher.flex label {
+    min-width: 0;
+    flex-grow: 1
+}
+
+.switcher.flex.three label {
+    width: 34%
+}
+
+.switcher.flex .informative-tooltip {
+    width: 200px
+}
+
+.disabled-area {
+    opacity: .5;
+    pointer-events: none
+}
+
+label.block, input.block, textarea.block {
+    display: block;
+    width: 100%
+}
+
+label>input[type="checkbox"] {
+    vertical-align: middle;
+    margin: 0 3px 3px 0
+}
+
+label>input[type="radio"] {
+    margin: 0 3px 4px 0
+}
+
+input[type="radio"], input[type="checkbox"] {
+    vertical-align: middle
+}
+
+.container .chosen-container .chosen-choices {
+    border: 1px solid hsl(210, 8%, 80%);
+    box-shadow: inset 0 1px 2px hsla(210, 8%, 5%, 0.1);
+    background: hsl(0, 0%, 100%)
+}
+
+.input-loader {
+    position: relative
+}
+
+.input-loader.loading:before {
+    content: '';
+    position: absolute !important;
+    top: 50%;
+    margin-top: -7px;
+    right: 7px
+}
+
+.f-label, label.f-label {
+    display: inline-flex;
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.61538462;
+    font-weight: 700;
+    color: var(--black-700);
+    cursor: pointer
+}
+
+.f-label._muted, label.f-label._muted {
+    color: var(--black-400)
+}
+
+.f-label._small, label.f-label._small {
+    font-size: 11px
+}
+
+.f-label._medium, label.f-label._medium {
+    font-size: 17px
+}
+
+.f-label._large, label.f-label._large {
+    font-size: 21px
+}
+
+.f-label._medium, label.f-label._medium, .f-label._large, label.f-label._large {
+    font-weight: 400
+}
+
+.f-label .is-required, label.f-label .is-required, .f-label .is-optional, label.f-label .is-optional {
+    display: inline-flex;
+    align-self: flex-end;
+    margin-bottom: 2px;
+    margin-left: 8px;
+    font-size: 86%;
+    font-style: italic;
+    font-weight: 400
+}
+
+p.is-required, span.is-required {
+    color: hsl(358, 68%, 59%)
+}
+
+p.is-optional, span.is-optional {
+    color: hsl(210, 8%, 45%)
+}
+
+.t-help {
+    margin-top: 6px;
+    margin-bottom: 12px;
+    color: hsl(210, 8%, 55%);
+    font-size: 11px;
+    line-height: 1.30769231
+}
+
+.t-help._medium {
+    font-size: 13px
+}
+
+.f-input, textarea.f-input, input[type="text"].f-input, input[type="password"].f-input, input[type="number"].f-input, input[type="email"].f-input, input[type="url"].f-input, input[type="search"].f-input, input[type="tel"].f-input, input[type="datetime"].f-input {
+    box-sizing: border-box;
+    flex: 1 auto;
+    margin: 0;
+    padding: 8px 16px;
+    min-height: auto;
+    vertical-align: middle;
+    border: 1px solid hsl(210, 8%, 80%);
+    border-radius: 0;
+    box-shadow: inset 0 0 1px hsla(210, 8%, 60%, 0.2), 0 0 0 hsla(0, 0%, 100%, 0);
+    font-size: 13px;
+    line-height: 1.61538462;
+    color: hsl(210, 8%, 25%);
+    background-color: hsl(0, 0%, 100%);
+    transition: all 600ms cubic-bezier(.165, .84, .44, 1)
+}
+
+.f-input::-webkit-input-placeholder, textarea.f-input::-webkit-input-placeholder, input[type="text"].f-input::-webkit-input-placeholder, input[type="password"].f-input::-webkit-input-placeholder, input[type="number"].f-input::-webkit-input-placeholder, input[type="email"].f-input::-webkit-input-placeholder, input[type="url"].f-input::-webkit-input-placeholder, input[type="search"].f-input::-webkit-input-placeholder, input[type="tel"].f-input::-webkit-input-placeholder, input[type="datetime"].f-input::-webkit-input-placeholder {
+    color: hsl(210, 8%, 80%)
+}
+
+.f-input::-moz-placeholder, textarea.f-input::-moz-placeholder, input[type="text"].f-input::-moz-placeholder, input[type="password"].f-input::-moz-placeholder, input[type="number"].f-input::-moz-placeholder, input[type="email"].f-input::-moz-placeholder, input[type="url"].f-input::-moz-placeholder, input[type="search"].f-input::-moz-placeholder, input[type="tel"].f-input::-moz-placeholder, input[type="datetime"].f-input::-moz-placeholder {
+    color: hsl(210, 8%, 80%);
+    opacity: 1
+}
+
+.f-input::-ms-input-placeholder, textarea.f-input::-ms-input-placeholder, input[type="text"].f-input::-ms-input-placeholder, input[type="password"].f-input::-ms-input-placeholder, input[type="number"].f-input::-ms-input-placeholder, input[type="email"].f-input::-ms-input-placeholder, input[type="url"].f-input::-ms-input-placeholder, input[type="search"].f-input::-ms-input-placeholder, input[type="tel"].f-input::-ms-input-placeholder, input[type="datetime"].f-input::-ms-input-placeholder {
+    color: hsl(210, 8%, 80%)
+}
+
+.f-input::placeholder, textarea.f-input::placeholder, input[type="text"].f-input::placeholder, input[type="password"].f-input::placeholder, input[type="number"].f-input::placeholder, input[type="email"].f-input::placeholder, input[type="url"].f-input::placeholder, input[type="search"].f-input::placeholder, input[type="tel"].f-input::placeholder, input[type="datetime"].f-input::placeholder {
+    color: hsl(210, 8%, 80%)
+}
+
+.f-input:hover, textarea.f-input:hover, input[type="text"].f-input:hover, input[type="password"].f-input:hover, input[type="number"].f-input:hover, input[type="email"].f-input:hover, input[type="url"].f-input:hover, input[type="search"].f-input:hover, input[type="tel"].f-input:hover, input[type="datetime"].f-input:hover {
+    border-color: hsla(206, 100%, 52%, 0.5);
+    box-shadow: inset 0 0 2px hsl(210, 8%, 85%), 0 0 2px hsla(206, 100%, 52%, 0.2)
+}
+
+.f-input:focus, textarea.f-input:focus, input[type="text"].f-input:focus, input[type="password"].f-input:focus, input[type="number"].f-input:focus, input[type="email"].f-input:focus, input[type="url"].f-input:focus, input[type="search"].f-input:focus, input[type="tel"].f-input:focus, input[type="datetime"].f-input:focus {
+    border-color: hsl(206, 100%, 52%);
+    box-shadow: inset 0 0 4px hsl(210, 8%, 95%), 0 0 5px hsla(206, 100%, 52%, 0.5);
+    outline: 0
+}
+
+.f-input[disabled], textarea.f-input[disabled], input[type="text"].f-input[disabled], input[type="password"].f-input[disabled], input[type="number"].f-input[disabled], input[type="email"].f-input[disabled], input[type="url"].f-input[disabled], input[type="search"].f-input[disabled], input[type="tel"].f-input[disabled], input[type="datetime"].f-input[disabled], .f-input.is-disabled, textarea.f-input.is-disabled, input[type="text"].f-input.is-disabled, input[type="password"].f-input.is-disabled, input[type="number"].f-input.is-disabled, input[type="email"].f-input.is-disabled, input[type="url"].f-input.is-disabled, input[type="search"].f-input.is-disabled, input[type="tel"].f-input.is-disabled, input[type="datetime"].f-input.is-disabled, .f-input[read-only], textarea.f-input[read-only], input[type="text"].f-input[read-only], input[type="password"].f-input[read-only], input[type="number"].f-input[read-only], input[type="email"].f-input[read-only], input[type="url"].f-input[read-only], input[type="search"].f-input[read-only], input[type="tel"].f-input[read-only], input[type="datetime"].f-input[read-only], .f-input.is-readonly, textarea.f-input.is-readonly, input[type="text"].f-input.is-readonly, input[type="password"].f-input.is-readonly, input[type="number"].f-input.is-readonly, input[type="email"].f-input.is-readonly, input[type="url"].f-input.is-readonly, input[type="search"].f-input.is-readonly, input[type="tel"].f-input.is-readonly, input[type="datetime"].f-input.is-readonly {
+    border-color: hsl(210, 8%, 90%);
+    box-shadow: inset 0 0 3px hsla(210, 8%, 60%, 0.1);
+    background-color: hsl(210, 8%, 95%);
+    color: hsl(210, 8%, 55%)
+}
+
+.f-input[disabled], textarea.f-input[disabled], input[type="text"].f-input[disabled], input[type="password"].f-input[disabled], input[type="number"].f-input[disabled], input[type="email"].f-input[disabled], input[type="url"].f-input[disabled], input[type="search"].f-input[disabled], input[type="tel"].f-input[disabled], input[type="datetime"].f-input[disabled], .f-input.is-disabled, textarea.f-input.is-disabled, input[type="text"].f-input.is-disabled, input[type="password"].f-input.is-disabled, input[type="number"].f-input.is-disabled, input[type="email"].f-input.is-disabled, input[type="url"].f-input.is-disabled, input[type="search"].f-input.is-disabled, input[type="tel"].f-input.is-disabled, input[type="datetime"].f-input.is-disabled {
+    background-image: url("https://cdn.sstatic.net/Img/forms/icon-disabled.svg?v=363cfdd5fd7d"), none;
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    cursor: not-allowed
+}
+
+.f-input._large, textarea.f-input._large, input[type="text"].f-input._large, input[type="password"].f-input._large, input[type="number"].f-input._large, input[type="email"].f-input._large, input[type="url"].f-input._large, input[type="search"].f-input._large, input[type="tel"].f-input._large, input[type="datetime"].f-input._large {
+    padding-top: 16px;
+    padding-bottom: 16px;
+    font-size: 24px
+}
+
+.f-input._medium, textarea.f-input._medium, input[type="text"].f-input._medium, input[type="password"].f-input._medium, input[type="number"].f-input._medium, input[type="email"].f-input._medium, input[type="url"].f-input._medium, input[type="search"].f-input._medium, input[type="tel"].f-input._medium, input[type="datetime"].f-input._medium {
+    font-size: 17px
+}
+
+.f-input._small, textarea.f-input._small, input[type="text"].f-input._small, input[type="password"].f-input._small, input[type="number"].f-input._small, input[type="email"].f-input._small, input[type="url"].f-input._small, input[type="search"].f-input._small, input[type="tel"].f-input._small, input[type="datetime"].f-input._small {
+    padding-left: 12px;
+    padding-right: 12px;
+    font-size: 11px
+}
+
+textarea.f-input {
+    padding: 12px;
+    height: auto;
+    resize: vertical
+}
+
+.f-select {
+    position: relative;
+    color: hsl(210, 8%, 25%)
+}
+
+.f-select:before, .f-select:after {
+    content: "";
+    position: absolute;
+    right: .75em;
+    pointer-events: none;
+    border-width: 3px;
+    border-style: solid;
+    border-color: currentColor transparent
+}
+
+.f-select:before {
+    top: calc(50% - 6px);
+    border-top-width: 0;
+    border-bottom-width: 5px
+}
+
+.f-select:after {
+    top: calc(50% + 1px);
+    border-top-width: 5px;
+    border-bottom-width: 0
+}
+
+.f-select>select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    flex: 1 auto;
+    padding: 8px 16px;
+    padding-right: 32px;
+    font-size: 13px;
+    font-family: var(--theme-body-font-family);
+    line-height: 1.61538462;
+    color: inherit;
+    background-color: hsl(0, 0%, 100%);
+    border: 1px solid hsl(210, 8%, 80%);
+    border-radius: 3px;
+    transition: color 600ms cubic-bezier(.165, .84, .44, 1), border-color 600ms cubic-bezier(.165, .84, .44, 1), box-shadow 600ms cubic-bezier(.165, .84, .44, 1), background-color 600ms cubic-bezier(.165, .84, .44, 1)
+}
+
+.f-select>select::-ms-expand {
+    display: none
+}
+
+.f-select>select:hover {
+    border-color: hsla(206, 100%, 52%, 0.5);
+    box-shadow: inset 0 0 2px hsl(210, 8%, 85%), 0 0 2px hsla(206, 100%, 52%, 0.2)
+}
+
+.f-select>select:focus {
+    border-color: hsl(206, 100%, 52%);
+    box-shadow: inset 0 0 4px hsl(210, 8%, 95%), 0 0 5px hsla(206, 100%, 52%, 0.5);
+    outline: 0
+}
+
+.f-select.is-disabled:before, .f-select.is-disabled:after {
+    opacity: .3
+}
+
+.f-select.is-disabled select {
+    color: hsl(210, 8%, 70%);
+    background-color: hsl(210, 8%, 95%);
+    border-color: hsl(210, 8%, 90%)
+}
+
+.f-select.is-disabled select:hover {
+    border-color: hsl(210, 8%, 90%);
+    box-shadow: none
+}
+
+.f-checkbox input[type="radio"], .f-radio input[type="radio"], .f-checkbox input[type="checkbox"], .f-radio input[type="checkbox"] {
+    margin: 0
+}
+
+.f-checkbox>.-input, .f-radio>.-input {
+    flex: none;
+    padding-right: 8px
+}
+
+.f-checkbox>.-input>input, .f-radio>.-input>input {
+    margin: 0
+}
+
+.f-checkbox>.-input>input[type="checkbox"], .f-radio>.-input>input[type="checkbox"] {
+    margin-top: 2px
+}
+
+.f-checkbox>.-input>input:focus, .f-radio>.-input>input:focus {
+    outline: 0
+}
+
+.f-checkbox .f-label, .f-radio .f-label {
+    font-weight: 400
+}
+
+.f-checkbox .t-help, .f-radio .t-help {
+    margin: 2px 0;
+    padding-right: 1em
+}
+
+.f-checkbox+.f-checkbox, .f-checkbox+.f-radio, .f-radio+.f-checkbox, .f-radio+.f-radio {
+    margin-top: 8px
+}
+
+.f-checkbox.is-disabled, .f-radio.is-disabled {
+    opacity: .5
+}
+
+.f-checkbox.is-disabled, .f-radio.is-disabled, .f-checkbox.is-disabled label, .f-radio.is-disabled label, .f-checkbox.is-disabled .label, .f-radio.is-disabled .label {
+    cursor: not-allowed
+}
+
+.input-group {
+    box-sizing: border-box
+}
+
+.input-group .message {
+    display: block;
+    margin-bottom: 0;
+    padding-top: 8px;
+    padding-bottom: 8px
+}
+
+.input-group.has-warning .f-input, .input-group.has-error .f-input, .input-group.is-success .f-input, .input-group.has-warning .tag-editor, .input-group.has-error .tag-editor, .input-group.is-success .tag-editor, .input-group.has-warning .autocomplete input, .input-group.has-error .autocomplete input, .input-group.is-success .autocomplete input, .input-group.has-warning .f-select select, .input-group.has-error .f-select select, .input-group.is-success .f-select select {
+    background-position: right 12px center;
+    background-repeat: no-repeat
+}
+
+.input-group.has-warning .f-select select, .input-group.has-error .f-select select, .input-group.is-success .f-select select {
+    background-position: right 24px center
+}
+
+.input-group.has-warning .f-input, .input-group.has-warning .f-select select {
+    border-color: #db8e17;
+    background-image: url("https://cdn.sstatic.net/Img/forms/icon-warning.svg?v=982eba4202d6"), none
+}
+
+.input-group.has-warning .f-input:hover, .input-group.has-warning .f-select select:hover {
+    border-color: #eaa63b;
+    box-shadow: inset 0 0 1px hsl(210, 8%, 85%), 0 0 2px hsl(47, 65%, 84%)
+}
+
+.input-group.has-warning .f-input:focus, .input-group.has-warning .f-select select:focus {
+    border-color: #e7910b;
+    box-shadow: inset 0 0 4px hsl(210, 8%, 95%), 0 0 4px hsl(47, 65%, 84%)
+}
+
+.input-group.has-warning .message {
+    color: #db8e17
+}
+
+.input-group.has-error .f-input, .input-group.has-error .tag-editor, .input-group.has-error .autocomplete input, .input-group.has-error .f-select select {
+    border-color: hsl(358, 68%, 59%);
+    background-image: url("https://cdn.sstatic.net/Img/forms/icon-error.svg?v=7912aa2ddbe0"), none
+}
+
+.input-group.has-error .f-input:hover, .input-group.has-error .tag-editor:hover, .input-group.has-error .autocomplete input:hover, .input-group.has-error .f-select select:hover {
+    border-color: hsl(358, 70%, 70%);
+    box-shadow: inset 0 0 1px hsl(210, 8%, 85%), 0 0 2px hsl(358, 76%, 90%)
+}
+
+.input-group.has-error .f-input:focus, .input-group.has-error .tag-editor:focus, .input-group.has-error .autocomplete input:focus, .input-group.has-error .f-select select:focus {
+    border-color: hsl(358, 62%, 52%);
+    box-shadow: inset 0 0 4px hsl(210, 8%, 95%), 0 0 4px hsl(358, 74%, 83%)
+}
+
+.input-group.has-error .message {
+    color: var(--red-500)
+}
+
+.input-group.is-success .f-input, .input-group.is-success .f-select select {
+    border-color: var(--green-400);
+    background-image: url("https://cdn.sstatic.net/Img/forms/icon-success.svg?v=4012387047df"), none
+}
+
+.input-group.is-success .f-input:hover, .input-group.is-success .f-select select:hover {
+    border-color: hsl(140, 40%, 65%);
+    box-shadow: inset 0 0 1px hsl(210, 8%, 85%), 0 0 2px hsl(140, 40%, 85%)
+}
+
+.input-group.is-success .f-input:focus, .input-group.is-success .f-select select:focus {
+    border-color: var(--green-500);
+    box-shadow: inset 0 0 4px hsl(210, 8%, 95%), 0 0 4px hsl(140, 40%, 75%)
+}
+
+.input-group.is-success .message {
+    color: hsl(140, 40%, 42%)
+}
+
+.input-group.is-disabled {
+    opacity: .5;
+    cursor: not-allowed
+}
+
+.input-group, .button-group {
+    position: relative;
+    display: flex
+}
+
+.input-group *, .button-group *, .input-group *:before, .button-group *:before, .input-group *:after, .button-group *:after {
+    box-sizing: border-box
+}
+
+.input-group {
+    flex-flow: column nowrap;
+    margin-bottom: 24px
+}
+
+.input-group>.input-group {
+    margin-bottom: 0
+}
+
+.input-group>.f-label+* {
+    margin-top: 6px
+}
+
+.input-group>.f-label+.t-help {
+    margin-top: 2px
+}
+
+.input-group>.f-label+.input-group {
+    margin-top: 16px
+}
+
+.input-group._clusters .input-group {
+    margin-bottom: 0
+}
+
+.input-group._clusters .input-group .f-label {
+    font-weight: 400
+}
+
+.input-group .-fill {
+    flex: none;
+    align-items: center;
+    padding: 8px 16px;
+    color: hsl(210, 8%, 35%);
+    background-color: hsl(210, 8%, 95%);
+    border: 1px solid hsl(210, 8%, 80%);
+    border-left-width: 0;
+    border-right-width: 0
+}
+
+.input-group .-fill>label {
+    font-size: inherit;
+    line-height: inherit
+}
+
+.input-group .-fill._clean {
+    border-color: transparent;
+    background-color: transparent
+}
+
+.input-group .-fill.is-first {
+    order: -1;
+    border-left-width: 1px
+}
+
+.input-group .-fill.is-last {
+    order: 99;
+    border-right-width: 1px
+}
+
+.input-group [class^="btn"].is-last {
+    order: 100;
+    margin-left: -1px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0
+}
+
+.button-group [class^="btn"]+[class^="btn"] {
+    margin-left: 2px
+}
+
+.button-group .t-help {
+    margin-top: 12px;
+    margin-bottom: 0
+}
+
+.button-group.has-border {
+    padding-top: 24px;
+    border-top: 1px solid hsl(210, 8%, 85%)
+}
+
+.f-radio-toggle .f-label {
+    flex: 1 auto;
+    justify-content: center;
+    padding: 8px 16px;
+    margin-left: -1px;
+    margin-right: -1px;
+    border: 1px solid hsl(210, 8%, 80%);
+    background-color: var(--white);
+    font-weight: 400;
+    line-height: 1.61538462;
+    color: hsl(210, 8%, 25%);
+    text-align: center;
+    transition: all 600ms cubic-bezier(.165, .84, .44, 1);
+    cursor: pointer
+}
+
+.f-radio-toggle .f-label:hover, .f-radio-toggle .f-label:focus, .f-radio-toggle .f-label:active {
+    color: hsl(210, 8%, 15%);
+    background-color: var(--blue-050);
+    border-color: var(--blue-200);
+    z-index: 1
+}
+
+.f-radio-toggle input[type="radio"] {
+    position: absolute;
+    left: -9999em;
+    opacity: 0
+}
+
+.f-radio-toggle input[type="radio"]:checked+.f-label {
+    color: var(--white);
+    background-color: var(--blue-500);
+    border-color: var(--blue-500);
+    pointer-events: none;
+    position: relative;
+    z-index: 2
+}
+
+.f-radio-toggle._muted .f-label {
+    border: 1px solid var(--black-150);
+    background-color: var(--white);
+    color: var(--black-400)
+}
+
+.f-radio-toggle._muted .f-label:hover, .f-radio-toggle._muted .f-label:focus, .f-radio-toggle._muted .f-label:active {
+    color: var(--black-700);
+    background-color: var(--black-050);
+    border-color: var(--black-200)
+}
+
+.f-radio-toggle._muted input[type="radio"]:checked+.f-label {
+    color: var(--white);
+    background-color: var(--green-400);
+    border-color: var(--green-400)
+}
+
+.f-radio-toggle._muted input[type="radio"]._off:checked+.f-label {
+    color: var(--black-500);
+    background-color: var(--black-100);
+    border-color: var(--black-200)
+}
+
+.container .chosen-container {
+    margin-top: 0
+}
+
+.container .chosen-container.chosen-container-active {
+    border-width: 0
+}
+
+.container .chosen-container.chosen-container-active .chosen-choices {
+    border-color: hsl(206, 100%, 52%);
+    box-shadow: inset 0 0 4px hsl(210, 8%, 95%), 0 0 5px hsla(206, 100%, 52%, 0.5)
+}
+
+.container .chosen-container .chosen-choices {
+    display: flex;
+    padding: 0 1px;
+    min-height: 38px;
+    background-image: none;
+    border-radius: 3px;
+    border-color: hsl(210, 8%, 80%)
+}
+
+.container .chosen-container .chosen-choices:hover {
+    border-color: hsla(206, 100%, 52%, 0.5);
+    box-shadow: inset 0 0 2px hsl(210, 8%, 85%), 0 0 2px hsla(206, 100%, 52%, 0.2)
+}
+
+.container .chosen-container .chosen-choices li.search-choice, .container .chosen-container .chosen-choices li.search-field {
+    display: inline-flex;
+    align-items: center;
+    margin: 4px 1px;
+    padding: 2px 6px
+}
+
+.container .chosen-container .chosen-choices li.search-choice {
+    float: none;
+    box-shadow: none;
+    background-image: none;
+    font-family: var(--ff-sans);
+    font-size: 12px;
+    color: var(--powder-600);
+    background-color: var(--powder-100);
+    border-color: transparent;
+    border-radius: 3px
+}
+
+.container .chosen-container .chosen-choices li.search-choice:first-child {
+    margin-left: 3px
+}
+
+.container .chosen-container .chosen-choices li.search-choice .search-choice-close {
+    position: relative;
+    top: 0;
+    right: -1px;
+    margin-left: 4px;
+    transition: none
+}
+
+.container .chosen-container li.search-field>input[type="text"] {
+    padding: 0;
+    margin: 0
+}
+
+ul, ol, li {
+    margin: 0;
+    padding: 0
+}
+
+ul, ol {
+    margin-left: 30px;
+    margin-bottom: 1em
+}
+
+ul ul, ol ul, ul ol, ol ol {
+    margin-bottom: 0
+}
+
+ul {
+    list-style-type: disc
+}
+
+ol {
+    list-style-type: decimal
+}
+
+.caption {
+    padding-top: 13px;
+    padding-bottom: 13px;
+    text-align: left
+}
+
+table {
+    border-spacing: 0;
+    border-collapse: collapse
+}
+
+.table {
+    margin-bottom: 15px;
+    width: 100%;
+    max-width: 100%;
+    background-color: transparent;
+    border-width: 0
+}
+
+.table th {
+    text-align: left
+}
+
+.table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td {
+    padding: 13px;
+    padding-left: 0;
+    vertical-align: top
+}
+
+.table>thead>tr>th small, .table>tbody>tr>th small, .table>tfoot>tr>th small, .table>thead>tr>td small, .table>tbody>tr>td small, .table>tfoot>tr>td small {
+    font-size: 11px
+}
+
+.table>thead>tr>th {
+    vertical-align: bottom
+}
+
+.table>tfoot>tr>td {
+    vertical-align: top
+}
+
+.table>caption+thead>tr:first-child>th, .table>.caption+thead>tr:first-child>th, .table>colgroup+thead>tr:first-child>th, .table>.colgroup+thead>tr:first-child>th, .table>thead:first-child>tr:first-child>th, .table>caption+thead>tr:first-child>td, .table>.caption+thead>tr:first-child>td, .table>colgroup+thead>tr:first-child>td, .table>.colgroup+thead>tr:first-child>td, .table>thead:first-child>tr:first-child>td {
+    border-top: 0
+}
+
+.table ._textLeft {
+    text-align: left
+}
+
+.table ._textCenter {
+    text-align: center
+}
+
+.table ._textRight {
+    text-align: right
+}
+
+.table col[class*="-col"] {
+    position: static;
+    float: none;
+    display: table-column
+}
+
+.table td[class*="-col"], .table th[class*="-col"] {
+    position: static;
+    float: none;
+    display: table-cell
+}
+
+.table td.-col1, .table th.-col1 {
+    width: 8.33333333%
+}
+
+.table td.-col2, .table th.-col2 {
+    width: 16.66666667%
+}
+
+.table td.-col3, .table th.-col3 {
+    width: 25%
+}
+
+.table td.-col4, .table th.-col4 {
+    width: 33.33333333%
+}
+
+.table td.-col5, .table th.-col5 {
+    width: 41.66666667%
+}
+
+.table td.-col6, .table th.-col6 {
+    width: 50%
+}
+
+.table td.-col7, .table th.-col7 {
+    width: 58.33333333%
+}
+
+.table td.-col8, .table th.-col8 {
+    width: 66.66666667%
+}
+
+.table td.-col9, .table th.-col9 {
+    width: 75%
+}
+
+.table td.-col10, .table th.-col10 {
+    width: 83.33333333%
+}
+
+.table td.-col11, .table th.-col11 {
+    width: 91.66666667%
+}
+
+.table td.-col12, .table th.-col12 {
+    width: 100%
+}
+
+.table._hover>tbody>tr:hover {
+    background-color: hsl(0, 0%, 97%)
+}
+
+.table._hover>tbody>tr:hover>td {
+    box-shadow: inset 0 2px 0 hsl(0, 0%, 100%), inset 0 -2px 0 hsl(0, 0%, 100%)
+}
+
+.table._condensed>thead>tr>th, .table._condensed>tbody>tr>th, .table._condensed>tfoot>tr>th, .table._condensed>thead>tr>td, .table._condensed>tbody>tr>td, .table._condensed>tfoot>tr>td {
+    padding: 7px;
+    padding-left: 0
+}
+
+.table._condensed input[type="radio"], .table._condensed input[type="checkbox"] {
+    margin-top: 0
+}
+
+.table._borders>thead>tr>th, .table._borders>tbody>tr>th, .table._borders>tfoot>tr>th, .table._borders>thead>tr>td, .table._borders>tbody>tr>td, .table._borders>tfoot>tr>td {
+    border-top: 1px solid var(--black-075)
+}
+
+.table._borders>thead>tr>th {
+    border-bottom: 1px solid var(--black-075)
+}
+
+.table._borders>tbody+tbody {
+    border-top: 2px solid var(--black-075)
+}
+
+.table tfoot.-totals>tr>td {
+    font-size: 1.46153846rem
+}
+
+.table tfoot.-totals:hover {
+    background-color: transparent;
+    transition: none
+}
+
+.table .js-tableToggle {
+    display: none
+}
+
+.table._whiteBg {
+    background: hsl(0, 0%, 100%)
+}
+
+.table._whiteBg>thead>tr>th, .table._whiteBg>tbody>tr>th, .table._whiteBg>tfoot>tr>th, .table._whiteBg>thead>tr>td, .table._whiteBg>tbody>tr>td, .table._whiteBg>tfoot>tr>td {
+    padding: 10px
+}
+
+.table._verticalCenter>thead>tr>th, .table._verticalCenter>tbody>tr>th, .table._verticalCenter>tfoot>tr>th, .table._verticalCenter>thead>tr>td, .table._verticalCenter>tbody>tr>td, .table._verticalCenter>tfoot>tr>td {
+    vertical-align: middle
+}
+
+.table th.-checkbox, .table td.-checkbox {
+    width: 2em
+}
+
+.table td.empty {
+    font-style: italic;
+    opacity: .75
+}
+
+.edit-table {
+    border: 1px solid var(--black-100);
+    margin-top: 5px
+}
+
+.edit-table._short {
+    max-height: 150px;
+    overflow-y: auto
+}
+
+.edit-table._medium {
+    max-height: 250px;
+    overflow-y: auto
+}
+
+.edit-table>table, .edit-table>.table {
+    margin-bottom: 0
+}
+
+.item-select-table {
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    background: var(--white);
+    border-right: 1px solid var(--black-100);
+    border-bottom: 1px solid var(--black-100);
+    margin-bottom: 20px
+}
+
+.item-select-table.limit-height-300 {
+    max-height: 300px;
+    overflow-y: auto;
+    overflow-x: hidden
+}
+
+.item-select-table.columns-3 .item {
+    width: 33.3%
+}
+
+.item-select-table.tag-table .item {
+    display: flex;
+    align-items: center
+}
+
+.item-select-table.tag-table .post-tag {
+    max-width: 110px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-right: 4px
+}
+
+.item-select-table label.item {
+    cursor: pointer
+}
+
+.item-select-table .item {
+    border: 1px solid var(--black-100);
+    padding: 10px;
+    position: relative;
+    flex-grow: 1;
+    text-align: center;
+    margin-right: -1px;
+    margin-bottom: -1px
+}
+
+.item-select-table .item:hover {
+    background: var(--black-050)
+}
+
+.item-select-table .item input[type="checkbox"] {
+    display: none
+}
+
+.item-select-table .item .check {
+    position: absolute;
+    top: 4px;
+    right: 4px
+}
+
+table.sorter {
+    margin: 10px 0pt 15px;
+    text-align: left;
+    border-bottom: solid 1px var(--black-100)
+}
+
+table.sorter>thead>tr .headerSortDown, table.sorter>thead>tr .headerSortUp {
+    background-color: var(--orange-400);
+    color: hsl(0, 0%, 100%)
+}
+
+table.sorter>thead>tr .headerSortUp span:after {
+    content: "▴"
+}
+
+table.sorter>thead>tr .headerSortDown span:after {
+    content: "▾"
+}
+
+table.sorter>thead>tr .header {
+    background-repeat: no-repeat;
+    background-position: center right;
+    cursor: pointer
+}
+
+table.sorter>thead>tr span:after {
+    padding-left: 5px
+}
+
+table.sorter>thead>tr>th {
+    text-align: center
+}
+
+table.sorter>thead>tr>th, table.sorter>tfoot>tr>td {
+    background-color: var(--black-500);
+    color: var(--white);
+    border: 1px solid var(--white);
+    font-size: 110%;
+    padding: 5px
+}
+
+table.sorter>tbody>tr>td {
+    padding: 5px 10px;
+    background-color: var(--white);
+    vertical-align: top
+}
+
+table.sorter>tbody>tr.odd>td {
+    background-color: var(--black-050)
+}
+
+table.sorter>tbody>tr>td.mod-ip-banned {
+    background-color: var(--red-100)
+}
+
+table.sorter>tbody>tr>td.mod-ip-hobbled {
+    background-color: var(--orange-100)
+}
+
+table.sorter>tbody .row-data {
+    text-align: right
+}
+
+.post-tag, .moderator-tag, .required-tag, .disliked-tag, .company-tag, .geo-tag, .geo-tag, .container .chosen-choices .search-choice, .container .chosen-container-multi .chosen-choices li.search-choice {
+    display: inline-block;
+    padding: .4em .5em;
+    margin: 2px 2px 2px 0;
+    font-size: 11px;
+    line-height: 1;
+    white-space: nowrap;
+    text-decoration: none;
+    text-align: center;
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 3px
+}
+
+body.theme-highcontrast .post-tag, body.theme-highcontrast .moderator-tag, body.theme-highcontrast .required-tag, body.theme-highcontrast .disliked-tag, body.theme-highcontrast .company-tag, body.theme-highcontrast .geo-tag {
+    border-color: currentColor
+}
+
+.post-tag:hover, .moderator-tag:hover, .required-tag:hover, .disliked-tag:hover, .company-tag:hover, .geo-tag:hover {
+    text-decoration: none
+}
+
+.post-tag img, .moderator-tag img, .required-tag img, .disliked-tag img, .company-tag img, .geo-tag img {
+    margin-bottom: 0
+}
+
+.post-tag img.sponsor-tag-img, .moderator-tag img.sponsor-tag-img, .required-tag img.sponsor-tag-img, .disliked-tag img.sponsor-tag-img, .company-tag img.sponsor-tag-img, .geo-tag img.sponsor-tag-img {
+    margin-top: -2px;
+    margin-bottom: -2px
+}
+
+.post-tag, .geo-tag, .container .chosen-choices .search-choice, .container .chosen-container-multi .chosen-choices li.search-choice {
+    color: var(--theme-tag-color);
+    background-color: var(--theme-tag-background-color);
+    border-color: var(--theme-tag-border-color)
+}
+
+.post-tag:hover {
+    color: var(--theme-tag-hover-color);
+    background-color: var(--theme-tag-hover-background-color);
+    border-color: var(--theme-tag-hover-border-color)
+}
+
+.moderator-tag {
+    color: var(--red-600);
+    background-color: var(--red-050);
+    border-color: var(--red-100)
+}
+
+.moderator-tag:hover {
+    color: var(--red-700);
+    background-color: var(--red-100);
+    border-color: var(--red-200)
+}
+
+.required-tag {
+    color: var(--black-700);
+    background-color: var(--black-075);
+    border-color: var(--black-200)
+}
+
+.required-tag:hover {
+    color: var(--black-800);
+    background-color: var(--black-100);
+    border-color: var(--black-300)
+}
+
+.disliked-tag {
+    color: hsl(210, 8%, 45%);
+    background-color: hsl(210, 8%, 90%);
+    border-color: transparent
+}
+
+.disliked-tag:hover {
+    color: hsl(210, 8%, 40%);
+    background-color: hsl(210, 8%, 85%);
+    border-color: rgba(0, 0, 0, 0)
+}
+
+.company-tag {
+    color: hsl(210, 8%, 5%);
+    font-size: 12px;
+    text-align: left;
+    background-color: hsl(210, 8%, 95%);
+    border-radius: 0;
+    border-color: transparent;
+    border-left: 2px solid hsl(27, 90%, 55%)
+}
+
+.company-tag:hover {
+    background-color: #ECEAEA;
+    color: hsl(210, 8%, 15%)
+}
+
+.company-tag img {
+    margin-bottom: auto;
+    padding-right: 4px;
+    max-height: 20px;
+    width: auto;
+    vertical-align: middle
+}
+
+.autocomplete .company-tag {
+    line-height: 1.5em
+}
+
+.geo-tag .delete-location {
+    margin: -2px 0 0 3px;
+    vertical-align: middle;
+    width: 14px;
+    height: 13px;
+    line-height: 26px
+}
+
+.geo-tag .icon-visa-show[value="false"]~.icon-visa {
+    display: none
+}
+
+.container .chosen-choices .search-choice, .container .chosen-container-multi .chosen-choices li.search-choice {
+    background-image: none;
+    box-shadow: none;
+    border-color: var(--theme-tag-border-color);
+    padding-right: 1.75em;
+    padding-top: .5em;
+    margin: 4px 4px 0 0 !important
+}
+
+.container .chosen-choices .search-choice .search-choice-close, .container .chosen-container-multi .chosen-choices li.search-choice .search-choice-close {
+    margin: 0 !important
+}
+
+.post-tag.s-tag__watched {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    padding-left: 22px;
+    --s-tag-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E")
+}
+
+.post-tag.s-tag__watched:before {
+    content: "";
+    display: block;
+    width: 14px;
+    height: 14px;
+    margin-right: 2px;
+    background-color: currentColor;
+    position: absolute;
+    left: 4px;
+    top: calc(50% - 7px);
+    -webkit-mask: var(--s-tag-icon) no-repeat center;
+    mask: var(--s-tag-icon) no-repeat center;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.post-tag.s-tag__ignored {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    padding-left: 22px;
+    --s-tag-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E")
+}
+
+.post-tag.s-tag__ignored:before {
+    content: "";
+    display: block;
+    width: 14px;
+    height: 14px;
+    margin-right: 2px;
+    background-color: currentColor;
+    position: absolute;
+    left: 4px;
+    top: calc(50% - 7px);
+    -webkit-mask: var(--s-tag-icon) no-repeat center;
+    mask: var(--s-tag-icon) no-repeat center;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+a {
+    color: var(--theme-link-color);
+    text-decoration: none;
+    cursor: pointer
+}
+
+a:hover, a:active {
+    color: var(--theme-link-color-hover);
+    text-decoration: none
+}
+
+a.comment-user {
+    display: inline-block;
+    white-space: nowrap;
+    padding: 0
+}
+
+a.comment-user.owner {
+    padding: 1px 5px
+}
+
+body.theme-highcontrast a.comment-user.owner {
+    background-color: var(--theme-link-color);
+    color: var(--theme-post-owner-background-color)
+}
+
+body.theme-highcontrast a.comment-user.owner:hover {
+    color: var(--theme-post-owner-background-color)
+}
+
+.s-prose a:not(.post-tag):not(.s-tag):not(.badge-tag):not(.s-link__visited):not(.s-btn):not(.s-editor-btn), .comment-copy a {
+    text-decoration: underline
+}
+
+.s-prose a:not(.post-tag):not(.s-tag):not(.badge-tag):not(.s-link__visited):not(.s-btn):not(.s-editor-btn):visited, .comment-copy a:visited {
+    color: var(--theme-link-color-visited)
+}
+
+a .mathjax {
+    width: 115px;
+    height: 55px;
+    background-image: url("https://cdn.sstatic.net/Img/share-sprite.png?v=0734e5a54af0");
+    background-position: -190px 5px
+}
+
+.external {
+    position: relative;
+    display: inline-block;
+    padding-left: 20px
+}
+
+.external>.-icon {
+    position: relative;
+    display: inline-block;
+    width: 9px;
+    height: 9px;
+    overflow: hidden;
+    background-image: url("https://cdn.sstatic.net/Img/share-sprite-new.png?v=e1b8bd67bc12");
+    background-image: url("https://cdn.sstatic.net/Img/share-sprite-new.svg?v=0e11bfd41fbc"), none;
+    background-position: 0 -220px;
+    background-repeat: no-repeat
+}
+
+.external:visited {
+    color: var(--theme-link-color)
+}
+
+.external:hover, .external:active {
+    text-decoration: none
+}
+
+.external:hover>.-icon, .external:active>.-icon {
+    background-position: -13px -220px
+}
+
+.question-hyperlink {
+    font-size: 1.30769231rem;
+    font-weight: 400
+}
+
+.question-hyperlink, .answer-hyperlink {
+    color: var(--theme-post-title-color);
+    line-height: 1.3;
+    margin-bottom: 1.2em
+}
+
+.question-hyperlink:hover, .answer-hyperlink:hover, .question-hyperlink:active, .answer-hyperlink:active {
+    color: var(--theme-post-title-color-hover)
+}
+
+body.theme-highcontrast .question-hyperlink:hover, body.theme-highcontrast .answer-hyperlink:hover, body.theme-highcontrast .question-hyperlink:focus, body.theme-highcontrast .answer-hyperlink:focus {
+    text-decoration: underline
+}
+
+.question-hyperlink:visited, .answer-hyperlink:visited {
+    color: var(--theme-post-title-color-visited)
+}
+
+b, strong {
+    font-weight: bold
+}
+
+i, em {
+    font-style: italic
+}
+
+sup, sub {
+    font-size: 80%
+}
+
+ins {
+    text-decoration: none
+}
+
+del, s {
+    text-decoration: line-through
+}
+
+del .post-tag, s .post-tag, del .required-tag, s .required-tag, del .moderator-tag, s .moderator-tag {
+    text-decoration: line-through !important
+}
+
+kbd {
+    display: inline-block;
+    margin: 0 .1em;
+    padding: .1em .6em;
+    font-family: var(--theme-body-font-family);
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--black-800);
+    text-shadow: 0 1px 0 var(--white);
+    background-color: var(--black-075);
+    border: 1px solid var(--black-300);
+    border-radius: 3px;
+    box-shadow: 0 1px 1px hsla(210, 8%, 5%, 0.15), inset 0 1px 0 0 var(--white);
+    white-space: nowrap
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system kbd {
+        box-shadow: 0 1px 2px hsla(210, 8%, 5%, 0.75)
+    }
+}
+
+body.theme-dark kbd, .theme-dark__forced kbd {
+    box-shadow: 0 1px 2px hsla(210, 8%, 5%, 0.75)
+}
+
+.placeholder-text {
+    color: var(--black-300)
+}
+
+.help-text {
+    color: var(--black-600);
+    font-size: 11px
+}
+
+p {
+    clear: both;
+    margin-bottom: 1em;
+    margin-top: 0
+}
+
+p code {
+    padding: 1px 5px
+}
+
+code {
+    font-family: var(--ff-mono);
+    background-color: var(--black-075)
+}
+
+pre {
+    margin-bottom: 1em;
+    padding: 12px;
+    width: auto;
+    max-height: 600px;
+    overflow: auto;
+    font-family: var(--ff-mono);
+    font-size: 13px;
+    background-color: var(--black-050);
+    border-radius: 3px;
+    scrollbar-color: var(--scrollbar) transparent
+}
+
+pre code {
+    background-color: transparent
+}
+
+pre::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+    background-color: transparent
+}
+
+pre::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background-color: transparent
+}
+
+pre::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: var(--scrollbar)
+}
+
+pre::-webkit-scrollbar-corner {
+    background-color: transparent;
+    border-color: transparent
+}
+
+li pre {
+    margin: .5em 0 1em 0
+}
+
+h1, h2, h3 {
+    line-height: 1.3;
+    margin: 0 0 1em
+}
+
+h1 {
+    font-size: 1.61538462rem
+}
+
+h2 {
+    font-size: 1.46153846rem
+}
+
+h3 {
+    font-size: 1.15384615rem
+}
+
+.s-prose, .comment-copy, .question-status, .excerpt {
+    font-family: var(--theme-post-body-font-family)
+}
+
+blockquote, q {
+    quotes: none
+}
+
+blockquote {
+    position: relative;
+    margin-bottom: 1em;
+    padding: 12px 12px 12px 16px
+}
+
+blockquote:before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    border-radius: 8px;
+    background: var(--black-150)
+}
+
+blockquote *:last-child {
+    margin-bottom: 0
+}
+
+li blockquote {
+    margin: .5em 0 1em 0
+}
+
+.favicon {
+    width: 16px;
+    height: 16px;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-size: 16px;
+    background-image: url('https://cdn.sstatic.net/Img/favicons-sprite16.png?v=986d639469b0')
+}
+
+body.theme-dark .favicon {
+    background-image: url('https://cdn.sstatic.net/Img/favicons-sprite16-dark.png?v=78243e15ed0e')
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .favicon {
+        background-image: url('https://cdn.sstatic.net/Img/favicons-sprite16-dark.png?v=78243e15ed0e')
+    }
+}
+
+div.favicon {
+    display: inline-block
+}
+
+@media only screen and (min--moz-device-pixel-ratio:1.5), only screen and (-o-min-device-pixel-ratio:3/2), only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min-device-pixel-ratio:1.5) {
+    .favicon {
+        background-image: url('https://cdn.sstatic.net/Img/favicons-sprite32.png?v=85acf8076063')
+    }
+
+    body.theme-dark .favicon {
+        background-image: url('https://cdn.sstatic.net/Img/favicons-sprite32-dark.png?v=de2232974c99')
+    }
+}
+
+@media only screen and (min--moz-device-pixel-ratio:1.5) and (prefers-color-scheme:dark), only screen and (-o-min-device-pixel-ratio:3/2) and (prefers-color-scheme:dark), only screen and (-webkit-min-device-pixel-ratio:1.5) and (prefers-color-scheme:dark), only screen and (min-device-pixel-ratio:1.5) and (prefers-color-scheme:dark) {
+    body.theme-system .favicon {
+        background-image: url('https://cdn.sstatic.net/Img/favicons-sprite32-dark.png?v=de2232974c99')
+    }
+}
+
+@media only screen and (min--moz-device-pixel-ratio:1.5), only screen and (-o-min-device-pixel-ratio:3/2), only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min-device-pixel-ratio:1.5) {
+    .favicon {
+        -moz-background-size: 16px 6966px;
+        -o-background-size: 16px 6966px;
+        -webkit-background-size: 16px 6966px;
+        background-size: 16px 6966px
+    }
+}
+
+.favicon-3dprinting {
+    background-position: 0 0
+}
+
+.favicon-3dprintingmeta {
+    background-position: 0 -18px
+}
+
+.favicon-academia {
+    background-position: 0 -36px
+}
+
+.favicon-academiameta {
+    background-position: 0 -54px
+}
+
+.favicon-ai {
+    background-position: 0 -72px
+}
+
+.favicon-aimeta {
+    background-position: 0 -90px
+}
+
+.favicon-alcohol {
+    background-position: 0 -108px
+}
+
+.favicon-alcoholmeta {
+    background-position: 0 -126px
+}
+
+.favicon-android {
+    background-position: 0 -144px
+}
+
+.favicon-androidmeta {
+    background-position: 0 -162px
+}
+
+.favicon-anime {
+    background-position: 0 -180px
+}
+
+.favicon-animemeta {
+    background-position: 0 -198px
+}
+
+.favicon-apple {
+    background-position: 0 -216px
+}
+
+.favicon-applemeta {
+    background-position: 0 -234px
+}
+
+.favicon-arabic {
+    background-position: 0 -252px
+}
+
+.favicon-arabicmeta {
+    background-position: 0 -270px
+}
+
+.favicon-arduino {
+    background-position: 0 -288px
+}
+
+.favicon-arduinometa {
+    background-position: 0 -306px
+}
+
+.favicon-area51 {
+    background-position: 0 -324px
+}
+
+.favicon-area51discuss {
+    background-position: 0 -342px
+}
+
+.favicon-askubuntu {
+    background-position: 0 -360px
+}
+
+.favicon-askubuntumeta {
+    background-position: 0 -378px
+}
+
+.favicon-astronomy {
+    background-position: 0 -396px
+}
+
+.favicon-astronomymeta {
+    background-position: 0 -414px
+}
+
+.favicon-augur {
+    background-position: 0 -432px
+}
+
+.favicon-augurmeta {
+    background-position: 0 -450px
+}
+
+.favicon-aviation {
+    background-position: 0 -468px
+}
+
+.favicon-aviationmeta {
+    background-position: 0 -486px
+}
+
+.favicon-avp {
+    background-position: 0 -504px
+}
+
+.favicon-avpmeta {
+    background-position: 0 -522px
+}
+
+.favicon-beta {
+    background-position: 0 -540px
+}
+
+.favicon-betameta {
+    background-position: 0 -558px
+}
+
+.favicon-bicycles {
+    background-position: 0 -576px
+}
+
+.favicon-bicyclesmeta {
+    background-position: 0 -594px
+}
+
+.favicon-bioinformatics {
+    background-position: 0 -612px
+}
+
+.favicon-bioinformaticsmeta {
+    background-position: 0 -630px
+}
+
+.favicon-biology {
+    background-position: 0 -648px
+}
+
+.favicon-biologymeta {
+    background-position: 0 -666px
+}
+
+.favicon-bitcoin {
+    background-position: 0 -684px
+}
+
+.favicon-bitcoinmeta {
+    background-position: 0 -702px
+}
+
+.favicon-blender {
+    background-position: 0 -720px
+}
+
+.favicon-blendermeta {
+    background-position: 0 -738px
+}
+
+.favicon-boardgames {
+    background-position: 0 -756px
+}
+
+.favicon-boardgamesmeta {
+    background-position: 0 -774px
+}
+
+.favicon-br {
+    background-position: 0 -792px
+}
+
+.favicon-bricks {
+    background-position: 0 -810px
+}
+
+.favicon-bricksmeta {
+    background-position: 0 -828px
+}
+
+.favicon-brmeta {
+    background-position: 0 -846px
+}
+
+.favicon-buddhism {
+    background-position: 0 -864px
+}
+
+.favicon-buddhismmeta {
+    background-position: 0 -882px
+}
+
+.favicon-cardano {
+    background-position: 0 -900px
+}
+
+.favicon-cardanometa {
+    background-position: 0 -918px
+}
+
+.favicon-careers {
+    background-position: 0 -936px
+}
+
+.favicon-channels {
+    background-position: 0 -954px
+}
+
+.favicon-chemistry {
+    background-position: 0 -972px
+}
+
+.favicon-chemistrymeta {
+    background-position: 0 -990px
+}
+
+.favicon-chess {
+    background-position: 0 -1008px
+}
+
+.favicon-chessmeta {
+    background-position: 0 -1026px
+}
+
+.favicon-chinese {
+    background-position: 0 -1044px
+}
+
+.favicon-chinesemeta {
+    background-position: 0 -1062px
+}
+
+.favicon-christianity {
+    background-position: 0 -1080px
+}
+
+.favicon-christianitymeta {
+    background-position: 0 -1098px
+}
+
+.favicon-civicrm {
+    background-position: 0 -1116px
+}
+
+.favicon-civicrmmeta {
+    background-position: 0 -1134px
+}
+
+.favicon-codegolf {
+    background-position: 0 -1152px
+}
+
+.favicon-codegolfmeta {
+    background-position: 0 -1170px
+}
+
+.favicon-codereview {
+    background-position: 0 -1188px
+}
+
+.favicon-codereviewmeta {
+    background-position: 0 -1206px
+}
+
+.favicon-coffee {
+    background-position: 0 -1224px
+}
+
+.favicon-coffeemeta {
+    background-position: 0 -1242px
+}
+
+.favicon-communitybuilding {
+    background-position: 0 -1260px
+}
+
+.favicon-communitybuildingmeta {
+    background-position: 0 -1278px
+}
+
+.favicon-computergraphics {
+    background-position: 0 -1296px
+}
+
+.favicon-computergraphicsmeta {
+    background-position: 0 -1314px
+}
+
+.favicon-conlang {
+    background-position: 0 -1332px
+}
+
+.favicon-conlangmeta {
+    background-position: 0 -1350px
+}
+
+.favicon-cooking {
+    background-position: 0 -1368px
+}
+
+.favicon-cookingmeta {
+    background-position: 0 -1386px
+}
+
+.favicon-craftcms {
+    background-position: 0 -1404px
+}
+
+.favicon-craftcmsmeta {
+    background-position: 0 -1422px
+}
+
+.favicon-crafts {
+    background-position: 0 -1440px
+}
+
+.favicon-craftsmeta {
+    background-position: 0 -1458px
+}
+
+.favicon-crypto {
+    background-position: 0 -1476px
+}
+
+.favicon-cryptometa {
+    background-position: 0 -1494px
+}
+
+.favicon-cs {
+    background-position: 0 -1512px
+}
+
+.favicon-cs50 {
+    background-position: 0 -1530px
+}
+
+.favicon-cs50meta {
+    background-position: 0 -1548px
+}
+
+.favicon-cseducators {
+    background-position: 0 -1566px
+}
+
+.favicon-cseducatorsmeta {
+    background-position: 0 -1584px
+}
+
+.favicon-csmeta {
+    background-position: 0 -1602px
+}
+
+.favicon-cstheory {
+    background-position: 0 -1620px
+}
+
+.favicon-cstheorymeta {
+    background-position: 0 -1638px
+}
+
+.favicon-datascience {
+    background-position: 0 -1656px
+}
+
+.favicon-datasciencemeta {
+    background-position: 0 -1674px
+}
+
+.favicon-dba {
+    background-position: 0 -1692px
+}
+
+.favicon-dbameta {
+    background-position: 0 -1710px
+}
+
+.favicon-deepweb {
+    background-position: 0 -1728px
+}
+
+.favicon-deepwebmeta {
+    background-position: 0 -1746px
+}
+
+.favicon-devops {
+    background-position: 0 -1764px
+}
+
+.favicon-devopsmeta {
+    background-position: 0 -1782px
+}
+
+.favicon-diy {
+    background-position: 0 -1800px
+}
+
+.favicon-diymeta {
+    background-position: 0 -1818px
+}
+
+.favicon-drones {
+    background-position: 0 -1836px
+}
+
+.favicon-dronesmeta {
+    background-position: 0 -1854px
+}
+
+.favicon-drupal {
+    background-position: 0 -1872px
+}
+
+.favicon-drupalmeta {
+    background-position: 0 -1890px
+}
+
+.favicon-dsp {
+    background-position: 0 -1908px
+}
+
+.favicon-dspmeta {
+    background-position: 0 -1926px
+}
+
+.favicon-earthscience {
+    background-position: 0 -1944px
+}
+
+.favicon-earthsciencemeta {
+    background-position: 0 -1962px
+}
+
+.favicon-ebooks {
+    background-position: 0 -1980px
+}
+
+.favicon-ebooksmeta {
+    background-position: 0 -1998px
+}
+
+.favicon-economics {
+    background-position: 0 -2016px
+}
+
+.favicon-economicsmeta {
+    background-position: 0 -2034px
+}
+
+.favicon-edx-cs169-1x {
+    background-position: 0 -2052px
+}
+
+.favicon-edx-cs169-1xmeta {
+    background-position: 0 -2070px
+}
+
+.favicon-electronics {
+    background-position: 0 -2088px
+}
+
+.favicon-electronicsmeta {
+    background-position: 0 -2106px
+}
+
+.favicon-elementaryos {
+    background-position: 0 -2124px
+}
+
+.favicon-elementaryosmeta {
+    background-position: 0 -2142px
+}
+
+.favicon-ell {
+    background-position: 0 -2160px
+}
+
+.favicon-ellmeta {
+    background-position: 0 -2178px
+}
+
+.favicon-emacs {
+    background-position: 0 -2196px
+}
+
+.favicon-emacsmeta {
+    background-position: 0 -2214px
+}
+
+.favicon-embedded {
+    background-position: 0 -2232px
+}
+
+.favicon-embeddedmeta {
+    background-position: 0 -2250px
+}
+
+.favicon-engineering {
+    background-position: 0 -2268px
+}
+
+.favicon-engineeringmeta {
+    background-position: 0 -2286px
+}
+
+.favicon-english {
+    background-position: 0 -2304px
+}
+
+.favicon-englishmeta {
+    background-position: 0 -2322px
+}
+
+.favicon-eosio {
+    background-position: 0 -2340px
+}
+
+.favicon-eosiometa {
+    background-position: 0 -2358px
+}
+
+.favicon-es {
+    background-position: 0 -2376px
+}
+
+.favicon-esmeta {
+    background-position: 0 -2394px
+}
+
+.favicon-esperanto {
+    background-position: 0 -2412px
+}
+
+.favicon-esperantometa {
+    background-position: 0 -2430px
+}
+
+.favicon-ethereum {
+    background-position: 0 -2448px
+}
+
+.favicon-ethereummeta {
+    background-position: 0 -2466px
+}
+
+.favicon-expatriates {
+    background-position: 0 -2484px
+}
+
+.favicon-expatriatesmeta {
+    background-position: 0 -2502px
+}
+
+.favicon-expressionengine {
+    background-position: 0 -2520px
+}
+
+.favicon-expressionenginemeta {
+    background-position: 0 -2538px
+}
+
+.favicon-fitness {
+    background-position: 0 -2556px
+}
+
+.favicon-fitnessmeta {
+    background-position: 0 -2574px
+}
+
+.favicon-freelancing {
+    background-position: 0 -2592px
+}
+
+.favicon-freelancingmeta {
+    background-position: 0 -2610px
+}
+
+.favicon-french {
+    background-position: 0 -2628px
+}
+
+.favicon-frenchmeta {
+    background-position: 0 -2646px
+}
+
+.favicon-gamedev {
+    background-position: 0 -2664px
+}
+
+.favicon-gamedevmeta {
+    background-position: 0 -2682px
+}
+
+.favicon-gamification {
+    background-position: 0 -2700px
+}
+
+.favicon-gamificationmeta {
+    background-position: 0 -2718px
+}
+
+.favicon-gaming {
+    background-position: 0 -2736px
+}
+
+.favicon-gamingmeta {
+    background-position: 0 -2754px
+}
+
+.favicon-gardening {
+    background-position: 0 -2772px
+}
+
+.favicon-gardeningmeta {
+    background-position: 0 -2790px
+}
+
+.favicon-genealogy {
+    background-position: 0 -2808px
+}
+
+.favicon-genealogymeta {
+    background-position: 0 -2826px
+}
+
+.favicon-german {
+    background-position: 0 -2844px
+}
+
+.favicon-germanmeta {
+    background-position: 0 -2862px
+}
+
+.favicon-gis {
+    background-position: 0 -2880px
+}
+
+.favicon-gismeta {
+    background-position: 0 -2898px
+}
+
+.favicon-graphicdesign {
+    background-position: 0 -2916px
+}
+
+.favicon-graphicdesignmeta {
+    background-position: 0 -2934px
+}
+
+.favicon-ham {
+    background-position: 0 -2952px
+}
+
+.favicon-hammeta {
+    background-position: 0 -2970px
+}
+
+.favicon-hardwarerecs {
+    background-position: 0 -2988px
+}
+
+.favicon-hardwarerecsmeta {
+    background-position: 0 -3006px
+}
+
+.favicon-hermeneutics {
+    background-position: 0 -3024px
+}
+
+.favicon-hermeneuticsmeta {
+    background-position: 0 -3042px
+}
+
+.favicon-hinduism {
+    background-position: 0 -3060px
+}
+
+.favicon-hinduismmeta {
+    background-position: 0 -3078px
+}
+
+.favicon-history {
+    background-position: 0 -3096px
+}
+
+.favicon-historymeta {
+    background-position: 0 -3114px
+}
+
+.favicon-homebrew {
+    background-position: 0 -3132px
+}
+
+.favicon-homebrewmeta {
+    background-position: 0 -3150px
+}
+
+.favicon-hsm {
+    background-position: 0 -3168px
+}
+
+.favicon-hsmmeta {
+    background-position: 0 -3186px
+}
+
+.favicon-i2p {
+    background-position: 0 -3204px
+}
+
+.favicon-i2pmeta {
+    background-position: 0 -3222px
+}
+
+.favicon-interpersonal {
+    background-position: 0 -3240px
+}
+
+.favicon-interpersonalmeta {
+    background-position: 0 -3258px
+}
+
+.favicon-iot {
+    background-position: 0 -3276px
+}
+
+.favicon-iota {
+    background-position: 0 -3294px
+}
+
+.favicon-iotameta {
+    background-position: 0 -3312px
+}
+
+.favicon-iotmeta {
+    background-position: 0 -3330px
+}
+
+.favicon-islam {
+    background-position: 0 -3348px
+}
+
+.favicon-islammeta {
+    background-position: 0 -3366px
+}
+
+.favicon-italian {
+    background-position: 0 -3384px
+}
+
+.favicon-italianmeta {
+    background-position: 0 -3402px
+}
+
+.favicon-ja {
+    background-position: 0 -3420px
+}
+
+.favicon-jameta {
+    background-position: 0 -3438px
+}
+
+.favicon-japanese {
+    background-position: 0 -3456px
+}
+
+.favicon-japanesemeta {
+    background-position: 0 -3474px
+}
+
+.favicon-joomla {
+    background-position: 0 -3492px
+}
+
+.favicon-joomlameta {
+    background-position: 0 -3510px
+}
+
+.favicon-judaism {
+    background-position: 0 -3528px
+}
+
+.favicon-judaismmeta {
+    background-position: 0 -3546px
+}
+
+.favicon-korean {
+    background-position: 0 -3564px
+}
+
+.favicon-koreanmeta {
+    background-position: 0 -3582px
+}
+
+.favicon-languagelearning {
+    background-position: 0 -3600px
+}
+
+.favicon-languagelearningmeta {
+    background-position: 0 -3618px
+}
+
+.favicon-latin {
+    background-position: 0 -3636px
+}
+
+.favicon-latinmeta {
+    background-position: 0 -3654px
+}
+
+.favicon-law {
+    background-position: 0 -3672px
+}
+
+.favicon-lawmeta {
+    background-position: 0 -3690px
+}
+
+.favicon-lifehacks {
+    background-position: 0 -3708px
+}
+
+.favicon-lifehacksmeta {
+    background-position: 0 -3726px
+}
+
+.favicon-linguistics {
+    background-position: 0 -3744px
+}
+
+.favicon-linguisticsmeta {
+    background-position: 0 -3762px
+}
+
+.favicon-literature {
+    background-position: 0 -3780px
+}
+
+.favicon-literaturemeta {
+    background-position: 0 -3798px
+}
+
+.favicon-magento {
+    background-position: 0 -3816px
+}
+
+.favicon-magentometa {
+    background-position: 0 -3834px
+}
+
+.favicon-martialarts {
+    background-position: 0 -3852px
+}
+
+.favicon-martialartsmeta {
+    background-position: 0 -3870px
+}
+
+.favicon-math {
+    background-position: 0 -3888px
+}
+
+.favicon-matheducators {
+    background-position: 0 -3906px
+}
+
+.favicon-matheducatorsmeta {
+    background-position: 0 -3924px
+}
+
+.favicon-mathematica {
+    background-position: 0 -3942px
+}
+
+.favicon-mathematicameta {
+    background-position: 0 -3960px
+}
+
+.favicon-mathmeta {
+    background-position: 0 -3978px
+}
+
+.favicon-mathoverflow {
+    background-position: 0 -3996px
+}
+
+.favicon-mathoverflowmeta {
+    background-position: 0 -4014px
+}
+
+.favicon-mattermodeling {
+    background-position: 0 -4032px
+}
+
+.favicon-mattermodelingmeta {
+    background-position: 0 -4050px
+}
+
+.favicon-mechanics {
+    background-position: 0 -4068px
+}
+
+.favicon-mechanicsmeta {
+    background-position: 0 -4086px
+}
+
+.favicon-medicalsciences {
+    background-position: 0 -4104px
+}
+
+.favicon-medicalsciencesmeta {
+    background-position: 0 -4122px
+}
+
+.favicon-monero {
+    background-position: 0 -4140px
+}
+
+.favicon-monerometa {
+    background-position: 0 -4158px
+}
+
+.favicon-money {
+    background-position: 0 -4176px
+}
+
+.favicon-moneymeta {
+    background-position: 0 -4194px
+}
+
+.favicon-movies {
+    background-position: 0 -4212px
+}
+
+.favicon-moviesmeta {
+    background-position: 0 -4230px
+}
+
+.favicon-music {
+    background-position: 0 -4248px
+}
+
+.favicon-musicfans {
+    background-position: 0 -4266px
+}
+
+.favicon-musicfansmeta {
+    background-position: 0 -4284px
+}
+
+.favicon-musicmeta {
+    background-position: 0 -4302px
+}
+
+.favicon-mythology {
+    background-position: 0 -4320px
+}
+
+.favicon-mythologymeta {
+    background-position: 0 -4338px
+}
+
+.favicon-neo {
+    background-position: 0 -4356px
+}
+
+.favicon-neometa {
+    background-position: 0 -4374px
+}
+
+.favicon-networkengineering {
+    background-position: 0 -4392px
+}
+
+.favicon-networkengineeringmeta {
+    background-position: 0 -4410px
+}
+
+.favicon-opendata {
+    background-position: 0 -4428px
+}
+
+.favicon-opendatameta {
+    background-position: 0 -4446px
+}
+
+.favicon-openscience {
+    background-position: 0 -4464px
+}
+
+.favicon-opensciencemeta {
+    background-position: 0 -4482px
+}
+
+.favicon-opensource {
+    background-position: 0 -4500px
+}
+
+.favicon-opensourcemeta {
+    background-position: 0 -4518px
+}
+
+.favicon-or {
+    background-position: 0 -4536px
+}
+
+.favicon-ormeta {
+    background-position: 0 -4554px
+}
+
+.favicon-outdoors {
+    background-position: 0 -4572px
+}
+
+.favicon-outdoorsmeta {
+    background-position: 0 -4590px
+}
+
+.favicon-parenting {
+    background-position: 0 -4608px
+}
+
+.favicon-parentingmeta {
+    background-position: 0 -4626px
+}
+
+.favicon-patents {
+    background-position: 0 -4644px
+}
+
+.favicon-patentsmeta {
+    background-position: 0 -4662px
+}
+
+.favicon-pets {
+    background-position: 0 -4680px
+}
+
+.favicon-petsmeta {
+    background-position: 0 -4698px
+}
+
+.favicon-philosophy {
+    background-position: 0 -4716px
+}
+
+.favicon-philosophymeta {
+    background-position: 0 -4734px
+}
+
+.favicon-photo {
+    background-position: 0 -4752px
+}
+
+.favicon-photometa {
+    background-position: 0 -4770px
+}
+
+.favicon-physics {
+    background-position: 0 -4788px
+}
+
+.favicon-physicsmeta {
+    background-position: 0 -4806px
+}
+
+.favicon-pm {
+    background-position: 0 -4824px
+}
+
+.favicon-pmmeta {
+    background-position: 0 -4842px
+}
+
+.favicon-poker {
+    background-position: 0 -4860px
+}
+
+.favicon-pokermeta {
+    background-position: 0 -4878px
+}
+
+.favicon-politics {
+    background-position: 0 -4896px
+}
+
+.favicon-politicsmeta {
+    background-position: 0 -4914px
+}
+
+.favicon-portuguese {
+    background-position: 0 -4932px
+}
+
+.favicon-portuguesemeta {
+    background-position: 0 -4950px
+}
+
+.favicon-productivity {
+    background-position: 0 -4968px
+}
+
+.favicon-productivitymeta {
+    background-position: 0 -4986px
+}
+
+.favicon-proofassistants {
+    background-position: 0 -5004px
+}
+
+.favicon-proofassistantsmeta {
+    background-position: 0 -5022px
+}
+
+.favicon-psychology {
+    background-position: 0 -5040px
+}
+
+.favicon-psychologymeta {
+    background-position: 0 -5058px
+}
+
+.favicon-puzzling {
+    background-position: 0 -5076px
+}
+
+.favicon-puzzlingmeta {
+    background-position: 0 -5094px
+}
+
+.favicon-quant {
+    background-position: 0 -5112px
+}
+
+.favicon-quantmeta {
+    background-position: 0 -5130px
+}
+
+.favicon-quantumcomputing {
+    background-position: 0 -5148px
+}
+
+.favicon-quantumcomputingmeta {
+    background-position: 0 -5166px
+}
+
+.favicon-raspberrypi {
+    background-position: 0 -5184px
+}
+
+.favicon-raspberrypimeta {
+    background-position: 0 -5202px
+}
+
+.favicon-retrocomputing {
+    background-position: 0 -5220px
+}
+
+.favicon-retrocomputingmeta {
+    background-position: 0 -5238px
+}
+
+.favicon-reverseengineering {
+    background-position: 0 -5256px
+}
+
+.favicon-reverseengineeringmeta {
+    background-position: 0 -5274px
+}
+
+.favicon-robotics {
+    background-position: 0 -5292px
+}
+
+.favicon-roboticsmeta {
+    background-position: 0 -5310px
+}
+
+.favicon-rpg {
+    background-position: 0 -5328px
+}
+
+.favicon-rpgmeta {
+    background-position: 0 -5346px
+}
+
+.favicon-ru {
+    background-position: 0 -5364px
+}
+
+.favicon-rumeta {
+    background-position: 0 -5382px
+}
+
+.favicon-rus {
+    background-position: 0 -5400px
+}
+
+.favicon-rusmeta {
+    background-position: 0 -5418px
+}
+
+.favicon-russian {
+    background-position: 0 -5436px
+}
+
+.favicon-russianmeta {
+    background-position: 0 -5454px
+}
+
+.favicon-salesforce {
+    background-position: 0 -5472px
+}
+
+.favicon-salesforcemeta {
+    background-position: 0 -5490px
+}
+
+.favicon-scicomp {
+    background-position: 0 -5508px
+}
+
+.favicon-scicompmeta {
+    background-position: 0 -5526px
+}
+
+.favicon-scifi {
+    background-position: 0 -5544px
+}
+
+.favicon-scifimeta {
+    background-position: 0 -5562px
+}
+
+.favicon-security {
+    background-position: 0 -5580px
+}
+
+.favicon-securitymeta {
+    background-position: 0 -5598px
+}
+
+.favicon-serverfault {
+    background-position: 0 -5616px
+}
+
+.favicon-serverfaultmeta {
+    background-position: 0 -5634px
+}
+
+.favicon-sharepoint {
+    background-position: 0 -5652px
+}
+
+.favicon-sharepointmeta {
+    background-position: 0 -5670px
+}
+
+.favicon-sitecore {
+    background-position: 0 -5688px
+}
+
+.favicon-sitecoremeta {
+    background-position: 0 -5706px
+}
+
+.favicon-skeptics {
+    background-position: 0 -5724px
+}
+
+.favicon-skepticsmeta {
+    background-position: 0 -5742px
+}
+
+.favicon-softwareengineering {
+    background-position: 0 -5760px
+}
+
+.favicon-softwareengineeringmeta {
+    background-position: 0 -5778px
+}
+
+.favicon-softwarerecs {
+    background-position: 0 -5796px
+}
+
+.favicon-softwarerecsmeta {
+    background-position: 0 -5814px
+}
+
+.favicon-sound {
+    background-position: 0 -5832px
+}
+
+.favicon-soundmeta {
+    background-position: 0 -5850px
+}
+
+.favicon-space {
+    background-position: 0 -5868px
+}
+
+.favicon-spacemeta {
+    background-position: 0 -5886px
+}
+
+.favicon-spanish {
+    background-position: 0 -5904px
+}
+
+.favicon-spanishmeta {
+    background-position: 0 -5922px
+}
+
+.favicon-sports {
+    background-position: 0 -5940px
+}
+
+.favicon-sportsmeta {
+    background-position: 0 -5958px
+}
+
+.favicon-sqa {
+    background-position: 0 -5976px
+}
+
+.favicon-sqameta {
+    background-position: 0 -5994px
+}
+
+.favicon-stackapps {
+    background-position: 0 -6012px
+}
+
+.favicon-stackexchange {
+    background-position: 0 -6030px
+}
+
+.favicon-stackexchangemeta {
+    background-position: 0 -6048px
+}
+
+.favicon-stackoverflow {
+    background-position: 0 -6066px
+}
+
+.favicon-stackoverflowmeta {
+    background-position: 0 -6084px
+}
+
+.favicon-stats {
+    background-position: 0 -6102px
+}
+
+.favicon-statsmeta {
+    background-position: 0 -6120px
+}
+
+.favicon-stellar {
+    background-position: 0 -6138px
+}
+
+.favicon-stellarmeta {
+    background-position: 0 -6156px
+}
+
+.favicon-substrate {
+    background-position: 0 -6174px
+}
+
+.favicon-substratemeta {
+    background-position: 0 -6192px
+}
+
+.favicon-superuser {
+    background-position: 0 -6210px
+}
+
+.favicon-superusermeta {
+    background-position: 0 -6228px
+}
+
+.favicon-sustainability {
+    background-position: 0 -6246px
+}
+
+.favicon-sustainabilitymeta {
+    background-position: 0 -6264px
+}
+
+.favicon-techcomm {
+    background-position: 0 -6282px
+}
+
+.favicon-techcommmeta {
+    background-position: 0 -6300px
+}
+
+.favicon-tex {
+    background-position: 0 -6318px
+}
+
+.favicon-texmeta {
+    background-position: 0 -6336px
+}
+
+.favicon-tezos {
+    background-position: 0 -6354px
+}
+
+.favicon-tezosmeta {
+    background-position: 0 -6372px
+}
+
+.favicon-tor {
+    background-position: 0 -6390px
+}
+
+.favicon-tormeta {
+    background-position: 0 -6408px
+}
+
+.favicon-travel {
+    background-position: 0 -6426px
+}
+
+.favicon-travelmeta {
+    background-position: 0 -6444px
+}
+
+.favicon-tridion {
+    background-position: 0 -6462px
+}
+
+.favicon-tridionmeta {
+    background-position: 0 -6480px
+}
+
+.favicon-ukrainian {
+    background-position: 0 -6498px
+}
+
+.favicon-ukrainianmeta {
+    background-position: 0 -6516px
+}
+
+.favicon-unix {
+    background-position: 0 -6534px
+}
+
+.favicon-unixmeta {
+    background-position: 0 -6552px
+}
+
+.favicon-ux {
+    background-position: 0 -6570px
+}
+
+.favicon-uxmeta {
+    background-position: 0 -6588px
+}
+
+.favicon-vegetarianism {
+    background-position: 0 -6606px
+}
+
+.favicon-vegetarianismmeta {
+    background-position: 0 -6624px
+}
+
+.favicon-vi {
+    background-position: 0 -6642px
+}
+
+.favicon-vimeta {
+    background-position: 0 -6660px
+}
+
+.favicon-webapps {
+    background-position: 0 -6678px
+}
+
+.favicon-webappsmeta {
+    background-position: 0 -6696px
+}
+
+.favicon-webmasters {
+    background-position: 0 -6714px
+}
+
+.favicon-webmastersmeta {
+    background-position: 0 -6732px
+}
+
+.favicon-windowsphone {
+    background-position: 0 -6750px
+}
+
+.favicon-windowsphonemeta {
+    background-position: 0 -6768px
+}
+
+.favicon-woodworking {
+    background-position: 0 -6786px
+}
+
+.favicon-woodworkingmeta {
+    background-position: 0 -6804px
+}
+
+.favicon-wordpress {
+    background-position: 0 -6822px
+}
+
+.favicon-wordpressmeta {
+    background-position: 0 -6840px
+}
+
+.favicon-workplace {
+    background-position: 0 -6858px
+}
+
+.favicon-workplacemeta {
+    background-position: 0 -6876px
+}
+
+.favicon-worldbuilding {
+    background-position: 0 -6894px
+}
+
+.favicon-worldbuildingmeta {
+    background-position: 0 -6912px
+}
+
+.favicon-writing {
+    background-position: 0 -6930px
+}
+
+.favicon-writingmeta {
+    background-position: 0 -6948px
+}
+
+.autocomplete {
+    position: relative
+}
+
+.autocomplete .autocomplete-suggestions-list {
+    background: hsl(0, 0%, 100%);
+    border: 1px solid hsl(210, 8%, 80%);
+    color: hsl(210, 8%, 45%);
+    position: absolute;
+    z-index: 999;
+    bottom: 6px;
+    left: 0;
+    right: 0;
+    transform: translate(0, 100%);
+    box-shadow: 0 6px 6px hsla(210, 8%, 5%, 0.1);
+    max-height: 350px;
+    overflow: auto
+}
+
+.autocomplete .autocomplete-suggestions-list a {
+    color: hsl(210, 8%, 45%)
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-category-name, .autocomplete .autocomplete-suggestions-list .autocomplete-suggestion, .autocomplete .autocomplete-suggestions-list .autocomplete-default, .autocomplete .autocomplete-suggestions-list .autocomplete-default {
+    padding: 10px
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-category-name {
+    background: #f6f6f7;
+    font-size: 11px;
+    text-transform: uppercase
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion {
+    cursor: pointer;
+    display: flex;
+    align-items: center
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion.child {
+    padding-left: 26px;
+    margin-top: -5px;
+    position: relative
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion.child:before {
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-left: 1px solid #b9c1c5;
+    border-bottom: 1px solid #b9c1c5;
+    position: relative;
+    top: -6px;
+    left: -6px
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion:hover, .autocomplete .autocomplete-suggestions-list .autocomplete-default:hover {
+    background: #eeeef0;
+    color: hsl(210, 8%, 5%)
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-item {
+    max-width: 90%;
+    word-wrap: break-word;
+    overflow: hidden;
+    flex-grow: 1;
+    margin-left: 6px
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-image {
+    width: 20px;
+    height: 20px;
+    overflow: hidden;
+    flex-shrink: 0
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-image img {
+    max-width: 100%;
+    height: auto
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-match {
+    color: hsl(210, 8%, 5%);
+    font-weight: 700
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-url {
+    font-size: 11px;
+    color: hsl(210, 8%, 75%)
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-suggestion-count {
+    font-size: 13px;
+    color: hsl(210, 8%, 60%)
+}
+
+.autocomplete .autocomplete-suggestions-list .autocomplete-default {
+    border-top: 1px solid hsl(210, 8%, 80%);
+    display: block
+}
+
+#tabs, .tabs {
+    float: right
+}
+
+#tabs a, .tabs a {
+    float: left;
+    margin-right: 8px;
+    padding: 12px 8px 14px;
+    color: var(--black-400);
+    line-height: 1;
+    text-decoration: none;
+    border-bottom: 2px solid transparent
+}
+
+#tabs a:last-child, .tabs a:last-child {
+    margin-right: 0
+}
+
+#tabs a:focus, .tabs a:focus {
+    outline: none
+}
+
+#tabs a:hover, .tabs a:hover {
+    color: var(--black-500);
+    border-bottom-color: var(--black-500)
+}
+
+#tabs a.youarehere, .tabs a.youarehere {
+    font-weight: 700;
+    color: var(--black-800);
+    border-bottom-color: var(--black-800)
+}
+
+#tabs .mod-flag-indicator, .tabs .mod-flag-indicator {
+    margin-left: -4px
+}
+
+#tabs .bounty-indicator-tab, .tabs .bounty-indicator-tab {
+    margin-right: 0;
+    padding: .4em .5em .3em;
+    vertical-align: middle;
+    line-height: 1
+}
+
+.subtabs, .filter {
+    box-sizing: border-box;
+    float: right;
+    margin: 0
+}
+
+.subtabs a, .filter a {
+    display: block;
+    margin: 0 0 0 2px;
+    padding: 8px;
+    border-bottom: 1px solid transparent;
+    color: var(--black-500);
+    font-size: 12px;
+    line-height: 1.92307692;
+    text-decoration: none;
+    transition: all 150ms cubic-bezier(.19, 1, .22, 1)
+}
+
+.subtabs a.youarehere, .filter a.youarehere, .subtabs a.active, .filter a.active, .subtabs a:hover, .filter a:hover {
+    border-color: var(--theme-primary-color);
+    color: var(--black-700);
+    text-decoration: none
+}
+
+.subtabs a.youarehere, .filter a.youarehere, .subtabs a.active, .filter a.active {
+    border-color: var(--theme-primary-color);
+    font-weight: 700
+}
+
+.subtabs a.youarehere:hover, .filter a.youarehere:hover, .subtabs a.active:hover, .filter a.active:hover {
+    border-color: var(--theme-primary-500);
+    color: var(--black-900)
+}
+
+.subtabs a {
+    float: right
+}
+
+.subtabs.filters.tag-synonyms {
+    width: auto
+}
+
+.filter {
+    margin: 0
+}
+
+.filter a {
+    display: inline-flex;
+    padding-left: 4px;
+    padding-right: 4px;
+    border-bottom-width: 2px
+}
+
+[class*="gravatar-wrapper-"] {
+    padding: 0;
+    overflow: hidden
+}
+
+[class*="gravatar-wrapper-"] img {
+    margin: 0 auto
+}
+
+.gravatar-wrapper-256, .gravatar-wrapper-164, .gravatar-wrapper-128, .gravatar-wrapper-256 img, .gravatar-wrapper-164 img, .gravatar-wrapper-128 img {
+    border-radius: 4px
+}
+
+.gravatar-wrapper-64, .gravatar-wrapper-50, .gravatar-wrapper-48, .gravatar-wrapper-64 img, .gravatar-wrapper-50 img, .gravatar-wrapper-48 img {
+    border-radius: 2px
+}
+
+.gravatar-wrapper-256, .gravatar-wrapper-256 img {
+    width: 256px;
+    height: 256px
+}
+
+.gravatar-wrapper-164, .gravatar-wrapper-164 img {
+    width: 164px;
+    height: 164px
+}
+
+.gravatar-wrapper-128, .gravatar-wrapper-128 img {
+    width: 128px;
+    height: 128px
+}
+
+.gravatar-wrapper-64, .gravatar-wrapper-64 img {
+    width: 64px;
+    height: 64px
+}
+
+.gravatar-wrapper-50, .gravatar-wrapper-50 img {
+    width: 50px;
+    height: 50px
+}
+
+.gravatar-wrapper-48, .gravatar-wrapper-48 img {
+    width: 48px;
+    height: 48px
+}
+
+.gravatar-wrapper-42, .gravatar-wrapper-42 img {
+    width: 42px;
+    height: 42px
+}
+
+.gravatar-wrapper-40, .gravatar-wrapper-40 img {
+    width: 40px;
+    height: 40px
+}
+
+.gravatar-wrapper-32, .gravatar-wrapper-32 img {
+    width: 32px;
+    height: 32px
+}
+
+.gravatar-wrapper-25, .gravatar-wrapper-25 img {
+    width: 25px;
+    height: 25px
+}
+
+.dropdown.left:before {
+    left: 4px
+}
+
+.dropdown.right:before {
+    right: 4px
+}
+
+.dropdown {
+    position: absolute !important;
+    top: 25px;
+    z-index: 100;
+    box-shadow: 0 2px 5px hsla(210, 8%, 5%, 0.3);
+    border-radius: 2px;
+    background-color: var(--white);
+    margin: 0
+}
+
+.dropdown:before {
+    position: absolute;
+    z-index: 101;
+    content: "";
+    width: 16px;
+    height: 16px;
+    top: -11px;
+    right: 4px;
+    background: url('https://cdn.sstatic.net/Img/filter-sprites.png?v=25267dbcd657') -16px 0 no-repeat;
+    background: url('https://cdn.sstatic.net/Img/filter-sprites.svg?v=d1e85fbf5198') -16px 0 no-repeat
+}
+
+.dropdown ul {
+    margin: 0
+}
+
+.dropdown li {
+    text-align: left;
+    white-space: nowrap;
+    position: relative;
+    border-bottom: 1px solid var(--black-050);
+    line-height: 12px;
+    display: block;
+    background-color: var(--white);
+    height: auto;
+    margin-bottom: 0;
+    transition: all .2s ease
+}
+
+.dropdown li:hover {
+    background-color: var(--black-025)
+}
+
+.dropdown li:active {
+    background-color: var(--black-050)
+}
+
+.dropdown li a.selected {
+    background-color: hsl(210, 8%, 95%);
+    color: hsl(210, 8%, 60%)
+}
+
+.dropdown li:first-child {
+    border-top: 1px solid var(--black-050)
+}
+
+.dropdown li .bounty-indicator-tab {
+    margin-left: 10px
+}
+
+.dropdown li .bounty-indicator-tab a:hover {
+    text-decoration: none
+}
+
+.dropdown li a {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 10px 10px 10px 10px;
+    display: inline-block
+}
+
+.dropdown li a#edit-favorite-tags {
+    width: auto;
+    font-size: 11px
+}
+
+.-is-active .-frequency-menu {
+    max-height: 40em
+}
+
+@keyframes spinnerRotate {
+    0% {
+        transform: rotate(0deg)
+    }
+
+    100% {
+        transform: rotate(360deg)
+    }
+}
+
+a.loading:before {
+    content: "";
+    position: relative;
+    display: inline-block;
+    top: 1px;
+    left: -4px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 2px solid hsl(205, 53%, 88%);
+    border-left-color: hsl(205, 56%, 76%);
+    transform: translateZ(0);
+    animation: spinnerRotate .8s infinite linear
+}
+
+.hero-background {
+    background-image: url("https://cdn.sstatic.net/Img/hero/anonymousHeroBackground.svg?v=b7f6054406b5");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center
+}
+
+.hero-box {
+    background: #437dcc;
+    margin: 40px 0;
+    color: hsl(0, 0%, 100%);
+    text-align: center;
+    position: relative
+}
+
+.hero-box .hero-content {
+    padding: 30px
+}
+
+.hero-box .hidden {
+    display: none
+}
+
+.hero-box .hero-title {
+    font-size: 1.46153846rem;
+    font-weight: 400;
+    margin-bottom: 30px
+}
+
+.hero-box .hero-title small {
+    display: block;
+    font-size: 1.30769231rem;
+    padding-top: 4px
+}
+
+.hero-box .subtitle {
+    font-size: 1.15384615rem
+}
+
+.hero-box .btn {
+    background: #f48024;
+    border-color: #9B6114;
+    box-shadow: inset 0 1px 0 #ffc272
+}
+
+.hero-box .btn.loading {
+    color: white
+}
+
+.hero-box .btn:hover {
+    background: #da670b
+}
+
+.modal {
+    max-width: 700px;
+    max-height: 900px;
+    min-width: 400px;
+    background-color: var(--white);
+    border-radius: 3px;
+    position: fixed !important;
+    z-index: 9999;
+    overflow: hidden
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .modal {
+        background-image: var(--black-100)
+    }
+}
+
+body.theme-dark .modal, .theme-dark__forced .modal {
+    background-image: var(--black-100)
+}
+
+.modal * {
+    box-sizing: border-box
+}
+
+.modal.auto-center {
+    left: 50% !important;
+    top: 50% !important;
+    transform: translate(-50%, -50%)
+}
+
+.modal.wmd-prompt-dialog {
+    padding: 0;
+    border: 0
+}
+
+.modal:focus {
+    outline: none
+}
+
+.modal .modal-close {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    z-index: 2;
+    font-family: var(--ff-sans);
+    color: var(--black-200);
+    font-size: 1.30769231rem;
+    font-weight: 600;
+    line-height: 1;
+    width: 30px;
+    height: 30px;
+    text-align: center;
+    padding-top: 7px;
+    border-radius: 50%;
+    cursor: pointer
+}
+
+.modal .modal-close:hover {
+    color: var(--black-600);
+    background: var(--black-050)
+}
+
+.modal .modal-content, .modal .modal-footer {
+    padding: 30px
+}
+
+.modal .modal-footer {
+    background: hsl(210, 8%, 25%);
+    color: hsl(0, 0%, 100%)
+}
+
+.modal .modal-footer a {
+    color: inherit;
+    text-decoration: underline
+}
+
+.modal .modal-footer a:hover {
+    color: hsl(0, 0%, 100%)
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: hsla(210, 8%, 5%, 0.5);
+    z-index: 1001
+}
+
+.modal.image-upload .modal-content {
+    text-align: center
+}
+
+.modal.image-upload .modal-options {
+    padding: 24px 0 9px 0;
+    color: var(--black-700)
+}
+
+.modal.image-upload .modal-options p {
+    margin-bottom: 0
+}
+
+.modal.image-upload .modal-options .ajax-loader {
+    margin-left: 10px
+}
+
+.modal.image-upload .modal-options-separator {
+    margin: 0 6px
+}
+
+.modal.image-upload .modal-dropzone-default, .modal.image-upload .modal-dropzone-preview {
+    border: 2px dashed var(--black-075);
+    height: 260px;
+    border-radius: 3px;
+    padding: 15px;
+    width: 620px;
+    position: relative
+}
+
+.modal.image-upload .modal-dropzone-default {
+    background: var(--black-050);
+    cursor: pointer;
+    transition: background 300ms ease, border 300ms ease
+}
+
+.modal.image-upload .modal-dropzone-default:hover, .modal.image-upload .modal-dropzone-default.hover {
+    background: var(--black-075);
+    border-color: var(--black-100)
+}
+
+.modal.image-upload .modal-dropzone-default:hover .modal-dropzone-img:before, .modal.image-upload .modal-dropzone-default.hover .modal-dropzone-img:before {
+    top: -50px
+}
+
+.modal.image-upload .modal-dropzone-default:hover .modal-dropzone-img:after, .modal.image-upload .modal-dropzone-default.hover .modal-dropzone-img:after {
+    top: -76px
+}
+
+.modal.image-upload .modal-dropzone-default>* {
+    pointer-events: none
+}
+
+.modal.image-upload .modal-dropzone-default .modal-dropzone-img {
+    background-image: url("https://cdn.sstatic.net/Img/img-upload.png?v=f6bb23984932");
+    background-image: url('https://cdn.sstatic.net/Img/img-upload.svg?v=16d9e4614ece'), none;
+    background-position: 0 0;
+    width: 86px;
+    height: 78px;
+    position: absolute;
+    top: 88px;
+    left: 50%;
+    margin-left: -43px
+}
+
+.modal.image-upload .modal-dropzone-default .modal-dropzone-img:before, .modal.image-upload .modal-dropzone-default .modal-dropzone-img:after {
+    position: absolute;
+    background-image: url("https://cdn.sstatic.net/Img/img-upload.png?v=f6bb23984932");
+    background-image: url('https://cdn.sstatic.net/Img/img-upload.svg?v=16d9e4614ece'), none;
+    display: block;
+    content: '';
+    transition: all .15s ease
+}
+
+.modal.image-upload .modal-dropzone-default .modal-dropzone-img:before {
+    background-position: -120px -21px;
+    width: 156px;
+    height: 65px;
+    top: -44px;
+    left: -33px
+}
+
+.modal.image-upload .modal-dropzone-default .modal-dropzone-img:after {
+    background-position: -130px -90px;
+    width: 53px;
+    height: 61px;
+    top: -66px;
+    left: 18px
+}
+
+.modal.image-upload .modal-dropzone-default p {
+    margin-top: 166px;
+    margin-bottom: 0;
+    color: var(--black-350);
+    font-size: 1.30769231rem
+}
+
+.modal.image-upload .modal-dropzone-default p b {
+    font-size: 2.07692308rem;
+    color: var(--black-500);
+    font-weight: 700;
+    display: block;
+    margin-bottom: 10px
+}
+
+.modal.image-upload .modal-options-error-message {
+    color: var(--red-500);
+    font-weight: bold
+}
+
+.modal.image-upload .modal-footer p {
+    padding-top: 12px
+}
+
+.modal.wmd-prompt-dialog.insert-link {
+    padding: 20px;
+    width: 470px;
+    overflow: visible
+}
+
+.modal.wmd-prompt-dialog.insert-link .tabs {
+    margin-bottom: 20px;
+    float: left;
+    width: 100%;
+    height: 41px;
+    border-bottom: 1px solid var(--black-050)
+}
+
+.modal.wmd-prompt-dialog.insert-link .notes {
+    padding: 5px
+}
+
+.modal.wmd-prompt-dialog.insert-link form {
+    padding: 0;
+    margin: 0;
+    float: left;
+    width: 100%;
+    position: relative
+}
+
+.modal.wmd-prompt-dialog.insert-link form input[type=text] {
+    display: block;
+    width: 100%;
+    margin: 0 auto
+}
+
+.modal.wmd-prompt-dialog.insert-link form input[type=button] {
+    margin: 20px 10px 0 0;
+    display: inline
+}
+
+.modal.wmd-prompt-dialog.insert-link form input[type=button].insert-hyperlink {
+    width: 5em
+}
+
+.popup {
+    z-index: 2000;
+    display: none;
+    position: absolute;
+    padding: 16px;
+    box-shadow: var(--bs-sm);
+    background-color: var(--white);
+    border: solid 1px var(--black-300)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .popup {
+        background-color: var(--black-100)
+    }
+}
+
+body.theme-dark .popup, .theme-dark__forced .popup {
+    background-color: var(--black-100)
+}
+
+.popup .already-flagged {
+    display: inline-block;
+    margin-left: 23px;
+    margin-top: 8px;
+    color: var(--red-700);
+    font-weight: 700
+}
+
+.popup .disabled-action {
+    cursor: default !important
+}
+
+.popup .disabled-action .action-desc, .popup .disabled-action .action-name {
+    opacity: .6;
+    cursor: default !important
+}
+
+.popup textarea {
+    width: 100%
+}
+
+.popup .subheader {
+    margin-bottom: 10px !important;
+    margin-top: 25px !important
+}
+
+.popup .popup-title-container {
+    margin-bottom: 10px
+}
+
+.popup .popup-title-container .popup-breadcrumbs .breadcrumb .arrow {
+    padding: 0 6px
+}
+
+.popup #search-text, .popup .close-as-duplicate-pane .actual-edit-overlay {
+    width: 755px !important
+}
+
+.popup .question-summary {
+    border: 0
+}
+
+.message.message-config, .contributor-dropdown, .ask-confirmation-popup {
+    border-radius: 5px;
+    border: 0;
+    box-shadow: var(--bs-sm)
+}
+
+.message.message-config .message-close, .contributor-dropdown .message-close, .ask-confirmation-popup .message-close, .message.message-config .popup-close a, .contributor-dropdown .popup-close a, .ask-confirmation-popup .popup-close a {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    z-index: 2;
+    top: 11px;
+    right: 10px;
+    border: 0;
+    font-size: 1.30769231rem;
+    cursor: pointer;
+    color: var(--black-200) !important;
+    font-weight: 600
+}
+
+.message.message-config .message-close:hover, .contributor-dropdown .message-close:hover, .ask-confirmation-popup .message-close:hover, .message.message-config .popup-close a:hover, .contributor-dropdown .popup-close a:hover, .ask-confirmation-popup .popup-close a:hover {
+    color: var(--black-600) !important
+}
+
+.message.message-config .popup-close a, .contributor-dropdown .popup-close a, .ask-confirmation-popup .popup-close a {
+    background: none;
+    right: 22px
+}
+
+.ask-confirmation-popup .popup-close a {
+    top: 16px;
+    right: 16px
+}
+
+.ask-confirmation-popup .popup-title {
+    padding-right: 32px
+}
+
+.ask-confirmation-popup .popup-actions {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 8px
+}
+
+.ask-confirmation-popup .popup-actions-cancel {
+    margin-right: 16px
+}
+
+.message.message-config .message-tip .popup-title {
+    font-weight: 700 !important
+}
+
+.message.message-config .message-tip.message-tip-top-right:before, .message.message-config .message-tip.message-tip-top-left:before {
+    width: 0;
+    height: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-bottom: 6px solid var(--white);
+    top: -12px
+}
+
+.message.message-config .message-tip.message-tip-top-right:before {
+    right: 12px
+}
+
+.message.message-config .message-tip.message-tip-top-left:before {
+    left: 12px
+}
+
+.message.message-config h1, .message.message-config h2, .message.message-config h3, .message.message-config h4 {
+    color: var(--black-900);
+    margin-bottom: 1em
+}
+
+.message.message-config h4 {
+    text-align: left;
+    letter-spacing: 0;
+    margin-right: 16px
+}
+
+.message.message-config h4.popup-nav-title {
+    text-align: center;
+    margin: 0 15px 15px 10px
+}
+
+.message.message-config .actions {
+    margin: 20px -20px -20px -20px;
+    padding: 0 15px 0 15px;
+    background: hsl(210, 8%, 25%);
+    height: 48px;
+    border-radius: 0 0 3px 3px
+}
+
+.message.message-config .actions:before, .message.message-config .actions:after {
+    content: "";
+    display: table
+}
+
+.message.message-config .actions:after {
+    clear: both
+}
+
+.message.message-config .actions .rep-number, .message.message-config .actions .button {
+    text-align: center;
+    font-size: 12px
+}
+
+.message.message-config .actions .rep-number {
+    float: left;
+    display: inline-block;
+    color: hsl(0, 0%, 100%);
+    font-weight: 700;
+    padding-top: 16px
+}
+
+.message.message-config .actions .button {
+    float: right;
+    padding: 8px 16px;
+    margin-top: 10px;
+    text-decoration: none;
+    display: inline-block;
+    color: hsl(0, 0%, 100%) !important;
+    font-weight: 600;
+    background: var(--blue-400);
+    box-shadow: none !important;
+    border: 0;
+    border-radius: 3px
+}
+
+.message.message-config .actions .button:hover {
+    background: var(--blue-600)
+}
+
+.message.message-config .actions .button:after {
+    content: " ";
+    display: inline-block;
+    background-image: url("https://cdn.sstatic.net/Img/user-profile-sprite.png?v=6829b895a42c");
+    background-image: url("https://cdn.sstatic.net/Img/user-profile-sprite.svg?v=d88bb7069e3d"), none;
+    background-position: -15px -409px;
+    width: 7px;
+    height: 10px;
+    position: relative;
+    top: 2px;
+    left: 4px
+}
+
+.message.message-config .message-text {
+    padding: 20px !important;
+    border-radius: 6px;
+    position: relative;
+    z-index: 1
+}
+
+.message.message-config .message-text .question-hyperlink, .message.message-config .message-text .answer-hyperlink {
+    font-size: 13px;
+    text-decoration: none;
+    color: var(--theme-post-title-color)
+}
+
+.message.message-config .message-text .question-hyperlink:hover, .message.message-config .message-text .answer-hyperlink:hover {
+    color: var(--theme-post-title-color-hover)
+}
+
+.message.message-config .popup-nav {
+    list-style: none;
+    margin: 0 -20px -20px -20px;
+    padding: 0;
+    text-align: center
+}
+
+.message.message-config .popup-nav li {
+    margin: 0;
+    padding: 0;
+    border-bottom: 1px solid var(--black-050)
+}
+
+.message.message-config .popup-nav li:last-child {
+    border-bottom: 0
+}
+
+.message.message-config .popup-nav li:first-child {
+    border-top: 1px solid var(--black-050)
+}
+
+.message.message-config .popup-nav li a {
+    transition: color .3s ease, background .3s ease;
+    text-decoration: none;
+    color: var(--black-500);
+    font-size: 13px;
+    display: block;
+    padding: 10px 15px
+}
+
+.message.message-config .popup-nav li a:hover, .message.message-config .popup-nav li a.active, .message.message-config .popup-nav li a.youarehere {
+    background: var(--blue-600);
+    color: var(--white)
+}
+
+.message.message-config .unstyled {
+    padding: 0;
+    list-style: none;
+    text-align: center;
+    margin: 0 -20px -20px -20px
+}
+
+.message.message-config .unstyled li {
+    border-bottom: 1px solid var(--black-050);
+    padding: 10px
+}
+
+.message.message-config .unstyled li .badge {
+    text-decoration: none
+}
+
+.message.message-config .unstyled li:first-child {
+    border-top: 1px solid var(--black-050)
+}
+
+.message.message-config .unstyled li:last-child {
+    border-bottom: 0
+}
+
+.message.message-config.tooltip {
+    border-radius: 3px;
+    pointer-events: none
+}
+
+.message.message-config.tooltip .message-inner:before {
+    display: none
+}
+
+.message.message-config.tooltip .message-text {
+    font-weight: 500;
+    font-size: 11px;
+    color: var(--black-900);
+    padding: 3px 8px !important;
+    border-radius: 3px
+}
+
+.message.message-config .no-cta p {
+    margin-bottom: 0
+}
+
+.message.message-config .no-cta .bars-wrapper {
+    margin-top: 10px
+}
+
+.envelope-on, .envelope-off, .vote-up-off, .vote-up-on, .vote-down-off, .vote-down-on, .feed-icon, .vote-accepted-off, .vote-accepted-on, .vote-accepted-bounty, .badge-earned-check, .delete-tag, .grippie, .expander-arrow-hide, .expander-arrow-show, .expander-arrow-small-hide, .expander-arrow-small-show, .anonymous-gravatar, .badge1, .badge2, .badge3 {
+    background-image: url("https://cdn.sstatic.net/Img/unified/sprites.png?v=0786b22b9381");
+    background-image: url("https://cdn.sstatic.net/Img/unified/sprites.svg?v=fcc0ea44ba27"), none;
+    background-size: initial;
+    background-repeat: no-repeat;
+    overflow: hidden
+}
+
+.vote-up-off, .vote-up-on, .vote-down-off, .vote-down-on, .vote-accepted-off, .vote-accepted-on {
+    display: block;
+    margin: 0 auto;
+    text-indent: -999em;
+    width: 40px;
+    height: 40px;
+    margin-bottom: 2px
+}
+
+.vote-up-off, .vote-down-off, .vote-accepted-off {
+    cursor: pointer
+}
+
+.vote-up-off, .vote-up-on, .vote-down-off, .vote-down-on, .vote-accepted-off, .vote-accepted-on {
+    text-indent: -9999em;
+    font-size: 1px
+}
+
+.vote-up-off {
+    background-position: 0 -170px
+}
+
+.vote-up-on {
+    background-position: -40px -170px
+}
+
+.vote-down-off {
+    background-position: 0 -220px;
+    margin-bottom: 8px
+}
+
+.vote-down-on {
+    background-position: -40px -220px;
+    margin-bottom: 8px
+}
+
+.vote-accepted-off {
+    background-position: 0 -270px
+}
+
+.vote-accepted-on {
+    background-position: -40px -270px
+}
+
+.migrated.to, .migrated.from {
+    background-image: url("https://cdn.sstatic.net/Img/unified/sprites.png?v=0786b22b9381") !important;
+    background-repeat: no-repeat;
+    overflow: hidden;
+    background-color: transparent
+}
+
+.icon-bg {
+    display: inline-block;
+    border: none;
+    height: 18px;
+    width: 18px;
+    padding: 0
+}
+
+.icon-bg::after {
+    content: "";
+    height: 100%;
+    width: 100%;
+    display: inline-block;
+    background-color: currentColor;
+    -webkit-mask: var(--bg-icon) no-repeat center;
+    mask: var(--bg-icon) no-repeat center;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.icon-bg.native::after {
+    background-color: unset;
+    -webkit-mask: none;
+    mask: none;
+    background-image: var(--bg-icon);
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center
+}
+
+.icon-bg.iconAchievements {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconAchievements' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M15 2V1H3v1H0v4c0 1.6 1.4 3 3 3v1c.4 1.5 3 2.6 5 3v2H5s-1 1.5-1 2h10c0-.4-1-2-1-2h-3v-2c2-.4 4.6-1.5 5-3V9c1.6-.2 3-1.4 3-3V2h-3zM3 7c-.5 0-1-.5-1-1V4h1v3zm8.4 2.5L9 8 6.6 9.4l1-2.7L5 5h3l1-2.7L10 5h2.8l-2.3 1.8 1 2.7h-.1zM16 6c0 .5-.5 1-1 1V4h1v2z'/%3E%3C/svg%3E")
+}
+
+.icon-bg.iconFaceMindBlown {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconFaceMindBlown' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath opacity='.4' d='M1.06 8a8 8 0 1015.88 0H16l-1 .5-1-.5h-1.5l-1.5.5L9 8l-.5.5-1-.5H6l-1 .5-.5-.5h-1l-.5.5L2 8h-.94z' fill='%23FFAA3B'/%3E%3Cpath opacity='.3' d='M3.5 8h.41a11.5 11.5 0 0010.38 7A8 8 0 011.06 8H2l1 .5.5-.5z' fill='%23FF9700'/%3E%3Cpath d='M6.07 14.68a.7.7 0 00.67.28c1.5-.16 3.01-.16 4.51 0a.71.71 0 00.67-.28.7.7 0 00.06-.72A3.23 3.23 0 009 12.36a3.3 3.3 0 00-3 1.6.7.7 0 00.07.72z' fill='var(--black-900)'/%3E%3Cpath d='M7.36 4.37c.18.23.4.42.68.55a2.19 2.19 0 001.95 0c.26-.13.48-.31.65-.53.15.93.36 2.29.36 2.61 0 .5-4 .5-4 0 0-.32.21-1.7.36-2.63z' fill='%23F75D37'/%3E%3Cpath opacity='.67' d='M15.33 2.43a2.8 2.8 0 00-1.73-.53c-.06-.4-.28-.76-.64-1.05-.35-.26-.8-.44-1.27-.5-.49-.06-.98 0-1.42.16A2.9 2.9 0 008.4.08c-.39.05-.75.17-1.06.36A3.04 3.04 0 006.02.37c-.8.13-1.48.6-1.72 1.2-.11.27-.13.55-.07.83-.77.07-1.47.45-1.8.99-.6.98.26 2.4 1.6 2.6.97.14 2.13-.15 2.63-.79.22-.27.33-.58.34-.9.21.26.5.47.86.62a2.92 2.92 0 002.28 0c.35-.15.64-.37.85-.63.04.43.27.83.65 1.14a2.93 2.93 0 003.03.25c.81-.42 1.42-1.42 1.32-2.16-.05-.41-.28-.8-.66-1.09z' fill='%23FFC166'/%3E%3Cpath opacity='.78' d='M7.4 2c1.19 0 2.3-.2 3.26-.55.9 1.2 2.88 2.13 5.32 2.44A2.61 2.61 0 0113.1 6a2.68 2.68 0 01-1.45-.56A1.65 1.65 0 0111 4.3c-.2.26-.5.48-.85.63a2.92 2.92 0 01-2.28 0A2.21 2.21 0 017 4.3c0 .32-.12.63-.34.9-.5.64-1.66.93-2.62.78-1.35-.2-2.22-1.6-1.6-2.6a2.36 2.36 0 011.79-.98 1.4 1.4 0 01.1-.88c.9.3 1.95.48 3.07.48z' fill='%23FFC166'/%3E%3Cpath opacity='.52' d='M11.09 3.47a7.43 7.43 0 01-5.43.05c-1 .27-2.17.44-3.42.47-.06.88.71 1.83 1.8 2 .96.14 2.12-.15 2.62-.79.22-.27.33-.58.34-.9.21.26.5.47.86.62a2.92 2.92 0 002.28 0c.35-.15.64-.37.85-.63.04.43.27.83.65 1.14a2.93 2.93 0 003.03.25c.35-.18.66-.47.9-.8a11.57 11.57 0 01-4.48-1.4z' fill='%23F75D37'/%3E%3Ccircle cx='11' cy='10.5' r='1.35' fill='var(--black-900)'/%3E%3Ccircle cx='7' cy='10.5' r='1.35' fill='var(--black-900)'/%3E%3Ccircle opacity='.6' cx='3.5' cy='6.5' r='.5'/%3E%3Ccircle opacity='.6' cx='14.5' cy='.5' r='.5'/%3E%3Ccircle opacity='.6' cx='14.5' cy='6.5' r='.5'/%3E%3Ccircle opacity='.6' cx='16.5' cy='4.5' r='.5'/%3E%3Ccircle opacity='.6' cx='3.5' cy='.5' r='.5'/%3E%3Ccircle opacity='.6' cx='1.5' cy='3.5' r='.5'/%3E%3C/svg%3E")
+}
+
+.icon-bg.iconWave {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconWave' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M10.7 17c-2.3 0-3.9-2.05-5.07-3.54l-.49-.6c-.67-.8-1.59-1.63-2.4-2.36A10.91 10.91 0 011.1 8.87a.79.79 0 01-.09-.56c.04-.19.14-.34.27-.4.14-.07.29-.1.45-.1.35 0 .67.18.87.34l3.5 2.75c.04.03.1.03.13 0a.09.09 0 00.02-.13l-.02-.02c-.57-.8-3.42-4.77-3.71-5.15-.21-.27-.3-.58-.24-.84.05-.2.2-.37.4-.48.18-.09.35-.13.52-.13.44 0 .76.28.96.51l3.6 4.42c.04.04.07.06.14.02.05-.02.06-.07.03-.12L4.41 2.96a.94.94 0 01-.1-.73.92.92 0 01.47-.57 1.06 1.06 0 011.4.39l3.8 6.14c.03.04.07.07.14.04.04-.03.06-.07.04-.13A153.8 153.8 0 008.1 2.54c-.31-.68-.2-1.14.36-1.42.52-.27 1.14-.07 1.47.48l3.69 8.3c.02.04.05.05.1.06a.1.1 0 00.09-.07l.66-2.28c.1-.3.31-.56.62-.72.3-.15.65-.18.98-.1.7.2 1.09.87.89 1.52-.1.37-.46 1.73-.99 3.43l-.1.33c-.58 1.86-1.03 3.33-3.11 4.4-.7.35-1.38.53-2.05.53z' fill='%23FFC166'/%3E%3Cpath d='M14 .37a.5.5 0 00-.88.45l1.96 3.9a.5.5 0 00.9-.45L14 .37zm-1.17 2.17a.5.5 0 00-.91.42l.84 1.87a.5.5 0 10.91-.41l-.84-1.88zm-10.6 9.74a.5.5 0 01.7-.02l1.7 1.6a.5.5 0 01-.7.72l-1.68-1.6a.5.5 0 01-.02-.7zm-1.39.98a.5.5 0 10-.68.73l3.03 2.84a.5.5 0 00.68-.73L.84 13.26z' opacity='.4'/%3E%3C/svg%3E")
+}
+
+.icon-bg.iconFire {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconFire' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath opacity='.6' d='M13.18 9c-.8.33-1.46.6-1.97 1.3A9.21 9.21 0 0010 13.89a10 10 0 001.32-.8 2.53 2.53 0 01-.63 2.91h.78a3 3 0 001.66-.5 4.15 4.15 0 001.26-1.61c.4-.96.47-1.7.55-2.73.05-1.24-.1-2.49-.46-3.68a2 2 0 01-.4.91 2.1 2.1 0 01-.9.62z' fill='%23FF6700'/%3E%3Cpath d='M10.4 12.11a7.1 7.1 0 01.78-1.76c.3-.47.81-.8 1.37-1.08 0 0-.05-3.27-1.55-5.27-1.5-2-3.37-2.75-4.95-2.61 0 0 3.73 2.42.72 5.15C4.63 8.45 3.59 10.87 4.13 13a4.14 4.14 0 003.1 3 4.05 4.05 0 011.08-3.89C9.42 10.92 8 9.79 8 9.79c.67.02 1.3.28 1.81.72a2 2 0 01.58 1.6z' fill='%23EF2E2E'/%3E%3C/svg%3E")
+}
+
+.icon-bg.iconHeart {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconHeart' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M5.25 2c-1.5 0-2.35.5-3.15 1.36C.5 5 .5 8.2 2.1 10l6 5.87c.2.2.6.2.8 0l6-5.87c1.6-1.8 1.6-5 0-6.64A3.86 3.86 0 0011.75 2C10.2 2 9 3 8.5 3.9 8 3 6.5 2 5.25 2zm8.6 4.85l-2 2a.5.5 0 01-.7-.7l2-2a.5.5 0 01.7.7z' fill='%23F75D37'/%3E%3C/svg%3E")
+}
+
+.icon-bg.iconClap {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconClap' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M12.5 3a.5.5 0 01-.5-.5v-2a.5.5 0 011 0v2a.5.5 0 01-.5.5zM14 4.5c0-.28.22-.5.5-.5h2a.5.5 0 010 1h-2a.5.5 0 01-.5-.5zm-.35-1.85a.5.5 0 00.7.7l1.5-1.5a.5.5 0 00-.7-.7l-1.5 1.5z' opacity='.4'/%3E%3Cpath d='M2.58 8.69c.33.45.73.8 1.15 1.06L5.8 6c.17-.29.4-.56.68-.74.44-.28.99-.26 1.4-.02h.02c.32-.04 1.6-.06 2.73-.08a41.5 41.5 0 001.77-.04c.49-.04.68-.3.65-.75-.02-.46-.44-.65-.9-.6l-6.76.36c-.05.01-.1-.07-.07-.11l1.03-1.36c.3-.4.16-.97-.21-1.26a.87.87 0 00-1.25.13C4.3 2.26 3.74 3 3.19 3.76c-1.08 1.47-1.83 3.29-.61 4.93zm10.1.41h-.75c.11-.23.18-.47.17-.73 0-.19-.06-.37-.15-.53l.73.01c.41.03.68.35.68.6 0 .24-.23.66-.68.65zM10.9 7.15l2.6-.02a.66.66 0 00.6-.77c-.08-.41-.47-.64-.87-.64l-2.66.04c.35.37.48.9.33 1.4zM5.52 17c-2.04 0-3.15-1.78-3.7-3.52a53.2 53.2 0 01-.77-2.7c-.15-.46.14-.94.63-1.07.47-.13 1 .1 1.15.58l.47 1.63c.02.06.11.06.14 0l3.01-5.54c.24-.4.6-.73.97-.54.4.2.47.54.25 1.02-.08.18-.33.66-.63 1.22-.51.96-1.15 2.16-1.26 2.49-.01.04-.03.21.08.29.1.07.28-.06.3-.09l2.71-4.14c.2-.34.63-.66.98-.48.34.18.46.6.26.93L7.37 11.2c-.02.03-.14.32.05.43.19.12.4-.04.42-.07L10.2 8.3c.27-.31.51-.51.9-.32.34.18.33.61.06.97-.45.6-.8 1.13-1.16 1.64-.4.58-.8 1.15-1.28 1.8-.02.03-.13.23 0 .37.12.13.27 0 .27 0l1.9-2.3c.23-.3.48-.42.8-.25.28.14.22.58.09.8-.53.91-1.2 1.72-1.86 2.53C8.75 14.94 7.55 17 5.52 17z' fill='%23FFC166'/%3E%3C/svg%3E")
+}
+
+.icon-bg.iconFaceSmile {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconFaceSmile' width='18' height='18' viewBox='0 0 18 18'%3E%3Ccircle opacity='.4' cx='9' cy='9' r='8' fill='%23FFAA3B'/%3E%3Cpath opacity='.3' d='M8.41 17a10 10 0 01.38-15.75c.1-.08.2-.16.28-.25a8 8 0 00-.66 16z' fill='%23FF9700'/%3E%3Cpath d='M6.5 8a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm2.6 6a7.37 7.37 0 01-4.79-2.06 1.1 1.1 0 010-1.54c.42-.51 1.15-.51 1.67-.1.31.3 3.23 2.88 6.14 0a1.06 1.06 0 011.57.1 1.1 1.1 0 010 1.54C12.13 13.38 10.56 14 9.1 14zM13 6.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z' fill='var(--black-900)'/%3E%3C/svg%3E")
+}
+
+.icon-bg.iconTada {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconTada' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath opacity='.4' d='M10.38 7.48c-2.9-2.9-5.4-3.73-5.51-3.38l-3.8 11.45c-.14.4-.03.86.27 1.15.3.3.78.38 1.17.22l11.42-3.31c.3-.15-.64-3.22-3.54-6.13z' fill='%23FF9700'/%3E%3Cpath d='M6.8 11.07a18.02 18.02 0 01-2.93-3.96l1-3C5.47 6.15 6.65 8 8.25 9.4a21.72 21.72 0 005.59 4.22l-2.86.83a31.19 31.19 0 01-4.17-3.39zM3.6 14.2a4.26 4.26 0 01-1.33-2.24l.91-2.74c.5 1.27 1.25 2.43 2.2 3.4.95.95 2 1.81 3.1 2.57l-2.57.74a9.03 9.03 0 01-2.31-1.72z' opacity='.6' fill='%23FF9700'/%3E%3Cpath d='M15.85 2.15c.2.2.2.5 0 .7l-4 4a.5.5 0 01-.7-.7l4-4c.2-.2.5-.2.7 0z' fill='%23F75D37'/%3E%3Cpath d='M10 1.5a.5.5 0 00-1 0v3a.5.5 0 001 0v-3zM13.5 8a.5.5 0 000 1h3a.5.5 0 000-1h-3z' fill='%2307C'/%3E%3Cpath d='M7.5 3a.5.5 0 100-1 .5.5 0 000 1zm5 0a.5.5 0 100-1 .5.5 0 000 1zM16 5.5a.5.5 0 11-1 0 .5.5 0 011 0zm-.5 5.5a.5.5 0 100-1 .5.5 0 000 1z' opacity='.6' fill='%2307C'/%3E%3C/svg%3E")
+}
+
+.icon-bg.iconSmileyAdd {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' class='svg-icon iconSmileyAdd' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M13 0h2v3h3v2h-3v3h-2V5h-3V3h3V0zM6.44 2.15A8 8 0 018 2v2a6 6 0 106 6h2a8 8 0 11-9.56-7.85zM8.1 14.22a5.51 5.51 0 01-3.72-1.6.88.88 0 011.24-1.24 3.24 3.24 0 004.76 0 .88.88 0 011.24 1.24 4.9 4.9 0 01-3.52 1.6zM7.25 8a1.25 1.25 0 11-2.5 0 1.25 1.25 0 012.5 0zM10 9.25a1.25 1.25 0 100-2.5 1.25 1.25 0 000 2.5z'/%3E%3C/svg%3E")
+}
+
+.informative-tooltip {
+    position: absolute;
+    padding: .8em;
+    max-width: 200px;
+    z-index: 3000;
+    border-radius: 3px;
+    background: #474747;
+    font-size: 12px;
+    color: hsl(0, 0%, 100%)
+}
+
+.informative-tooltip.arrow:before {
+    position: absolute;
+    content: "";
+    width: 0;
+    height: 0
+}
+
+.informative-tooltip.arrow.up-left:before, .informative-tooltip.arrow.up-center:before, .informative-tooltip.arrow.up-right:before {
+    top: -4px;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid #474747
+}
+
+.informative-tooltip.arrow.up-center:before {
+    left: 50%;
+    margin-left: -5px
+}
+
+.informative-tooltip.arrow.up-left:before {
+    left: 10px
+}
+
+.informative-tooltip.arrow.up-right:before {
+    right: 10px
+}
+
+.informative-tooltip.arrow.down-left:before, .informative-tooltip.arrow.down-center:before, .informative-tooltip.arrow.down-right:before {
+    bottom: -4px;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #474747
+}
+
+.informative-tooltip.arrow.down-center:before {
+    left: 50%;
+    margin-left: -5px
+}
+
+.informative-tooltip.arrow.down-left:before {
+    left: 10px
+}
+
+.informative-tooltip.arrow.down-right:before {
+    right: 10px
+}
+
+.informative-tooltip.arrow.left-top:before, .informative-tooltip.arrow.left-center:before, .informative-tooltip.arrow.left-bottom:before {
+    left: -4px;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-right: 5px solid #474747
+}
+
+.informative-tooltip.arrow.left-center:before {
+    top: 50%;
+    margin-top: -5px
+}
+
+.informative-tooltip.arrow.left-top:before {
+    top: 10px
+}
+
+.informative-tooltip.arrow.left-bottom:before {
+    bottom: 10px
+}
+
+.informative-tooltip.arrow.right-top:before, .informative-tooltip.arrow.right-center:before, .informative-tooltip.arrow.right-bottom:before {
+    right: -4px;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 5px solid #474747
+}
+
+.informative-tooltip.arrow.right-center:before {
+    top: 50%;
+    margin-top: -5px
+}
+
+.informative-tooltip.arrow.right-top:before {
+    top: 10px
+}
+
+.informative-tooltip.arrow.right-bottom:before {
+    bottom: 10px
+}
+
+.informative-tooltip.error {
+    background: hsl(358, 68%, 59%);
+    color: white
+}
+
+.informative-tooltip.display-above, .informative-tooltip.display-right {
+    top: 0;
+    max-width: none
+}
+
+.informative-tooltip.display-above:before, .informative-tooltip.display-right:before {
+    content: "";
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent
+}
+
+.informative-tooltip.display-above.size-200, .informative-tooltip.display-right.size-200 {
+    width: 200px
+}
+
+.informative-tooltip.display-above.error:before, .informative-tooltip.display-right.error:before {
+    border-top-color: hsl(358, 68%, 59%)
+}
+
+.informative-tooltip.display-above {
+    left: 50%;
+    transform: translate(-50%, -110%)
+}
+
+.informative-tooltip.display-above:before {
+    bottom: -4px;
+    left: 50%;
+    margin-left: -5px;
+    border-bottom-width: 0;
+    border-top-color: #474747
+}
+
+.informative-tooltip.display-right {
+    right: 50%;
+    transform: translate(115%, 0%)
+}
+
+.informative-tooltip.display-right:before {
+    left: -4px;
+    top: 50%;
+    margin-top: -5px;
+    border-left-width: 0;
+    border-right-color: #474747
+}
+
+.has-tooltip {
+    position: relative
+}
+
+.has-tooltip .informative-tooltip {
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 300ms ease, transform 300ms ease
+}
+
+.has-tooltip:hover .informative-tooltip {
+    opacity: 1;
+    visibility: visible
+}
+
+.has-tooltip.on-hover .tooltip-above.arrow.down-right {
+    right: -6px;
+    top: -10px;
+    -webkit-transform: translate(0, -80%);
+    transform: translate(0, -80%)
+}
+
+.has-tooltip.on-hover:hover .tooltip-above.arrow.down-right {
+    -webkit-transform: translate(0, -100%);
+    transform: translate(0, -100%)
+}
+
+.has-tooltip .informative-tooltip.display-above {
+    transform: translate(-50%, -80%)
+}
+
+.has-tooltip:hover .informative-tooltip.display-above {
+    transform: translate(-50%, -110%)
+}
+
+.has-tooltip .informative-tooltip.display-right {
+    transform: translate(120%, 0%)
+}
+
+.has-tooltip:hover .informative-tooltip.display-right {
+    transform: translate(115%, 0%)
+}
+
+.css-tooltip {
+    position: relative
+}
+
+.css-tooltip[data-title]:hover:after {
+    content: attr(data-title);
+    background: #474747;
+    padding: .8em;
+    margin-left: 5px;
+    max-width: 200px;
+    color: hsl(0, 0%, 100%);
+    font-size: 12px;
+    border-radius: 3px;
+    position: absolute;
+    z-index: 1031;
+    left: 0;
+    top: 100%
+}
+
+.users-grid {
+    margin-bottom: 30px;
+    display: flex;
+    flex-wrap: wrap
+}
+
+.users-grid .-user {
+    border: 1px solid var(--black-050);
+    border-radius: 3px;
+    padding: 20px 10px 20px 20px;
+    margin: 0 20px 20px 0;
+    width: calc((100% / 3) - (40px / 3));
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center
+}
+
+.users-grid .-user .-details {
+    padding-left: 15px;
+    max-width: calc(100% - 64px);
+    flex-grow: 2
+}
+
+.users-grid .-user .-details>*:not(:last-child) {
+    margin-bottom: 4px
+}
+
+.users-grid .-user .-details h3, .users-grid .-user .-details p {
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+.users-grid .-user .-details h3 {
+    font-weight: 400;
+    font-size: 1.30769231rem
+}
+
+.users-grid .-user .-details p {
+    margin-bottom: 0;
+    color: var(--black-400)
+}
+
+.users-grid .-user .-details p:last-child {
+    margin-bottom: 0
+}
+
+.users-grid .-user:nth-child(3n) {
+    margin-right: 0
+}
+
+.users-grid .-user .-avatar {
+    width: 64px;
+    height: 64px
+}
+
+.users-grid .-user .-avatar img {
+    max-width: 100%;
+    height: auto
+}
+
+.users-grid .-user.-private .-avatar {
+    background: url('https://cdn.sstatic.net/Img/user.svg?v=20c64bb67fc9') no-repeat center center var(--powder-050);
+    background-size: 50%
+}
+
+.users-grid .-user.-private .-details h3 {
+    margin-bottom: 0
+}
+
+.list-card {
+    position: absolute;
+    z-index: 3000;
+    background: var(--white);
+    width: 395px;
+    padding: 20px;
+    border-radius: 3px;
+    box-shadow: 0 1px 25px rgba(0, 0, 0, 0.15);
+    transform: translate(0%, -110%);
+    align-items: center;
+    border: 1px solid var(--black-075)
+}
+
+.list-card:before {
+    content: '';
+    width: 0;
+    height: 0;
+    border-left: 12px solid transparent;
+    border-right: 12px solid transparent;
+    border-top: 9px solid var(--white);
+    position: absolute;
+    bottom: -7px;
+    left: 20px
+}
+
+.list-card .-avatar {
+    width: 100px;
+    height: 100px;
+    align-self: flex-start;
+    border-radius: 2px;
+    background: var(--white);
+    padding: 6px;
+    border: 1px solid var(--black-075);
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    margin-right: 15px;
+    flex: 0 0 auto
+}
+
+.list-card .-avatar img {
+    border-radius: 3px;
+    max-width: 100%;
+    height: auto;
+    width: 100%
+}
+
+.list-card .-avatar .logo-blank {
+    background-color: var(--black-050);
+    color: var(--black-300);
+    max-width: 100%;
+    width: 100%;
+    height: 100%;
+    border-radius: 3px
+}
+
+.list-card .-details {
+    color: var(--black-500);
+    font-weight: 400;
+    font-size: 13px;
+    width: 100%
+}
+
+.list-card .-details .-name {
+    color: var(--black-700);
+    font-weight: 700;
+    font-size: 1.30769231rem;
+    margin-bottom: 0
+}
+
+.list-card .-details .-users-list {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 5px 0
+}
+
+.list-card .-details .-users-list .-user:not(:last-child) {
+    margin-right: 4px
+}
+
+.list-card .-details .-users-list .avatar {
+    width: 26px;
+    height: 26px;
+    overflow: hidden
+}
+
+.list-card .-details .-users-list .avatar img {
+    max-width: 100%;
+    height: auto;
+    width: 100%
+}
+
+.list-card .-details .-users-list .avatar.-private {
+    background: url('https://cdn.sstatic.net/Img/user.svg?v=20c64bb67fc9') no-repeat center center var(--powder-100);
+    background-size: 50%
+}
+
+.list-card .-details .more {
+    display: inline-block;
+    margin-top: 2px
+}
+
+.modal.auto-center.snippet-modal {
+    position: fixed;
+    transform: translateZ(0) !important;
+    width: 100% !important;
+    height: 100% !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0;
+    bottom: 0;
+    background: none !important;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    pointer-events: none
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .modal.auto-center.snippet-modal {
+        background-color: var(--black-050)
+    }
+}
+
+body.theme-dark .modal.auto-center.snippet-modal, .theme-dark__forced .modal.auto-center.snippet-modal {
+    background-color: var(--black-050)
+}
+
+.modal.auto-center.snippet-modal .snippet-holder {
+    background: var(--white);
+    border-radius: 3px;
+    width: 95%;
+    height: 95%;
+    overflow: hidden;
+    pointer-events: auto
+}
+
+.snippet-modal * {
+    box-sizing: border-box
+}
+
+.snippet-modal.modal {
+    max-width: none;
+    max-height: none
+}
+
+.snippet-box-edit {
+    box-sizing: border-box;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin-top: 0;
+    border: 0;
+    margin: 0;
+    resize: none;
+    background: var(--white);
+    overflow: auto
+}
+
+.snippet-box-result {
+    background-color: hsl(0, 0%, 100%)
+}
+
+textarea.snippet-box-edit {
+    background-color: var(--white);
+    background-image: linear-gradient(to bottom, var(--white) 0%, var(--black-025) 69%, var(--black-050) 100%)
+}
+
+.snippet-box-label {
+    position: absolute;
+    top: 10px;
+    right: 20px;
+    padding: 3px;
+    border: 1px solid var(--black-350);
+    font-size: 11px;
+    color: var(--black-500)
+}
+
+.snippet-footer {
+    text-align: center;
+    padding: 5px
+}
+
+.snippet-code {
+    border: 1px solid var(--black-100);
+    border-radius: 5px;
+    padding: 12px
+}
+
+.snippet-code .snippet-ctas {
+    font-size: 13px
+}
+
+.snippet-code .snippet-ctas>*:not(:last-child) {
+    margin-right: 6px
+}
+
+.snippet-code .snippet-ctas .icon-play-white {
+    position: relative;
+    top: 1px;
+    margin-right: 2px
+}
+
+.snippet-code .hideResults:before {
+    content: '';
+    display: inline-block;
+    background: url('https://cdn.sstatic.net/Img/share-sprite-new.svg?v=0e11bfd41fbc') no-repeat;
+    background-position: 0 -238px;
+    width: 12px;
+    height: 12px;
+    margin-right: 6px;
+    position: relative;
+    top: 1px
+}
+
+.snippet-code .snippet-result .snippet-result-code {
+    padding-top: 20px;
+    margin-top: 20px;
+    height: 200px;
+    position: relative
+}
+
+.snippet-code .popin, .snippet-code .popout, .snippet-code .popout-code {
+    font-size: 13px;
+    right: 0
+}
+
+.snippet-code .popout {
+    position: absolute;
+    top: -48px
+}
+
+.ask-mainbar .snippet-code .popout {
+    top: -43px
+}
+
+.snippet-code .popout-code {
+    display: inline;
+    margin-left: 10px
+}
+
+.snippet-code .popout:before, .snippet-code .popout-code:before {
+    content: '';
+    display: inline-block;
+    background: url('https://cdn.sstatic.net/Img/share-sprite-new.svg?v=0e11bfd41fbc') no-repeat;
+    background-position: 0 -220px;
+    width: 9px;
+    height: 9px;
+    margin-right: 6px
+}
+
+.snippet-code .popin {
+    position: fixed;
+    background: var(--powder-025);
+    padding: 4px 6px;
+    right: 0;
+    top: 0;
+    z-index: 9001
+}
+
+div.snippet-hidden div.snippet-currently-hidden {
+    display: none
+}
+
+a.snippet-show-link-chevron, a.snippet-show-link-chevron:hover {
+    border-bottom: 0;
+    text-decoration: none
+}
+
+.expanded-snippet {
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin: 5px;
+    width: 99%;
+    z-index: 900
+}
+
+.CodeMirror {
+    font-family: monospace;
+    color: var(--black);
+    position: absolute !important;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%
+}
+
+.CodeMirror-lines {
+    padding: 4px 0
+}
+
+.CodeMirror pre {
+    padding: 0 4px
+}
+
+.CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+    background-color: var(--white)
+}
+
+.CodeMirror-gutters {
+    border-right: 1px solid var(--black-100);
+    background-color: var(--black-025);
+    white-space: nowrap
+}
+
+.CodeMirror-linenumber {
+    padding: 0 3px 0 5px;
+    min-width: 20px;
+    text-align: right;
+    color: var(--black-350);
+    white-space: nowrap
+}
+
+.CodeMirror-guttermarker {
+    color: var(--black)
+}
+
+.CodeMirror-guttermarker-subtle {
+    color: var(--black-350)
+}
+
+.CodeMirror-cursor {
+    border-left: 1px solid var(--black);
+    border-right: none;
+    width: 0
+}
+
+.CodeMirror div.CodeMirror-secondarycursor {
+    border-left: 1px solid silver
+}
+
+.cm-fat-cursor .CodeMirror-cursor {
+    width: auto;
+    border: 0 !important;
+    background: #7e7
+}
+
+.cm-fat-cursor div.CodeMirror-cursors {
+    z-index: 1
+}
+
+.cm-animate-fat-cursor {
+    width: auto;
+    border: 0;
+    animation: blink 1.06s steps(1) infinite;
+    background-color: #7e7
+}
+
+@keyframes blink {
+    50% {
+        background-color: transparent
+    }
+}
+
+.cm-tab {
+    display: inline-block;
+    text-decoration: inherit
+}
+
+.CodeMirror-rulers {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: -50px;
+    bottom: -20px;
+    overflow: hidden
+}
+
+.CodeMirror-ruler {
+    border-left: 1px solid var(--black-150);
+    top: 0;
+    bottom: 0;
+    position: absolute
+}
+
+.cm-s-default .cm-header {
+    color: var(--blue-800)
+}
+
+.cm-s-default .cm-quote {
+    color: var(--green-600)
+}
+
+.cm-negative {
+    color: var(--red-400)
+}
+
+.cm-positive {
+    color: var(--green-600)
+}
+
+.cm-header, .cm-strong {
+    font-weight: bold
+}
+
+.cm-em {
+    font-style: italic
+}
+
+.cm-link {
+    text-decoration: underline
+}
+
+.cm-strikethrough {
+    text-decoration: line-through
+}
+
+.cm-s-default .cm-keyword {
+    color: var(--powder-700)
+}
+
+.cm-s-default .cm-atom {
+    color: var(--powder-800)
+}
+
+.cm-s-default .cm-number {
+    color: var(--green-700)
+}
+
+.cm-s-default .cm-def {
+    color: var(--blue-700)
+}
+
+.cm-s-default .cm-variable-2 {
+    color: var(--blue-800)
+}
+
+.cm-s-default .cm-variable-3 {
+    color: var(--green-600)
+}
+
+.cm-s-default .cm-comment {
+    color: var(--orange-800)
+}
+
+.cm-s-default .cm-string {
+    color: var(--red-700)
+}
+
+.cm-s-default .cm-string-2 {
+    color: var(--orange-500)
+}
+
+.cm-s-default .cm-meta {
+    color: var(--black-600)
+}
+
+.cm-s-default .cm-qualifier {
+    color: var(--black-600)
+}
+
+.cm-s-default .cm-builtin {
+    color: var(--powder-700)
+}
+
+.cm-s-default .cm-bracket {
+    color: var(--black-350)
+}
+
+.cm-s-default .cm-tag {
+    color: var(--green-700)
+}
+
+.cm-s-default .cm-attribute {
+    color: var(--blue-800)
+}
+
+.cm-s-default .cm-hr {
+    color: var(--black-350)
+}
+
+.cm-s-default .cm-link {
+    color: var(--blue-800)
+}
+
+.cm-s-default .cm-error {
+    color: var(--red-500)
+}
+
+.cm-invalidchar {
+    color: var(--red-500)
+}
+
+.CodeMirror-composing {
+    border-bottom: 2px solid
+}
+
+div.CodeMirror span.CodeMirror-matchingbracket {
+    color: #0f0
+}
+
+div.CodeMirror span.CodeMirror-nonmatchingbracket {
+    color: var(--red-400)
+}
+
+.CodeMirror-matchingtag {
+    background: rgba(255, 150, 0, 0.3)
+}
+
+.CodeMirror-activeline-background {
+    background: var(--powder-100)
+}
+
+.CodeMirror {
+    position: relative;
+    overflow: hidden;
+    background: var(--white)
+}
+
+.CodeMirror-scroll {
+    overflow: scroll !important;
+    margin-bottom: -30px;
+    margin-right: -30px;
+    padding-bottom: 30px;
+    height: 100%;
+    outline: none;
+    position: relative
+}
+
+.CodeMirror-sizer {
+    position: relative;
+    border-right: 30px solid transparent
+}
+
+.CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+    position: absolute;
+    z-index: 6;
+    display: none
+}
+
+.CodeMirror-vscrollbar {
+    right: 0;
+    top: 0;
+    overflow-x: hidden;
+    overflow-y: scroll
+}
+
+.CodeMirror-hscrollbar {
+    bottom: 0;
+    left: 0;
+    overflow-y: hidden;
+    overflow-x: scroll
+}
+
+.CodeMirror-scrollbar-filler {
+    right: 0;
+    bottom: 0
+}
+
+.CodeMirror-gutter-filler {
+    left: 0;
+    bottom: 0
+}
+
+.CodeMirror-gutters {
+    position: absolute;
+    left: 0;
+    top: 0;
+    min-height: 100%;
+    z-index: 3;
+    padding-bottom: 30px
+}
+
+.CodeMirror-gutter {
+    white-space: normal;
+    height: 100%;
+    display: inline-block;
+    vertical-align: top;
+    margin-bottom: -30px
+}
+
+.CodeMirror-gutter-wrapper {
+    position: absolute;
+    z-index: 4;
+    background: none !important;
+    border: none !important
+}
+
+.CodeMirror-gutter-background {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 4
+}
+
+.CodeMirror-gutter-elt {
+    position: absolute;
+    cursor: default;
+    z-index: 4
+}
+
+.CodeMirror-gutter-wrapper {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none
+}
+
+.CodeMirror-lines {
+    cursor: text;
+    min-height: 1px
+}
+
+.CodeMirror pre {
+    border-radius: 0;
+    border-width: 0;
+    background: transparent;
+    font-family: inherit;
+    font-size: inherit;
+    margin: 0;
+    white-space: pre;
+    word-wrap: normal;
+    line-height: inherit;
+    color: inherit;
+    z-index: 2;
+    position: relative;
+    overflow: visible;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-font-variant-ligatures: none;
+    font-variant-ligatures: none
+}
+
+.CodeMirror-wrap pre {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    word-break: normal
+}
+
+.CodeMirror-linebackground {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 0
+}
+
+.CodeMirror-linewidget {
+    position: relative;
+    z-index: 2;
+    overflow: auto
+}
+
+.CodeMirror-code {
+    outline: none
+}
+
+.CodeMirror-scroll, .CodeMirror-sizer, .CodeMirror-gutter, .CodeMirror-gutters, .CodeMirror-linenumber {
+    box-sizing: content-box
+}
+
+.CodeMirror-measure {
+    position: absolute;
+    width: 100%;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden
+}
+
+.CodeMirror-cursor {
+    position: absolute;
+    pointer-events: none
+}
+
+.CodeMirror-measure pre {
+    position: static
+}
+
+div.CodeMirror-cursors {
+    visibility: hidden;
+    position: relative;
+    z-index: 3
+}
+
+div.CodeMirror-dragcursors {
+    visibility: visible
+}
+
+.CodeMirror-focused div.CodeMirror-cursors {
+    visibility: visible
+}
+
+.CodeMirror-selected {
+    background: var(--black-100)
+}
+
+.CodeMirror-focused .CodeMirror-selected {
+    background: #d7d4f0
+}
+
+.CodeMirror-crosshair {
+    cursor: crosshair
+}
+
+.CodeMirror-line::selection, .CodeMirror-line>span::selection, .CodeMirror-line>span>span::selection {
+    background: var(--powder-100)
+}
+
+.CodeMirror-line::-moz-selection, .CodeMirror-line>span::-moz-selection, .CodeMirror-line>span>span::-moz-selection {
+    background: var(--powder-100)
+}
+
+.cm-searching {
+    background: #ffa;
+    background: rgba(255, 255, 0, 0.4)
+}
+
+.cm-force-border {
+    padding-right: .1px
+}
+
+@media print {
+    .CodeMirror div.CodeMirror-cursors {
+        visibility: hidden
+    }
+}
+
+.cm-tab-wrap-hack:after {
+    content: ''
+}
+
+span.CodeMirror-selectedtext {
+    background: none
+}
+
+.post-layout {
+    display: grid;
+    grid-template-columns: -webkit-max-content 1fr;
+    grid-template-columns: max-content 1fr
+}
+
+.post-layout--left {
+    grid-column: 1;
+    width: auto
+}
+
+.post-layout--left, .post-layout--left.votecell {
+    width: auto;
+    padding-right: 16px
+}
+
+.post-layout--right {
+    padding-right: 16px;
+    grid-column: 2;
+    width: auto;
+    min-width: 0
+}
+
+.post-layout--right .s-prose, .post-layout--right .comments {
+    width: 100%
+}
+
+.post-layout--full {
+    grid-column: 1 / 3
+}
+
+.wmd-container {
+    width: 100%;
+    box-sizing: border-box
+}
+
+.wmd-button-bar {
+    clear: both;
+    background-color: transparent;
+    margin: 10px 0 0 0;
+    padding: 0;
+    width: 100%;
+    border: 1px solid var(--bc-darker);
+    border-bottom: 0;
+    min-height: 44px;
+    overflow: hidden;
+    z-index: 2;
+    position: relative
+}
+
+textarea.wmd-input, textarea#wmd-input {
+    padding: 10px;
+    margin: -1px 0 0;
+    height: 200px;
+    line-height: 1.3;
+    width: 100%;
+    font-family: var(--ff-mono);
+    font-size: 1.15384615rem;
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4
+}
+
+.wmd-button-row {
+    padding: 0 4px 0 8px;
+    margin: 0;
+    display: flex;
+    list-style: none;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    height: 44px;
+    border-bottom: 1px solid var(--bc-darker)
+}
+
+.wmd-spacer {
+    height: 44px;
+    flex: 1 0 4px;
+    max-width: 27px;
+    display: flex;
+    flex-wrap: wrap;
+    overflow: hidden;
+    position: relative;
+    left: 4px
+}
+
+.wmd-spacer:before, .wmd-spacer:after {
+    flex: none;
+    justify-content: center;
+    content: '';
+    position: relative;
+    top: -44px;
+    background: var(--green-600)
+}
+
+.wmd-spacer:before {
+    width: 9px;
+    height: 44px
+}
+
+.wmd-spacer:after {
+    background: var(--black-200);
+    width: 1px;
+    height: 43px;
+    margin-top: 1px
+}
+
+.wmd-spacer-max {
+    max-width: none
+}
+
+.wmd-button {
+    max-width: 28px;
+    height: 44px;
+    flex: 10 0 23px;
+    padding: 0;
+    padding: 12px 0 0 0;
+    text-align: center;
+    cursor: pointer
+}
+
+.wmd-button>span {
+    background-repeat: no-repeat;
+    background-position: 0 0;
+    width: 20px;
+    height: 20px;
+    display: inline-block
+}
+
+.wmd-prompt-background {
+    background-color: var(--black);
+    z-index: 8950
+}
+
+.wmd-prompt-dialog {
+    padding: 15px;
+    box-shadow: var(--bs-sm);
+    background-color: var(--white);
+    border: solid 1px var(--black-300)
+}
+
+.wmd-button>span {
+    background-image: url("https://cdn.sstatic.net/Img/unified/wmd-buttons.svg?v=c26278fc22d9");
+    background-size: initial !important
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .wmd-button>span {
+        background-image: url("https://cdn.sstatic.net/Img/unified/wmd-buttons-dark.svg?v=41498242bcce")
+    }
+}
+
+body.theme-dark .wmd-button>span, .theme-dark__forced .wmd-button>span {
+    background-image: url("https://cdn.sstatic.net/Img/unified/wmd-buttons-dark.svg?v=41498242bcce")
+}
+
+.wmd-snippet-button span {
+    background-position: -260px 0 !important
+}
+
+.wmd-snippet-button span:hover {
+    background-position: -260px -40px !important
+}
+
+.wmd-schematic-button span {
+    background-position: -320px 0 !important
+}
+
+.wmd-schematic-button span:hover {
+    background-position: -320px -40px !important
+}
+
+.wmd-virtual-keyboard-button span {
+    background-position: -280px 0 !important
+}
+
+.wmd-virtual-keyboard-button span:hover, .wmd-virtual-keyboard-button span.enabled {
+    background-position: -280px -40px !important
+}
+
+.wmd-mockup-button span {
+    background-position: -300px 0 !important
+}
+
+.wmd-mockup-button span:hover {
+    background-position: -300px -40px !important
+}
+
+.wmd-cite-button span {
+    background-position: -340px 0 !important
+}
+
+.wmd-cite-button span:hover {
+    background-position: -340px -40px !important
+}
+
+.wmd-inline-dialog {
+    border: 1px solid var(--bc-darker);
+    border-top: none;
+    position: absolute;
+    width: 100%;
+    z-index: 1;
+    padding: 16px;
+    background-color: var(--white);
+    box-shadow: var(--bs-sm)
+}
+
+.wmd-button__active {
+    border-left: 1px solid var(--bc-darker);
+    border-right: 1px solid var(--bc-darker);
+    border-bottom: 1px solid var(--white);
+    background-color: var(--white)
+}
+
+.wmd-button__active>span {
+    background-position-y: -40px !important
+}
+
+.wmd-button-bar.has-active-button .wmd-button:not(.wmd-button__active) {
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: .3
+}
+
+.wmd-help-button.active-help {
+    background-color: var(--black-050)
+}
+
+.mdhelp {
+    background-color: var(--black-050);
+    color: var(--fc-dark);
+    border-right: 1px solid var(--bc-darker);
+    border-left: 1px solid var(--bc-darker)
+}
+
+.mdhelp-tabs {
+    background-color: var(--black-050);
+    list-style-type: none;
+    margin: 0;
+    padding: 3px 0 0 3px;
+    overflow: hidden
+}
+
+.mdhelp-tabs li {
+    display: inline-block;
+    padding: 3px 6px 6px;
+    margin: 0 2px;
+    cursor: pointer
+}
+
+.mdhelp-tabs li.selected {
+    background-color: var(--yellow-050)
+}
+
+.mdhelp-tab {
+    padding: 10px;
+    display: none;
+    line-height: 1.2
+}
+
+.mdhelp-tab pre {
+    background-color: var(--yellow-100);
+    border: none !important
+}
+
+.mdhelp-tab--content {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-left: -2%
+}
+
+.mdhelp-tab--content .col1, .mdhelp-tab--content .col2 {
+    min-width: 150px;
+    flex-grow: 1
+}
+
+.mdhelp-tab--content>*:not(ol) {
+    margin-left: 2%
+}
+
+.mdhelp-tab--content>p, .mdhelp-tab--content>pre {
+    width: 100%
+}
+
+.grippie {
+    background-position: calc(50% + 34px) -364px;
+    border: 1px solid var(--bc-darker);
+    border-width: 0 1px 1px;
+    cursor: s-resize;
+    height: 11px;
+    overflow: hidden;
+    background-color: var(--black-050)
+}
+
+.wmd-button-bar.btr-sm~.grippie {
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px
+}
+
+.user-page .grippie {
+    margin-bottom: 3px
+}
+
+.grippie {
+    margin-top: -4px
+}
+
+.wmd-preview.s-prose {
+    clear: both;
+    width: 100%
+}
+
+.bg-inherit {
+    background-color: inherit !important
+}
+
+.s-input__readonly {
+    border-color: var(--black-075);
+    background-color: var(--black-050);
+    color: var(--black-200);
+    cursor: not-allowed
+}
+
+.s-editor-shadow {
+    transform-style: preserve-3d
+}
+
+.s-editor-shadow:after {
+    content: "";
+    position: absolute;
+    transform: translateZ(-1px);
+    top: -112px;
+    left: 0;
+    right: 0;
+    height: 62px;
+    background: radial-gradient(50% 50% at 50% 45%, rgba(0, 0, 0, 0.8) -200%, rgba(0, 0, 0, 0) 115%);
+    opacity: 0;
+    pointer-events: none;
+    transition: top 1s ease, opacity 1.5s ease
+}
+
+@media not all and (min-resolution:.001dpcm) {
+    @supports (-webkit-appearance: none) and (stroke-color: transparent) {
+        .s-editor-shadow:after {
+            transition: none
+        }
+    }
+}
+
+.s-editor-shadow.is-stuck:after {
+    top: 0;
+    opacity: 1;
+    transition: top .2s ease, opacity .1s ease
+}
+
+.s-editor-btn {
+    position: relative;
+    display: inline-block;
+    padding: 2px;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    color: var(--black-700);
+    background-color: transparent;
+    outline: none;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: normal;
+    line-height: 1.15384615;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer
+}
+
+.s-editor-btn:hover {
+    background-color: var(--black-050);
+    color: var(--black-700)
+}
+
+.s-editor-btn.is-selected, .s-editor-btn:active {
+    color: var(--black-900);
+    background-color: var(--black-100)
+}
+
+.s-editor-btn.is-disabled {
+    color: var(--black-150);
+    cursor: default
+}
+
+.s-editor-btn.is-disabled:hover {
+    background-color: transparent
+}
+
+.s-editor-btn:focus {
+    box-shadow: 0 0 0 4px var(--focus-ring-muted)
+}
+
+.s-editor-btn.s-btn__dropdown {
+    padding-right: 16px
+}
+
+.s-editor-btn.s-btn__dropdown:after {
+    right: 4px
+}
+
+.s-editor-resizable {
+    max-height: 48.6153846rem;
+    resize: vertical
+}
+
+.s-editor-resizable[style*="height"] {
+    max-height: none
+}
+
+.ProseMirror {
+    min-height: inherit;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    white-space: break-spaces;
+    font-variant-ligatures: none
+}
+
+.ProseMirror .ProseMirror-hideselection *::selection {
+    background: transparent
+}
+
+.ProseMirror .ProseMirror-hideselection {
+    caret-color: transparent
+}
+
+.ProseMirror .ProseMirror-selectednode {
+    box-shadow: 0 0 0 4px var(--focus-ring)
+}
+
+.ProseMirror .ProseMirror-widget {
+    white-space: normal;
+    word-wrap: normal
+}
+
+.ProseMirror .ProseMirror-widget .ProseMirror-contentdom {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    white-space: break-spaces
+}
+
+.ProseMirror img {
+    max-width: 100%
+}
+
+.ProseMirror.s-prose .spoiler * {
+    visibility: visible
+}
+
+.ProseMirror.s-prose div {
+    margin-bottom: var(--s-prose-spacing)
+}
+
+.ProseMirror.s-prose div:last-child, .ProseMirror.s-prose div:only-child {
+    margin-bottom: 0
+}
+
+.ProseMirror.s-prose ol div, .ProseMirror.s-prose ul div {
+    margin-bottom: var(--s-prose-spacing-condensed)
+}
+
+.ProseMirror pre, .ProseMirror code {
+    word-wrap: break-word;
+    white-space: pre-wrap
+}
+
+.ProseMirror>pre, .ProseMirror>code {
+    margin: 0;
+    padding: 0;
+    width: auto;
+    max-height: unset;
+    background-color: inherit;
+    border-radius: 0
+}
+
+.ProseMirror[contenteditable="true"] p>a[href] {
+    cursor: inherit
+}
+
+.ProseMirror[contenteditable="false"] pre, .ProseMirror[contenteditable="false"] code {
+    opacity: 80%
+}
+
+.ProseMirror[contenteditable="false"] .ProseMirror-widget, .ProseMirror[contenteditable="false"] .ProseMirror-widget * {
+    background-color: inherit
+}
+
+.icon-bg {
+    display: inline-block;
+    vertical-align: bottom;
+    border: none;
+    height: 18px;
+    width: 18px;
+    padding: 0
+}
+
+.icon-bg::after {
+    content: "";
+    height: 100%;
+    width: 100%;
+    display: inline-block;
+    background-color: currentColor;
+    -webkit-mask: var(--bg-icon) no-repeat center;
+    mask: var(--bg-icon) no-repeat center;
+    -webkit-mask-size: contain;
+    mask-size: contain
+}
+
+.icon-bg.iconBold {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M13 6C13 4.5 11.43 3 9.5 3H4V15H10.25C12.04 15 13.5 13.29 13.5 11.5C13.5 10.2 12.6 9.02 11.5 8.5C12.33 7.92 13 7.5 13 6ZM6.5 5H9C9.39782 5 9.77936 5.15804 10.0607 5.43934C10.342 5.72064 10.5 6.10218 10.5 6.5C10.5 6.89782 10.342 7.27936 10.0607 7.56066C9.77936 7.84196 9.39782 8 9 8H6.5V5ZM9.5 13H6.5V10H9.5C9.89782 10 10.2794 10.158 10.5607 10.4393C10.842 10.7206 11 11.1022 11 11.5C11 11.8978 10.842 12.2794 10.5607 12.5607C10.2794 12.842 9.89782 13 9.5 13Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconHeader {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M13.62 10.08L12.1 4.66H12.04L10.54 10.08H13.62ZM5.7 11.13L4.53 7.02H4.45L3.32 11.13H5.7ZM17.31 15H15.06L14.11 11.75H10.04L9.09 15H6.84L6.15 12.67H2.87L2.17 15H0L3.3 5.41H5.8L7.97 11.75L10.86 3H13.38L17.32 15H17.31Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconItalic {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M7 3V5H9.58L5.92 13H3V15H11V13H8.42L12.08 5H15V3H7Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconCode {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M8 4.41L6.59 3L0.589996 9L6.59 15L8 13.59L3.41 9L8 4.41Z' fill='black'/%3e %3cpath d='M10 4.41L11.41 3L17.41 9L11.41 15L10 13.59L14.59 9L10 4.41Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconStrikethrough {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M11.9572 6.19964C11.879 6.12146 11.7339 6.01537 11.5217 5.88135C11.3206 5.74733 11.0694 5.6189 10.7678 5.49605C10.4775 5.36204 10.1592 5.25036 9.81295 5.16101C9.46675 5.07167 9.11495 5.027 8.75758 5.027C8.121 5.027 7.64636 5.14426 7.33365 5.37879C7.02095 5.61332 6.8646 5.94277 6.8646 6.36716C6.8646 6.61285 6.92044 6.81946 7.03212 6.98698L7.04249 7H4.49366C4.48843 6.9143 4.48581 6.8262 4.48581 6.7357C4.48581 6.13263 4.59749 5.59657 4.82085 5.12751C5.04421 4.65845 5.35133 4.26757 5.74221 3.95487C6.14426 3.64216 6.60773 3.40763 7.13263 3.25128C7.65753 3.08376 8.22151 3 8.82458 3C9.66219 3 10.4328 3.13402 11.1364 3.40205C11.84 3.65891 12.4542 3.96603 12.9791 4.32341L11.9572 6.19964Z' fill='black'/%3e %3cpath d='M3 8V10H8.0204C8.42354 10.1155 8.79211 10.2224 9.12612 10.3206C9.50583 10.4323 9.82971 10.5552 10.0977 10.6892C10.3658 10.8232 10.5724 10.9795 10.7176 11.1582C10.8627 11.3369 10.9353 11.5547 10.9353 11.8116C10.9353 12.6268 10.2988 13.0345 9.02561 13.0345C8.56772 13.0345 8.121 12.9786 7.68545 12.8669C7.24989 12.7553 6.85343 12.6213 6.49605 12.4649C6.13868 12.2974 5.82597 12.1354 5.55794 11.9791C5.30107 11.8116 5.12239 11.6776 5.02187 11.577L4 13.5705C4.69242 14.0619 5.47418 14.4416 6.34528 14.7097C7.21639 14.9777 8.09866 15.1117 8.99211 15.1117C9.57284 15.1117 10.1257 15.0503 10.6506 14.9274C11.1866 14.7934 11.6557 14.5868 12.0577 14.3076C12.4709 14.0284 12.7948 13.6655 13.0293 13.2187C13.275 12.7608 13.3979 12.2136 13.3979 11.577C13.3979 11.0298 13.3085 10.5719 13.1299 10.2034C13.0971 10.1337 13.0617 10.0659 13.0236 10H15V8H3Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconLink {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M7.2233 11.8311C7.7117 12.1908 8.25504 12.4768 8.83653 12.676L9.45259 10.8781C8.59978 10.5859 7.86707 10.0207 7.36788 9.27009C6.86868 8.51944 6.63083 7.62517 6.69115 6.72571C6.75147 5.82624 7.10659 4.97174 7.70155 4.29447C8.2965 3.61719 9.09811 3.15491 9.9823 2.97918C10.8665 2.80345 11.784 2.92407 12.5927 3.32236C13.4014 3.72066 14.0563 4.37442 14.456 5.18246C14.8557 5.9905 14.9778 6.90775 14.8036 7.79224C14.6294 8.67673 14.1685 9.47913 13.4923 10.0752L14.749 11.5009C15.2101 11.0945 15.6028 10.6225 15.9165 10.1034C16.2762 9.50815 16.5321 8.85098 16.6683 8.15952C16.9233 6.86498 16.7445 5.52249 16.1595 4.33984C15.5745 3.15719 14.616 2.20034 13.4324 1.61739C12.2487 1.03445 10.9059 0.857909 9.61182 1.11511C8.31772 1.37231 7.14448 2.04891 6.2737 3.04017C5.40292 4.03143 4.88317 5.28208 4.79488 6.59854C4.7066 7.915 5.05471 9.22385 5.78534 10.3225C6.17558 10.9093 6.66334 11.4187 7.2233 11.8311Z' fill='black'/%3e %3cpath d='M10.6461 6.23494C10.1644 5.86633 9.62642 5.57045 9.04869 5.36057L8.39975 7.14688C9.24706 7.45469 9.96928 8.03321 10.4546 8.79289C10.94 9.55257 11.1614 10.4511 11.0846 11.3493C11.0077 12.2475 10.637 13.0953 10.0297 13.7616C9.42245 14.4278 8.6125 14.8753 7.72523 15.0348C6.83797 15.1943 5.92288 15.0568 5.1216 14.6438C4.32031 14.2307 3.67753 13.565 3.29274 12.7498C2.90794 11.9346 2.8026 11.0152 2.99301 10.1341C3.18342 9.25295 3.65896 8.45914 4.34603 7.87552L3.11565 6.42702C2.64717 6.82495 2.24588 7.28966 1.92268 7.80296C1.55212 8.39146 1.28421 9.04383 1.13536 9.73267C0.856672 11.0223 1.01086 12.3679 1.57404 13.561C2.13723 14.7542 3.07801 15.7285 4.25077 16.3331C5.42352 16.9376 6.76286 17.1388 8.06146 16.9053C9.36006 16.6719 10.5455 16.017 11.4343 15.0418C12.3231 14.0667 12.8658 12.8258 12.9782 11.5112C13.0906 10.1966 12.7665 8.88155 12.0562 7.76968C11.6768 7.1758 11.1984 6.65756 10.6461 6.23494Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconQuote {
+    width: 17px;
+    --bg-icon: url("data:image/svg+xml,%3csvg width='17' height='18' viewBox='0 0 17 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M0 4C0 2.89543 0.89543 2 2 2H6C7.10457 2 8 2.89543 8 4V13L6.25 16H4L5.75 13H2C0.895431 13 0 12.1046 0 11V4Z' fill='black'/%3e %3cpath d='M9 4C9 2.89543 9.89543 2 11 2H15C16.1046 2 17 2.89543 17 4V13L15.25 16H13L14.75 13H11C9.89543 13 9 12.1046 9 11V4Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconCodeblock {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M1 3C1 1.89543 1.89543 1 3 1H13L17 5V15C17 16.1046 16.1046 17 15 17H3C1.89543 17 1 16.1046 1 15V3ZM10.7106 5L9.30063 6.41L11.8906 9L9.30063 11.59L10.7106 13L14.7106 9L10.7106 5ZM8.71329 6.41L7.30329 5L3.30329 9L7.30329 13L8.71329 11.59L6.12329 9L8.71329 6.41Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconImage {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M1 3C1 1.9 1.9 1 3 1H15C16.0893 1 17 1.91067 17 3V15C17 16.0893 16.0893 17 15 17H3C1.91067 17 1 16.0893 1 15V3ZM5.5 10.5L2 15H16L11.5 9L8 13.51L5.5 10.5ZM5.5 6C5.89782 6 6.27936 5.84196 6.56066 5.56066C6.84196 5.27936 7 4.89782 7 4.5C7 4.10218 6.84196 3.72064 6.56066 3.43934C6.27936 3.15804 5.89782 3 5.5 3C5.10218 3 4.72064 3.15804 4.43934 3.43934C4.15804 3.72064 4 4.10218 4 4.5C4 4.89782 4.15804 5.27936 4.43934 5.56066C4.72064 5.84196 5.10218 6 5.5 6Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconTable {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M1 3C1 1.89543 1.89543 1 3 1H15C16.1046 1 17 1.89543 17 3V15C17 16.1046 16.1046 17 15 17H3C1.89543 17 1 16.1046 1 15V3ZM8 7V3H3V7H8ZM8 11V9H3V11H8ZM15 9H10V11H15V9ZM15 15V13H10V15H15ZM8 13H3V15H8V13ZM15 3H10V7H15V3Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconOrderedList {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath fill-rule='evenodd' clip-rule='evenodd' d='M3 6H4V2H2V3H3V6ZM3.8 8H2V7H5V7.9L3.2 10H5V11H2V10.1L3.8 8ZM2 13V12H5V16H2V15H4V14.5H3V13.5H4V13H2ZM7 5V3H16V5H7ZM7 15H16V13H7V15ZM16 10H7V8H16V10Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconUnorderedList {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='17' height='18' viewBox='0 0 17 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M4.25 4C4.25 4.69036 3.69036 5.25 3 5.25C2.30964 5.25 1.75 4.69036 1.75 4C1.75 3.30964 2.30964 2.75 3 2.75C3.69036 2.75 4.25 3.30964 4.25 4Z' fill='black'/%3e %3cpath d='M15 5H6V3H15V5Z' fill='black'/%3e %3cpath d='M15 15H6V13H15V15Z' fill='black'/%3e %3cpath d='M6 10H15V8H6V10Z' fill='black'/%3e %3cpath d='M4.25 14C4.25 14.6904 3.69036 15.25 3 15.25C2.30964 15.25 1.75 14.6904 1.75 14C1.75 13.3096 2.30964 12.75 3 12.75C3.69036 12.75 4.25 13.3096 4.25 14Z' fill='black'/%3e %3cpath d='M3 10.25C3.69036 10.25 4.25 9.69036 4.25 9C4.25 8.30964 3.69036 7.75 3 7.75C2.30964 7.75 1.75 8.30964 1.75 9C1.75 9.69036 2.30964 10.25 3 10.25Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconHorizontalRule {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M2 8H16V10H2V8Z' fill='black'/%3e %3cpath opacity='0.4' d='M2 2H16V3H2V2ZM2 5H16V6H2V5ZM2 12H16V13H2V12ZM2 15H16V16H2V15Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconUndo {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M3.35147 3.35C4.80238 1.9 6.79362 1 9.005 1C13.4278 1 17 4.58 17 9C17 13.42 13.4278 17 9.005 17C5.27267 17 2.16073 14.45 1.27017 11H3.35147C4.17198 13.33 6.39337 15 9.005 15C12.3171 15 15.0088 12.31 15.0088 9C15.0088 5.69 12.3171 3 9.005 3C7.34396 3 5.86304 3.69 4.78236 4.78L8.00438 8H1V1L3.35147 3.35Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconRefresh {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M14.6485 3.35C13.1976 1.9 11.2064 1 8.995 1C4.57223 1 1 4.58 1 9C1 13.42 4.57223 17 8.995 17C12.7273 17 15.8393 14.45 16.7298 11H14.6485C13.828 13.33 11.6066 15 8.995 15C5.68293 15 2.99124 12.31 2.99124 9C2.99124 5.69 5.68293 3 8.995 3C10.656 3 12.137 3.69 13.2176 4.78L9.99562 8H17V1L14.6485 3.35Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconHelp {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M9 1C4.64267 1 1 4.64267 1 9C1 13.3573 4.64266 17 9 17C13.3573 17 17 13.3573 17 9C17 4.64266 13.3573 1 9 1ZM9.81 13.13C9.79 13.84 9.26 14.28 8.57 14.26C7.91 14.24 7.4 13.77 7.42 13.06C7.44 12.34 7.98 11.88 8.64 11.9C9.34 11.93 9.84 12.41 9.81 13.13ZM11.77 8C11.1836 8.6629 9.99229 9.08507 9.72 9.97C9.66641 10.2166 9.63627 10.4677 9.63 10.72C9.63 10.77 9.6 10.88 9.45 10.88H7.88C7.72 10.88 7.7 10.78 7.7 10.73C7.76152 9.37659 8.36087 8.53141 9.53 7.85C9.91723 7.55958 10.2225 7.10274 10.2282 6.60861C10.2427 5.36872 8.5915 4.79041 7.88 5.89C7.67 6.22 7.7 6.62 7.7 6.99H5.75C5.75 5.01906 6.77665 3.73 8.78 3.73C10.5347 3.73 12.25 4.60389 12.25 6.56C12.25 7.13 12.05 7.61 11.77 8Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconPlay {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='17' height='18' viewBox='0 0 17 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M3 2.86852C3 2.06982 3.89015 1.59343 4.5547 2.03647L13.7519 8.16795C14.3457 8.56377 14.3457 9.43623 13.7519 9.83205L4.5547 15.9635C3.89014 16.4066 3 15.9302 3 15.1315V2.86852Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconShare {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M2.99406 1H8V3H3V15H15V10H17V15.0059C17 16.1072 16.1055 17 15.0059 17H2.99406C1.89277 17 1 16.1055 1 15.0059V2.99406C1 1.89277 1.89451 1 2.99406 1Z' fill='black'/%3e %3cpath d='M17 1H10V3H13.5L6 10.5L7.5 12L15 4.5V8H17V1Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.icon-bg.iconPencilSm {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M11.0937 1.71081L12.2347 2.83019C12.4347 3.03005 12.4347 3.33983 12.2347 3.53968L11.0898 4.70381L9.21 2.86474L10.3837 1.71081C10.5837 1.51095 10.8937 1.51095 11.0937 1.71081Z' fill='black'/%3e %3cpath d='M2 10.12L8.37 3.69427L10.2466 5.57034L3.88 12H2V10.12Z' fill='black'/%3e %3c/svg%3e");
+    height: 14px;
+    width: 14px
+}
+
+.icon-bg.iconTrashSm {
+    --bg-icon: url("data:image/svg+xml,%3csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M11 2C11.5523 2 12 2.44772 12 3V4H2V3C2 2.44772 2.44772 2 3 2H5C5 1.44772 5.44772 1 6 1H8C8.55228 1 9 1.44772 9 2H11Z' fill='black'/%3e %3cpath d='M11 5H3V11C3 12.1046 3.89543 13 5 13H9C10.1046 13 11 12.1046 11 11V5Z' fill='black'/%3e %3c/svg%3e");
+    height: 14px;
+    width: 14px
+}
+
+.icon-bg.iconMarkdown {
+    width: 21px;
+    --bg-icon: url("data:image/svg+xml,%3csvg width='21' height='18' viewBox='0 0 21 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3e %3cpath d='M21 14C21 15.1046 20.1046 16 19 16H2.00098C0.896407 16 0.000976562 15.1046 0.000976562 14V4C0.000976562 2.89543 0.896407 2 2.00098 2L19 2C20.1046 2 21 2.89543 21 4V14ZM4.308 13V8.345L6.5 11.23L8.692 8.345V13H11V5H8.692L6.5 7.885L4.308 5H2V13H4.308ZM19.5 8.99999H17V5H15.0055V8.99999H12.5L16 13.5L19.5 8.99999Z' fill='black'/%3e %3c/svg%3e")
+}
+
+.s-code-block.markdown .hljs-section {
+    color: var(--black-800) !important;
+    font-weight: bold;
+    font-size: 1.15384615rem
+}
+
+.s-code-block.markdown .hljs-link {
+    color: var(--blue-600) !important
+}
+
+.s-code-block.markdown .hljs-quote, .s-code-block.markdown .hljs-string, .s-code-block.markdown .hljs-symbol, .s-code-block.markdown .hljs-tag {
+    color: var(--black-600) !important
+}
+
+.uql-nav .uql-nav--collapsed-item {
+    display: none !important
+}
+
+@media screen and (max-width:1111px) and (min-width:980.1px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .uql-nav .uql-nav--expanded-item {
+        display: none !important
+    }
+
+    html.html__responsive:not(.html__unpinned-leftnav) .uql-nav .uql-nav--collapsed-item {
+        display: flex !important
+    }
+}
+
+@media screen and (max-width:947px) and (min-width:816.1px) {
+    html.html__responsive.html__unpinned-leftnav .uql-nav .uql-nav--expanded-item {
+        display: none !important
+    }
+
+    html.html__responsive.html__unpinned-leftnav .uql-nav .uql-nav--collapsed-item {
+        display: flex !important
+    }
+}
+
+@media screen and (max-width:771px) and (min-width:640.1px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .uql-nav .uql-nav--expanded-item {
+        display: none !important
+    }
+
+    html.html__responsive:not(.html__unpinned-leftnav) .uql-nav .uql-nav--collapsed-item {
+        display: flex !important
+    }
+}
+
+@media screen and (max-width:607px) and (min-width:640.1px) {
+    html.html__responsive.html__unpinned-leftnav .uql-nav .uql-nav--expanded-item {
+        display: none !important
+    }
+
+    html.html__responsive.html__unpinned-leftnav .uql-nav .uql-nav--collapsed-item {
+        display: flex !important
+    }
+}
+
+@media screen and (max-width:607px) {
+    html.html__responsive .uql-nav .uql-nav--expanded-item {
+        display: none !important
+    }
+
+    html.html__responsive .uql-nav .uql-nav--collapsed-item {
+        display: flex !important
+    }
+}
+
+@media print {
+    .uql-nav .uql-nav--expanded-item {
+        display: none !important
+    }
+
+    .uql-nav .uql-nav--collapsed-item {
+        display: flex !important
+    }
+}
+
+.uql-nav .uql-item {
+    margin: 8px 0;
+    display: flex
+}
+
+.uql-nav .uql-item.uql-item__separator {
+    height: 1px;
+    margin-left: -12px;
+    margin-right: -12px
+}
+
+.topbar-dialog {
+    font-family: var(--ff-sans);
+    color: var(--black-700);
+    font-size: 12px;
+    background-color: var(--white);
+    box-shadow: var(--bs-sm);
+    z-index: 999;
+    position: absolute;
+    text-align: left;
+    border-left: 1px solid var(--black-075);
+    border-right: 1px solid var(--black-075);
+    border-bottom: 1px solid var(--black-075)
+}
+
+.topbar-dialog .child-content-loading {
+    text-align: center;
+    padding-top: 10px
+}
+
+.topbar-dialog a:not(.s-btn):not(.nav-links--link) {
+    color: var(--blue-600);
+    text-decoration: none
+}
+
+.topbar-dialog a:not(.s-btn):not(.nav-links--link):visited {
+    color: var(--blue-600)
+}
+
+.topbar-dialog a:not(.s-btn):not(.nav-links--link):hover {
+    color: var(--blue-500);
+    text-decoration: none
+}
+
+.topbar-dialog .related-links {
+    color: var(--black-400);
+    white-space: nowrap
+}
+
+.topbar-dialog .related-links a, .topbar-dialog .related-links a:visited {
+    margin-left: 10px;
+    color: var(--blue-600)
+}
+
+.topbar-dialog.siteSwitcher-dialog {
+    width: 375px;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    min-height: 390px;
+    max-height: 390px;
+    scrollbar-color: var(--scrollbar) transparent
+}
+
+.topbar-dialog.siteSwitcher-dialog::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+    background-color: transparent
+}
+
+.topbar-dialog.siteSwitcher-dialog::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background-color: transparent
+}
+
+.topbar-dialog.siteSwitcher-dialog::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: var(--scrollbar)
+}
+
+.topbar-dialog.siteSwitcher-dialog::-webkit-scrollbar-corner {
+    background-color: transparent;
+    border-color: transparent
+}
+
+.topbar-dialog.siteSwitcher-dialog .call-to-login {
+    padding: 7px 0 7px 0;
+    text-align: center;
+    line-height: 1.3
+}
+
+.topbar-dialog.siteSwitcher-dialog .modal-content {
+    padding: 0
+}
+
+.topbar-dialog.siteSwitcher-dialog .modal-content li:first-child {
+    padding-top: 2px
+}
+
+.topbar-dialog.siteSwitcher-dialog .modal-content li:last-child {
+    padding-bottom: 2px
+}
+
+.topbar-dialog.siteSwitcher-dialog .modal-content li {
+    padding-left: 7px;
+    padding-right: 7px
+}
+
+.topbar-dialog.siteSwitcher-dialog .modal-content .pinned-site-candidate {
+    padding-top: 6px;
+    padding-bottom: 6px
+}
+
+.topbar-dialog.siteSwitcher-dialog .modal-content#your-communities-section {
+    max-height: none
+}
+
+.topbar-dialog.siteSwitcher-dialog .other-sites {
+    min-height: 345px
+}
+
+.topbar-dialog.siteSwitcher-dialog .other-sites .other-site-link {
+    display: inline-block;
+    width: 100%
+}
+
+.topbar-dialog.siteSwitcher-dialog .current-site .current-site-link {
+    font-weight: bold
+}
+
+.topbar-dialog.siteSwitcher-dialog .current-site li {
+    border: none
+}
+
+.topbar-dialog.siteSwitcher-dialog .current-site li:hover {
+    background-color: var(--powder-100)
+}
+
+.topbar-dialog.siteSwitcher-dialog .site-desc {
+    margin-bottom: 0;
+    margin-left: 25px;
+    color: var(--black-300);
+    font-size: 12px;
+    padding-right: 4px
+}
+
+.topbar-dialog.siteSwitcher-dialog .L-shaped-icon-container {
+    float: left;
+    padding: 0;
+    margin: 8px 6px 0 15px
+}
+
+.topbar-dialog.siteSwitcher-dialog .L-shaped-icon {
+    width: 10px;
+    height: 10px;
+    border: solid #b9c1c5;
+    border-width: 0 0 1px 1px;
+    display: inline-block
+}
+
+.topbar-dialog.inbox-dialog .modal-content .message-text, .topbar-dialog.modInbox-dialog .modal-content .message-text {
+    width: 313px
+}
+
+.topbar-dialog.inbox-dialog, .topbar-dialog.modInbox-dialog, .topbar-dialog.achievements-dialog {
+    width: 375px;
+    max-height: 505px
+}
+
+.topbar-dialog.inbox-dialog .modal-content, .topbar-dialog.modInbox-dialog .modal-content, .topbar-dialog.achievements-dialog .modal-content {
+    min-height: 390px;
+    max-height: 390px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-color: var(--scrollbar) transparent
+}
+
+.topbar-dialog.inbox-dialog .modal-content::-webkit-scrollbar, .topbar-dialog.modInbox-dialog .modal-content::-webkit-scrollbar, .topbar-dialog.achievements-dialog .modal-content::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+    background-color: transparent
+}
+
+.topbar-dialog.inbox-dialog .modal-content::-webkit-scrollbar-track, .topbar-dialog.modInbox-dialog .modal-content::-webkit-scrollbar-track, .topbar-dialog.achievements-dialog .modal-content::-webkit-scrollbar-track {
+    border-radius: 10px;
+    background-color: transparent
+}
+
+.topbar-dialog.inbox-dialog .modal-content::-webkit-scrollbar-thumb, .topbar-dialog.modInbox-dialog .modal-content::-webkit-scrollbar-thumb, .topbar-dialog.achievements-dialog .modal-content::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: var(--scrollbar)
+}
+
+.topbar-dialog.inbox-dialog .modal-content::-webkit-scrollbar-corner, .topbar-dialog.modInbox-dialog .modal-content::-webkit-scrollbar-corner, .topbar-dialog.achievements-dialog .modal-content::-webkit-scrollbar-corner {
+    background-color: transparent;
+    border-color: transparent
+}
+
+.topbar-dialog.inbox-dialog .modal-content .timestamp, .topbar-dialog.modInbox-dialog .modal-content .timestamp, .topbar-dialog.achievements-dialog .modal-content .timestamp {
+    color: var(--black-350)
+}
+
+.topbar-dialog.inbox-dialog .inbox-item .item-content .item-header, .topbar-dialog.modInbox-dialog .inbox-item .item-content .item-header, .topbar-dialog.achievements-dialog .inbox-item .item-content .item-header {
+    color: var(--black-400)
+}
+
+.topbar-dialog.inbox-dialog .inbox-item .item-content .item-creation, .topbar-dialog.modInbox-dialog .inbox-item .item-content .item-creation, .topbar-dialog.achievements-dialog .inbox-item .item-content .item-creation {
+    float: right
+}
+
+.topbar-dialog.inbox-dialog .inbox-item .item-content .item-location, .topbar-dialog.modInbox-dialog .inbox-item .item-content .item-location, .topbar-dialog.achievements-dialog .inbox-item .item-content .item-location {
+    margin: 4px 0
+}
+
+.topbar-dialog.inbox-dialog .inbox-item .item-content .item-summary, .topbar-dialog.modInbox-dialog .inbox-item .item-content .item-summary, .topbar-dialog.achievements-dialog .inbox-item .item-content .item-summary {
+    color: var(--black-700)
+}
+
+.topbar-dialog.inbox-dialog .inbox-item.inbox-se-link, .topbar-dialog.modInbox-dialog .inbox-item.inbox-se-link, .topbar-dialog.achievements-dialog .inbox-item.inbox-se-link {
+    text-align: center
+}
+
+.topbar-dialog.inbox-dialog.anon, .topbar-dialog.achievements-dialog.anon {
+    width: 275px
+}
+
+.topbar-dialog.inbox-dialog.anon .modal-content, .topbar-dialog.achievements-dialog.anon .modal-content {
+    min-height: 200px;
+    padding: 13px 20px
+}
+
+.topbar-dialog.inbox-dialog.anon .huge-button-container, .topbar-dialog.achievements-dialog.anon .huge-button-container {
+    text-align: center
+}
+
+.topbar-dialog.inbox-dialog.anon .huge-button, .topbar-dialog.achievements-dialog.anon .huge-button {
+    width: 35%;
+    padding: 3% 0
+}
+
+.topbar-dialog.help-dialog {
+    width: 215px
+}
+
+.topbar-dialog.help-dialog .modal-content {
+    max-height: none
+}
+
+.topbar-dialog.help-dialog .item-summary {
+    display: block;
+    color: var(--black-700);
+    margin-top: 4px
+}
+
+.topbar-dialog.help-dialog a {
+    display: block
+}
+
+.topbar-dialog.review-dialog {
+    width: 215px
+}
+
+.topbar-dialog.review-dialog.review-dialog-mod {
+    width: 265px
+}
+
+.topbar-dialog.review-dialog .modal-content {
+    max-height: none
+}
+
+.topbar-dialog.review-dialog .modal-content .timestamp {
+    color: var(--black-350)
+}
+
+.topbar-dialog.review-dialog .modal-content li {
+    display: block
+}
+
+.topbar-dialog.review-dialog .modal-content li>a {
+    display: flex;
+    align-items: center;
+    flex-flow: row nowrap
+}
+
+.topbar-dialog.review-dialog .modal-content li>a:visited {
+    color: var(--blue)
+}
+
+.topbar-dialog.review-dialog .modal-content li>a .-title {
+    flex-grow: 2
+}
+
+.topbar-dialog.review-dialog .modal-content li>a .-indicator {
+    font-size: 11px;
+    display: inline-block;
+    padding: 3px 5px;
+    background: hsla(210, 8%, 5%, 0.05);
+    color: var(--black-400);
+    border-radius: 3px
+}
+
+.topbar-dialog.review-dialog .modal-content .suspension-notice .notice-content .notice-header {
+    color: var(--black-400)
+}
+
+.topbar-dialog.review-dialog .modal-content .suspension-notice .notice-content .notice-creation {
+    float: right
+}
+
+.topbar-dialog.review-dialog .modal-content .suspension-notice .notice-content .notice-location {
+    margin: 4px 0
+}
+
+.topbar-dialog.review-dialog .modal-content .suspension-notice .notice-content .notice-summary {
+    color: var(--black-700)
+}
+
+.topbar-dialog.review-dialog.danger-dialog .-item a {
+    padding-left: 32px;
+    position: relative
+}
+
+.topbar-dialog.review-dialog.danger-dialog .-item a:before {
+    content: '';
+    width: 10px;
+    height: 10px;
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    margin-top: -5px;
+    border-radius: 50%;
+    background: transparent
+}
+
+.topbar-dialog.review-dialog.danger-dialog .-item.danger-urgent .-title {
+    font-weight: bold
+}
+
+.topbar-dialog.review-dialog.danger-dialog .-item.danger-urgent a:before {
+    background: hsl(358, 62%, 52%);
+    box-shadow: 0 0 5px hsla(358, 62%, 52%, 0.2)
+}
+
+.topbar-dialog.review-dialog.danger-dialog .-item.danger-active a:before {
+    background: hsl(210, 8%, 85%)
+}
+
+.topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:before, .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:after {
+    left: 20px
+}
+
+.topbar-dialog.network-logo-dialog {
+    width: 320px;
+    border: 1px solid var(--black-200);
+    border-radius: 3px;
+    font-size: 13px;
+    box-shadow: var(--bs-sm)
+}
+
+.topbar-dialog.network-logo-dialog .dialog-content {
+    padding: 16px;
+    background: var(--white);
+    border-radius: 5px
+}
+
+.topbar-dialog.network-logo-dialog h4 {
+    margin-bottom: 12px
+}
+
+.topbar-dialog.network-logo-dialog a {
+    font-weight: normal
+}
+
+.topbar-dialog.network-logo-dialog .icon-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: block;
+    width: 18px;
+    height: 18px;
+    border-radius: 3px;
+    color: #d1d1d1;
+    transition: opacity .2s ease-in-out
+}
+
+.topbar-dialog.network-logo-dialog .icon-close:hover {
+    opacity: .5
+}
+
+.topbar-dialog ul {
+    padding-left: 0;
+    margin-left: 0;
+    margin-bottom: 0
+}
+
+.topbar-dialog ul li {
+    list-style: none;
+    margin-left: 0;
+    line-height: 1.3
+}
+
+.topbar-dialog .header {
+    background-color: var(--black-050);
+    width: 100%;
+    box-sizing: border-box;
+    position: relative;
+    clear: both;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px
+}
+
+.topbar-dialog .header h3 {
+    font-family: var(--ff-sans);
+    color: var(--black-500);
+    font-weight: bold;
+    text-transform: uppercase;
+    font-size: 11px;
+    margin-bottom: 0;
+    display: inline-block
+}
+
+.topbar-dialog .header h3 a {
+    font-size: inherit;
+    color: inherit;
+    font-family: var(--ff-sans)
+}
+
+.topbar-dialog .header .-right {
+    color: var(--black-300)
+}
+
+.topbar-dialog .header .-right a {
+    color: var(--blue)
+}
+
+.topbar-dialog #edit-pinned-sites, .topbar-dialog #cancel-pinned-sites {
+    float: right
+}
+
+.topbar-dialog .modal-content {
+    width: 100%;
+    max-height: 300px;
+    position: relative
+}
+
+.topbar-dialog .modal-content li {
+    border-bottom: 1px solid var(--black-050);
+    margin-bottom: 0
+}
+
+.topbar-dialog .modal-content li .rep-score {
+    float: right;
+    color: var(--black-400);
+    font-size: 12px
+}
+
+.topbar-dialog .modal-content li:hover {
+    background-color: var(--black-075)
+}
+
+.topbar-dialog .modal-content li>* {
+    padding: 8px
+}
+
+.topbar-dialog .modal-content li>a>* {
+    white-space: normal
+}
+
+.topbar-dialog .modal-content li>a.pinned-site-link {
+    display: inline-block
+}
+
+.topbar-dialog .modal-content li:last-child {
+    border-bottom: none
+}
+
+.topbar-dialog .modal-content .message-text {
+    display: inline-block
+}
+
+.topbar-dialog .modal-content .message-text h4 {
+    margin-bottom: 0;
+    font-size: 100%;
+    font-weight: normal;
+    font-family: var(--ff-sans);
+    color: inherit
+}
+
+.topbar-dialog .unread-item {
+    background-color: var(--powder-100);
+    padding-bottom: 8px;
+    padding-top: 8px
+}
+
+.topbar-dialog .unread-item .unread-bold {
+    font-weight: bold;
+    color: var(--blue-700)
+}
+
+.topbar-dialog .unread-item:hover {
+    background-color: var(--powder-200)
+}
+
+.topbar-dialog .site-icon {
+    width: 16px;
+    height: 16px;
+    vertical-align: top;
+    flex: none
+}
+
+.topbar-dialog .site-title, .topbar-dialog .site-title:visited {
+    color: var(--black-700)
+}
+
+.topbar-dialog .pinned-site-editor-container {
+    width: 100%
+}
+
+.topbar-dialog .pinned-site-editor-container .site-filter-input {
+    width: 100%
+}
+
+.topbar-dialog .pinned-site-editor-container .found-sites {
+    position: absolute;
+    background-color: var(--white);
+    border: 1px solid var(--black-075)
+}
+
+.topbar-dialog .pinned-site-editor-container .found-sites li:hover {
+    font-weight: bold;
+    cursor: pointer
+}
+
+.topbar-dialog .pinned-site-editor-container .found-sites li.already-pinned-site {
+    font-weight: normal;
+    background-color: var(--blue-050);
+    cursor: default
+}
+
+.topbar-dialog .pinned-site-editor-container .remove-pinned-site-link {
+    float: right
+}
+
+.topbar-dialog .pinned-site-editor-container .remove-pinned-site-link a {
+    padding: 0 5px 2px 5px;
+    font-weight: bold;
+    color: var(--black-350);
+    background-color: var(--black-050);
+    font-family: var(--ff-sans);
+    line-height: 1;
+    border-radius: 15px
+}
+
+.topbar-dialog .pinned-site-editor-container .remove-pinned-site-link a:hover {
+    color: var(--white);
+    background-color: var(--black-400)
+}
+
+.topbar-dialog .pinned-site-editor-container .sortable li {
+    cursor: move
+}
+
+.achievements-dialog {
+    width: 450px;
+    max-height: 505px;
+    font-size: 12px
+}
+
+.achievements-dialog .utc-clock {
+    color: var(--black-350);
+    font-size: 11px;
+    font-weight: normal;
+    display: inline-block;
+    padding-left: 5px;
+    font-variant: small-caps
+}
+
+.achievements-dialog .date-group .date-group-toggle-row {
+    cursor: pointer
+}
+
+.achievements-dialog .date-group .date-group-toggle {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    background-position: 2px -94px
+}
+
+.achievements-dialog .date-group .date-group-toggle.toggle-hidden {
+    background-position: -17px -94px
+}
+
+.achievements-dialog ul {
+    margin-bottom: 10px
+}
+
+.achievements-dialog .rep-change {
+    vertical-align: top;
+    text-align: right;
+    font-size: 11px;
+    display: inline-block;
+    white-space: nowrap
+}
+
+.achievements-dialog .rep-up {
+    color: var(--green-400)
+}
+
+.achievements-dialog .rep-down {
+    color: var(--red-500)
+}
+
+.achievements-dialog .rep-site-container {
+    margin: 10px 0;
+    width: 100%;
+    cursor: default
+}
+
+.achievements-dialog .rep-site-container .rep-site {
+    width: 30px;
+    display: inline-block;
+    text-align: center
+}
+
+.achievements-dialog .rep-site-container .rep-site img {
+    display: block;
+    margin: 0 auto 4px auto
+}
+
+.achievements-dialog .date-header, .achievements-dialog .single-rep-site-container {
+    font-weight: bold;
+    margin: 3px 0 4px 0;
+    display: inline-block;
+    font-size: 12px
+}
+
+.achievements-dialog .date-header .rep-change, .achievements-dialog .single-rep-site-container .rep-change {
+    font-size: 12px
+}
+
+.achievements-dialog .date-header {
+    padding: 8px;
+    color: var(--black-400)
+}
+
+.achievements-dialog .single-rep-site-container {
+    margin-left: 2px
+}
+
+.achievements-dialog .message-text {
+    margin-left: 2px;
+    width: 278px
+}
+
+.achievements-dialog .achievements-badge {
+    text-align: right
+}
+
+.achievements-dialog .achievements-privilege-category .icon {
+    vertical-align: top;
+    margin: 0;
+    width: 18px
+}
+
+.achievements-dialog .modal-content.short {
+    min-height: 297px;
+    max-height: 297px
+}
+
+.achievements-dialog .modal-content.tiny {
+    min-height: 197px;
+    max-height: 197px
+}
+
+.self-actions {
+    width: 200px;
+    max-height: 505px;
+    left: 535px
+}
+
+html {
+    --top-bar-allocated-space: 50px
+}
+
+.s-topbar~.container, .s-topbar~#announcement-banner {
+    margin-top: var(--topbar-height)
+}
+
+.s-topbar~#announcement-banner~.container {
+    margin-top: 0
+}
+
+.s-topbar {
+    --theme-topbar-height: 50px
+}
+
+.s-topbar, .s-topbar * {
+    box-sizing: border-box
+}
+
+.s-topbar .s-topbar--logo .-img {
+    display: inline-block;
+    text-indent: -9999em;
+    height: 30px;
+    width: 146px;
+    margin-top: -4px;
+    margin-left: 0;
+    background-position: 0 -500px
+}
+
+.s-topbar .s-topbar--logo .-img._glyph {
+    margin-left: 0;
+    width: 150px;
+    height: 30px;
+    margin-top: -4px
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .s-topbar .s-topbar--logo .-img._glyph {
+        width: 25px;
+        margin-top: 0
+    }
+}
+
+@media print {
+    .s-topbar .s-topbar--logo .-img._glyph {
+        width: 25px;
+        margin-top: 0
+    }
+}
+
+body.theme-highcontrast .s-topbar .s-topbar--logo .-img {
+    filter: brightness(0)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-topbar .s-topbar--logo .-img {
+        filter: invert(.5) brightness(2)
+    }
+}
+
+body.theme-dark .s-topbar .s-topbar--logo .-img, .theme-dark__forced .s-topbar .s-topbar--logo .-img {
+    filter: invert(.5) brightness(2)
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .s-topbar .s-topbar--logo.network-logo {
+        width: 41px;
+        overflow: hidden;
+        display: block
+    }
+
+    html.html__responsive .s-topbar .s-topbar--logo.network-logo .svg-icon {
+        transform: scale(2);
+        transform-origin: 0 -10px
+    }
+}
+
+@media print {
+    .s-topbar .s-topbar--logo.network-logo {
+        width: 41px;
+        overflow: hidden;
+        display: block
+    }
+
+    .s-topbar .s-topbar--logo.network-logo .svg-icon {
+        transform: scale(2);
+        transform-origin: 0 -10px
+    }
+}
+
+.s-topbar .topbar-dialog.leftnav-dialog {
+    width: auto;
+    right: auto
+}
+
+.s-topbar .topbar-dialog.leftnav-dialog .left-sidebar:not(:empty) {
+    width: 240px
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .s-topbar .topbar-dialog:not(.leftnav-dialog), html.html__responsive .s-topbar .topbar-dialog.review-dialog.review-dialog-mod {
+        width: 100%;
+        left: 0;
+        right: 0
+    }
+
+    html.html__responsive .s-topbar .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:before, html.html__responsive .s-topbar .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:after {
+        left: 105px
+    }
+}
+
+@media print {
+    .s-topbar .topbar-dialog:not(.leftnav-dialog), .s-topbar .topbar-dialog.review-dialog.review-dialog-mod {
+        width: 100%;
+        left: 0;
+        right: 0
+    }
+
+    .s-topbar .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:before, .s-topbar .topbar-dialog.feature-notice-dialog .s-popover--arrow__tl:after {
+        left: 105px
+    }
+}
+
+.s-topbar .s-topbar--menu-btn {
+    display: none
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .s-topbar .s-topbar--menu-btn {
+        display: flex
+    }
+}
+
+@media print {
+    .s-topbar .s-topbar--menu-btn {
+        display: flex
+    }
+}
+
+html.html__unpinned-leftnav .s-topbar .s-topbar--menu-btn {
+    display: flex
+}
+
+.s-topbar .s-user-card .-badges {
+    font-size: inherit;
+    color: var(--black-050)
+}
+
+.s-topbar .s-user-card .-badges>span+span {
+    padding-left: 6px
+}
+
+.s-topbar .s-user-card .-badges .badge1, .s-topbar .s-user-card .-badges .badge2, .s-topbar .s-user-card .-badges .badge3 {
+    text-indent: -9999em
+}
+
+.s-topbar .s-user-card .-badges .badgecount {
+    font-weight: normal
+}
+
+.s-topbar .s-user-card .-badges .badge1+.badgecount {
+    color: var(--gold-darker)
+}
+
+.s-topbar .s-user-card .-badges .badge2+.badgecount {
+    color: var(--silver-darker)
+}
+
+.s-topbar .s-user-card .-badges .badge3+.badgecount {
+    color: var(--bronze-darker)
+}
+
+.s-topbar .topbar-dialog {
+    --scrollbar: var(--hack-topbar-scrollbar-fallback)
+}
+
+body {
+    --hack-topbar-scrollbar-fallback: var(--scrollbar)
+}
+
+.s-topbar .s-topbar--item__unset>* {
+    align-self: center;
+    padding-top: 8px;
+    padding-bottom: 8px
+}
+
+.s-topbar .s-topbar--item__unset+.s-topbar--item__unset {
+    margin-left: 4px
+}
+
+.s-topbar .s-topbar--item__unset:last-child {
+    margin-right: 8px
+}
+
+.site-footer, .site-footer *, .site-footer *:before, .site-footer *:after {
+    box-sizing: border-box
+}
+
+.site-footer .-list {
+    margin: 0;
+    list-style: none
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .site-footer .-list:not(.-social) {
+        display: flex;
+        flex-wrap: wrap;
+        column-gap: 12px;
+        row-gap: 8px
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .site-footer .-list:not(.-social) {
+        display: flex;
+        flex-wrap: wrap;
+        column-gap: 12px;
+        row-gap: 8px
+    }
+}
+
+@media print {
+    .site-footer .-list:not(.-social) {
+        display: flex;
+        flex-wrap: wrap;
+        column-gap: 12px;
+        row-gap: 8px
+    }
+}
+
+.site-footer .-link {
+    color: var(--theme-footer-link-color);
+    padding: 4px 0;
+    line-height: 1.30769231;
+    display: inline-block;
+    text-decoration: none
+}
+
+.site-footer .-link:hover {
+    color: var(--theme-footer-link-color-hover)
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .site-footer .-link {
+        padding: 0
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .site-footer .-link {
+        padding: 0
+    }
+}
+
+@media print {
+    .site-footer .-link {
+        padding: 0
+    }
+}
+
+.site-footer .-title {
+    text-transform: uppercase;
+    font-weight: bold;
+    margin-bottom: 12px;
+    color: var(--theme-footer-title-color);
+    line-height: 1.30769231
+}
+
+.site-footer .-title a {
+    color: var(--theme-footer-title-color);
+    text-decoration: none
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .site-footer .-title {
+        margin-bottom: 8px
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .site-footer .-title {
+        margin-bottom: 8px
+    }
+}
+
+@media print {
+    .site-footer .-title {
+        margin-bottom: 8px
+    }
+}
+
+.site-footer {
+    background-color: var(--theme-footer-background-color);
+    background-image: none;
+    background-position: var(--theme-footer-background-position);
+    background-repeat: var(--theme-footer-background-repeat);
+    border-top: var(--theme-footer-background-border-top);
+    background-size: var(--theme-footer-background-size);
+    color: var(--theme-footer-text-color);
+    padding-top: var(--theme-footer-padding-top);
+    padding-bottom: var(--theme-footer-padding-bottom)
+}
+
+body.theme-highcontrast .site-footer {
+    --theme-footer-background-color: hsl(210, 8%, 5%);
+    --theme-footer-background-border-top: hsl(0, 0%, 100%);
+    --theme-footer-title-color: hsl(0, 0%, 100%);
+    --theme-footer-text-color: hsl(0, 0%, 100%);
+    --theme-footer-link-color: hsl(0, 0%, 100%);
+    --theme-footer-link-color-hover: hsl(0, 0%, 100%);
+    --theme-footer-link-color-active: hsl(0, 0%, 100%);
+    --theme-footer-link-caret-color: hsl(210, 8%, 5%);
+    --theme-footer-divider-color: hsl(0, 0%, 100%);
+    background-image: none !important;
+    border-top: 1px solid var(--black)
+}
+
+body.theme-highcontrast .site-footer a:hover, body.theme-highcontrast .site-footer a:focus {
+    color: hsl(0, 0%, 100%);
+    text-decoration: underline
+}
+
+.site-footer .site-footer--container, .site-footer .site-footer--extra {
+    max-width: 1264px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 32px 12px 12px 12px;
+    display: flex;
+    flex-flow: row wrap
+}
+
+@media screen and (max-width:980px) and (min-width:640.1px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .site-footer .site-footer--container, html.html__responsive:not(.html__unpinned-leftnav) .site-footer .site-footer--extra {
+        padding: 24px
+    }
+}
+
+@media screen and (max-width:816px) and (min-width:640.1px) {
+    html.html__responsive.html__unpinned-leftnav .site-footer .site-footer--container, html.html__responsive.html__unpinned-leftnav .site-footer .site-footer--extra {
+        padding: 24px
+    }
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .site-footer .site-footer--container, html.html__responsive .site-footer .site-footer--extra {
+        padding: 16px
+    }
+}
+
+@media print {
+    .site-footer .site-footer--container, .site-footer .site-footer--extra {
+        padding: 16px
+    }
+}
+
+.site-footer .site-footer--extra {
+    padding: 32px 12px;
+    border-top: 1px solid var(--theme-footer-divider-color)
+}
+
+.site-footer .site-footer--logo {
+    flex: 0 0 64px;
+    margin: -12px 0 32px 0
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .site-footer .site-footer--logo {
+        display: none
+    }
+}
+
+@media print {
+    .site-footer .site-footer--logo {
+        display: none
+    }
+}
+
+.site-footer .site-footer--nav {
+    display: flex;
+    flex: 2 1 auto;
+    flex-wrap: wrap
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .site-footer .site-footer--nav {
+        flex-direction: column
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .site-footer .site-footer--nav {
+        flex-direction: column
+    }
+}
+
+@media print {
+    .site-footer .site-footer--nav {
+        flex-direction: column
+    }
+}
+
+.site-footer .site-footer--col {
+    padding: 0 12px 24px 0;
+    flex: 1 0 auto
+}
+
+.site-footer .site-footer--copyright {
+    flex: 1 1 150px;
+    display: flex;
+    flex-direction: column
+}
+
+.site-footer .site-footer--copyright ul {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0
+}
+
+.site-footer .site-footer--copyright ul li+li {
+    margin-left: 12px
+}
+
+.site-footer .site-footer--copyright p {
+    margin-top: auto;
+    margin-bottom: 24px
+}
+
+.site-footer .site-footer--copyright p a, .site-footer .site-footer--copyright p a:visited {
+    line-height: inherit;
+    color: var(--theme-footer-link-color);
+    padding: 0
+}
+
+.message.error, .message.success, .message.regular, .message.incomplete, .message.gray {
+    display: inline-block;
+    padding: 12px;
+    margin: 10px 0;
+    border-radius: 3px
+}
+
+.message.error.text-only, .message.success.text-only, .message.regular.text-only, .message.incomplete.text-only, .message.gray.text-only {
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0 0 10px 0;
+    color: var(--black-500)
+}
+
+.message.error.text-only i[class^="icon-"], .message.success.text-only i[class^="icon-"], .message.regular.text-only i[class^="icon-"], .message.incomplete.text-only i[class^="icon-"], .message.gray.text-only i[class^="icon-"], .message.error.text-only span[class^="icon-"], .message.success.text-only span[class^="icon-"], .message.regular.text-only span[class^="icon-"], .message.incomplete.text-only span[class^="icon-"], .message.gray.text-only span[class^="icon-"] {
+    margin-right: 4px
+}
+
+.message.error.centered, .message.success.centered, .message.regular.centered, .message.incomplete.centered, .message.gray.centered {
+    text-align: center
+}
+
+.message.error.centered-block, .message.success.centered-block, .message.regular.centered-block, .message.incomplete.centered-block, .message.gray.centered-block {
+    display: block;
+    margin: 10px auto
+}
+
+.message.error.left-block, .message.success.left-block, .message.regular.left-block, .message.incomplete.left-block, .message.gray.left-block {
+    display: block;
+    margin: 10px auto
+}
+
+.message.error .message-ctas, .message.success .message-ctas, .message.regular .message-ctas, .message.incomplete .message-ctas, .message.gray .message-ctas {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 10px
+}
+
+.message.error .message-cta, .message.success .message-cta, .message.regular .message-cta, .message.incomplete .message-cta, .message.gray .message-cta {
+    margin-top: 10px
+}
+
+.message.error .message-title, .message.success .message-title, .message.regular .message-title, .message.incomplete .message-title, .message.gray .message-title {
+    text-align: center;
+    font-weight: 700;
+    padding: 10px 0;
+    margin: -12px -12px 10px -12px;
+    border-radius: 3px 3px 0 0
+}
+
+.message.error .message-title [class^="icon"], .message.success .message-title [class^="icon"], .message.regular .message-title [class^="icon"], .message.incomplete .message-title [class^="icon"], .message.gray .message-title [class^="icon"] {
+    margin-right: 4px;
+    vertical-align: middle
+}
+
+.message.error .message-title [class*="icon-warning"], .message.success .message-title [class*="icon-warning"], .message.regular .message-title [class*="icon-warning"], .message.incomplete .message-title [class*="icon-warning"], .message.gray .message-title [class*="icon-warning"] {
+    position: relative;
+    top: -1px
+}
+
+.message.inline-message {
+    display: block
+}
+
+.message.inline-message:before, .message.inline-message:after {
+    content: "";
+    display: table
+}
+
+.message.inline-message:after {
+    clear: both
+}
+
+.message.inline-message .message-title {
+    display: inline-block;
+    margin: 0 12px 0 0;
+    color: var(--orange)
+}
+
+.message.inline-message .inline-message-cta {
+    float: right
+}
+
+.message.regular {
+    background: var(--yellow-050);
+    color: var(--yellow-900);
+    border: 1px solid var(--yellow-100)
+}
+
+.message.error {
+    color: var(--red-900);
+    background: var(--red-050);
+    border: 1px solid var(--red-100)
+}
+
+.message.error.text-only {
+    color: var(--red-500)
+}
+
+.message.error.text-only:before {
+    top: 3px;
+    background-position: -72px -330px
+}
+
+.message.success {
+    color: var(--green-900);
+    background: var(--green-050);
+    border: 1px solid var(--green-100)
+}
+
+.message.success.text-only {
+    color: var(--green-500)
+}
+
+.message.success.text-only:before {
+    background-position: -95px -330px
+}
+
+.message.incomplete {
+    color: var(--black-900);
+    background: var(--orange-050);
+    border: 1px solid var(--orange-100)
+}
+
+.message.incomplete .message-title {
+    color: var(--orange);
+    background: var(--orange-100);
+    padding: 10px 0;
+    margin: -12px -12px 10px -12px
+}
+
+.message.gray {
+    background: #f6f6f7;
+    color: hsl(210, 8%, 5%);
+    border: 1px solid hsl(210, 8%, 90%)
+}
+
+.message.gray .message-title {
+    background: hsl(210, 8%, 90%);
+    padding: 10px 0
+}
+
+.job-requirements {
+    padding: 15px
+}
+
+.job-requirements input[type=submit].dno {
+    display: none
+}
+
+.message.job-improve .message-title {
+    background: hsl(210, 8%, 90%);
+    padding: 10px 0
+}
+
+.message.label.regular {
+    font-size: 12px;
+    padding: 6px;
+    margin: 0
+}
+
+.message.label.regular.has-tooltip {
+    cursor: default
+}
+
+h1 .message.label, h2 .message.label, h3 .message.label {
+    position: relative;
+    top: -1px
+}
+
+.top-notification {
+    background: hsl(206, 100%, 52%);
+    color: hsl(0, 0%, 100%);
+    font-size: 12px;
+    margin-bottom: 20px;
+    padding: 10px 20px
+}
+
+.top-notification .container {
+    width: 100%;
+    max-width: 1050px;
+    margin: 0 auto;
+    min-height: 30px;
+    align-items: center
+}
+
+.top-notification a {
+    color: hsl(0, 0%, 100%)
+}
+
+.top-notification .-content p:last-child {
+    margin-bottom: 0
+}
+
+.top-notification .-content .btn {
+    background: #F48024;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+    margin-left: 10px
+}
+
+.top-notification .-actions {
+    text-align: right
+}
+
+.comments {
+    width: 660px;
+    padding-bottom: 10px
+}
+
+.comments>table {
+    width: 100%
+}
+
+.comments-link {
+    padding: 0 3px 2px 3px
+}
+
+a.comments-link:hover {
+    padding: 0 3px 2px 3px;
+    text-decoration: none
+}
+
+tr.comment>td {
+    padding: 6px 6px 6px 0;
+    vertical-align: top;
+    line-height: 1.3;
+    border-bottom: 1px solid var(--black-050)
+}
+
+.comment img {
+    vertical-align: middle
+}
+
+.comment:not([style*="background-color"]) {
+    transition: background-color linear 2s
+}
+
+.comment-actions {
+    padding-left: 3px;
+    width: 15px
+}
+
+.comment-score span {
+    font-size: 13px;
+    font-weight: normal;
+    padding-right: 4px
+}
+
+.comment-text, .comment-form {
+    padding: 0 6px 0 7px;
+    vertical-align: text-top
+}
+
+.comment-text code {
+    padding: 1px 5px
+}
+
+.comment-text .comment-edited {
+    margin-top: 3px;
+    margin-left: 2px;
+    vertical-align: top
+}
+
+.comment-form>form textarea, .comment-form>form div[contenteditable=true] {
+    margin-bottom: 4px;
+    height: 5em;
+    width: 100%;
+    resize: vertical;
+    overflow: auto
+}
+
+.comment-date {
+    color: var(--black-400)
+}
+
+.text-counter {
+    margin-right: 20px
+}
+
+.comment-text .hover-only-label {
+    visibility: hidden
+}
+
+.comment-text:hover .hover-only-label {
+    visibility: visible
+}
+
+.comment-text:focus-within .hover-only-label {
+    visibility: visible
+}
+
+.comment-text button:focus .hover-only-label {
+    visibility: visible
+}
+
+@media (hover:none) {
+    .comment-text .hover-only-label {
+        visibility: visible
+    }
+}
+
+.comment__highlight:not([style*="background-color"]) {
+    transition: none;
+    background-color: var(--yellow-100)
+}
+
+ul.comments-list {
+    list-style-type: none;
+    margin: 0
+}
+
+ul.comments-list .comment {
+    display: flex
+}
+
+ul.comments-list .comment-score {
+    width: 15px;
+    width: 2ch;
+    padding-right: 4px
+}
+
+ul.comments-list .comment-score>span {
+    float: right;
+    padding-right: 0px;
+    min-width: 15px;
+    min-width: 2ch
+}
+
+ul.comments-list .comment-text {
+    flex-grow: 1
+}
+
+ul.comments-list .comment-voting, ul.comments-list .comment-flagging {
+    width: 20px
+}
+
+ul.comments-list .comment>* {
+    border-bottom: 1px solid var(--black-050)
+}
+
+ul.comments-list .comment-text, ul.comments-list comment-form, ul.comments-list .comment-actions {
+    padding: 6px 0
+}
+
+ul.comments-list .comment-text {
+    min-width: 0;
+    flex-basis: 0;
+    padding-left: 6px;
+    padding-right: 6px
+}
+
+ul.comments-list .comment-body {
+    word-wrap: break-word
+}
+
+ul.comments-list .comment-actions {
+    padding-right: 2px
+}
+
+ul.comments-list .comment-text, ul.comments-list .comment-actions {
+    transition: background-color ease-out 3s
+}
+
+ul.comments-list .deleted-comment {
+    background-color: transparent
+}
+
+ul.comments-list .deleted-comment .comment-text, ul.comments-list .deleted-comment .comment-actions {
+    background-color: var(--red-050)
+}
+
+ul.comments-list .comment__highlight {
+    background-color: transparent
+}
+
+ul.comments-list .comment__highlight .comment-text {
+    transition: none;
+    background-color: var(--yellow-100)
+}
+
+ul.comments-list .comment-actions {
+    width: 38px;
+    flex-shrink: 0
+}
+
+ul.comments-list .comment-score {
+    display: inline-block
+}
+
+ul.comments-list .comment-voting, ul.comments-list .comment-flagging {
+    float: right
+}
+
+@supports (display: grid) {
+    ul.comments-list .comment-actions {
+        display: grid;
+        grid-template-columns: repeat(2, max-content);
+        align-content: flex-start;
+        width: 37px;
+        width: calc(2ch + 16px + 4px + 2px)
+    }
+
+    ul.comments-list .comment-flagging:nth-child(3) {
+        grid-column: 2
+    }
+}
+
+@supports (display: grid) and (display: contents) and (not (-apple-trailing-word: auto)) {
+    body:not(.no-grid-comments) ul.comments-list {
+        display: grid;
+        grid-template-columns: max-content 1fr
+    }
+
+    body:not(.no-grid-comments) ul.comments-list .comment-score {
+        width: auto;
+        min-width: 16px
+    }
+
+    body:not(.no-grid-comments) ul.comments-list .comment-score>span {
+        min-width: 0;
+        float: none
+    }
+
+    body:not(.no-grid-comments) ul.comments-list .comment-actions {
+        width: auto
+    }
+
+    body:not(.no-grid-comments) ul.comments-list .comment {
+        display: contents
+    }
+
+    body:not(.no-grid-comments) ul.comments-list .comment__highlight .comment-actions {
+        transition: none;
+        background-color: var(--yellow-100)
+    }
+}
+
+.message.message-config.unsubscribe-all-popup {
+    z-index: 2000
+}
+
+.col-6.with-padding:first-child {
+    padding-right: 10px
+}
+
+.col-6.with-padding:last-child {
+    padding-left: 10px
+}
+
+.profile-section-title {
+    font-weight: 700;
+    color: var(--fc-dark)
+}
+
+.profile-section-title span {
+    font-weight: 400;
+    color: var(--fc-light)
+}
+
+#mod-content {
+    margin-top: 25px
+}
+
+#mod-content .mod-sidebar {
+    padding-right: 30px
+}
+
+#mod-content .mod-sidebar .account-details {
+    margin-bottom: 20px
+}
+
+.mod-quick-links {
+    margin-bottom: 30px
+}
+
+.mod-links li {
+    margin-bottom: 5px
+}
+
+.account-info .row.mod-section {
+    padding-bottom: 20px;
+    margin-bottom: 20px;
+    border-bottom: 1px solid hsl(210, 8%, 95%)
+}
+
+#mod-content .row h3 {
+    margin-bottom: 10px
+}
+
+.row.mod-credentials {
+    margin-top: 20px;
+    margin-bottom: 0
+}
+
+.account-info dl {
+    float: right;
+    font-size: .8em
+}
+
+.account-info dl dt {
+    display: inline-block;
+    font-weight: bold
+}
+
+.account-info dl dd {
+    display: inline-block;
+    font-style: italic
+}
+
+.ui-datepicker.ui-widget {
+    color: var(--fc-medium)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .ui-datepicker.ui-widget {
+        background-color: var(--black-100);
+        border-color: transparent;
+        box-shadow: var(--bs-lg)
+    }
+}
+
+body.theme-dark .ui-datepicker.ui-widget, .theme-dark__forced .ui-datepicker.ui-widget {
+    background-color: var(--black-100);
+    border-color: transparent;
+    box-shadow: var(--bs-lg)
+}
+
+.ui-datepicker table.ui-datepicker-calendar .ui-state-default {
+    color: inherit;
+    background: none;
+    border: 0
+}
+
+.ui-datepicker table.ui-datepicker-calendar .ui-state-hover, .ui-datepicker .ui-datepicker-header .ui-state-hover {
+    background-color: var(--theme-button-hover-background-color)
+}
+
+.ui-datepicker table.ui-datepicker-calendar .ui-state-active {
+    background: var(--theme-button-primary-background-color);
+    color: #fff
+}
+
+.ui-datepicker .ui-datepicker-header {
+    color: inherit;
+    background: none;
+    border: 0
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .ui-datepicker .ui-datepicker-header .ui-icon {
+        filter: invert(1)
+    }
+}
+
+body.theme-dark .ui-datepicker .ui-datepicker-header .ui-icon, .theme-dark__forced .ui-datepicker .ui-datepicker-header .ui-icon {
+    filter: invert(1)
+}
+
+.ui-datepicker .ui-datepicker-header.ui-widget-header .ui-state-hover {
+    background: none;
+    border-color: var(--black-200)
+}
+
+.ui-datepicker table.ui-datepicker-calendar .ui-state-highlight {
+    font-weight: bold
+}
+
+.block {
+    display: block
+}
+
+.fw {
+    margin-bottom: 4px;
+    width: 100%
+}
+
+.relative {
+    position: relative
+}
+
+.cp {
+    cursor: pointer
+}
+
+.help-text {
+    color: var(--black-500)
+}
+
+.bold {
+    font-weight: 700
+}
+
+.help-text.has-icon, .message.text-only.has-icon {
+    display: flex
+}
+
+.help-text.has-icon [class^='icon'], .message.text-only.has-icon [class^='icon'], .help-text.has-icon .svg-icon, .message.text-only.has-icon .svg-icon {
+    flex-shrink: 0;
+    margin-top: -3px;
+    margin-right: 5px
+}
+
+.help-text.has-icon .icon-i-orange, .message.text-only.has-icon .icon-i-orange {
+    position: relative;
+    top: 2px
+}
+
+.success-text {
+    color: var(--green-500)
+}
+
+.error-text {
+    color: var(--red-500)
+}
+
+.hidden, .dno, ._hidden {
+    display: none
+}
+
+.hidden-important {
+    display: none !important
+}
+
+.stop-scrolling {
+    height: 100%;
+    overflow: hidden
+}
+
+._blocked {
+    overflow: hidden;
+    position: fixed
+}
+
+html {
+    height: 100%;
+    min-width: 1264px
+}
+
+body {
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--theme-background-color);
+    background-image: none;
+    background-position: var(--theme-background-position);
+    background-repeat: var(--theme-background-repeat);
+    background-size: var(--theme-background-size);
+    background-attachment: var(--theme-background-attachment);
+    min-width: 1279px;
+    --mp-alt-row-color: var(--black-050);
+    --mp-critical-color: var(--red-600);
+    --mp-duration-color: var(--black-800);
+    --mp-gap-bg-color: var(--black-025);
+    --mp-gap-font-color: var(--black-700);
+    --mp-highlight-default-color: var(--fc-dark);
+    --mp-highlight-fade-color: var(--yellow-300);
+    --mp-highlight-keyword-color: var(--blue-700);
+    --mp-highlight-literal-color: var(--green-500);
+    --mp-label-color: var(--black-700);
+    --mp-link-color: var(--blue-700);
+    --mp-main-bg-color: var(--white);
+    --mp-muted-color: var(--black-300);
+    --mp-popup-shadow: var(--bs-sm);
+    --mp-query-border-color: var(--black-100);
+    --mp-result-border: solid .5px var(--black-300);
+    --mp-warning-color: var(--red-600)
+}
+
+body.read-only .askquestion, body.read-only .login-link, body.read-only .bookmark-off, body.read-only .vote-down-off, body.read-only .vote-up-off {
+    opacity: .3
+}
+
+body.read-only .bookmark-off, body.read-only .vote-down-off, body.read-only .vote-up-off {
+    cursor: not-allowed
+}
+
+.container {
+    position: relative;
+    width: 100%;
+    flex: 1 0 auto;
+    margin: 0 auto;
+    text-align: left
+}
+
+#content {
+    box-sizing: content-box;
+    margin: 0 auto;
+    padding: 15px;
+    width: 1264px;
+    background-color: hsl(0, 0%, 100%)
+}
+
+#content:before, #content:after {
+    content: "";
+    display: table
+}
+
+#content:after {
+    clear: both
+}
+
+.ask-page:not(.wizard) #content {
+    min-height: 750px;
+    overflow: visible
+}
+
+body:not(.unified-theme) .container._full #content {
+    padding: 0;
+    width: 100%
+}
+
+body:not(.unified-theme) .container._full #content .inner-content {
+    box-sizing: content-box;
+    margin: 0 auto;
+    padding: 15px;
+    width: 1264px
+}
+
+body:not(.unified-theme) .container._full #content .inner-content:before, body:not(.unified-theme) .container._full #content .inner-content:after {
+    content: "";
+    display: table
+}
+
+body:not(.unified-theme) .container._full #content .inner-content:after {
+    clear: both
+}
+
+.main-columns {
+    display: flex
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .main-columns {
+        flex-direction: column
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .main-columns {
+        flex-direction: column
+    }
+}
+
+@media print {
+    .main-columns {
+        flex-direction: column
+    }
+}
+
+.main-columns #mainbar, .main-columns .mainbar {
+    float: none
+}
+
+.main-columns #sidebar, .main-columns .sidebar {
+    float: none;
+    margin-left: 24px
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .main-columns #sidebar, html.html__responsive:not(.html__unpinned-leftnav) .main-columns .sidebar {
+        margin-left: auto
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .main-columns #sidebar, html.html__responsive.html__unpinned-leftnav .main-columns .sidebar {
+        margin-left: auto
+    }
+}
+
+@media print {
+    .main-columns #sidebar, .main-columns .sidebar {
+        margin-left: auto
+    }
+}
+
+.container__full {
+    max-width: 100%
+}
+
+.container__full .left-sidebar {
+    display: none
+}
+
+.container__full #content {
+    padding: 0;
+    max-width: 100%;
+    width: 100%
+}
+
+.container .container--inner {
+    max-width: 1264px;
+    padding: 0 24px;
+    margin: 0 auto
+}
+
+#header {
+    margin: 0 auto;
+    width: 1264px;
+    height: 96px;
+    padding: 0 15px;
+    box-sizing: content-box;
+    position: relative
+}
+
+#questions, #answers {
+    clear: both;
+    width: 728px
+}
+
+#questions {
+    float: left;
+    margin-bottom: 20px
+}
+
+#question-header .question-hyperlink {
+    font-size: 2.07692308rem;
+    font-family: var(--theme-post-title-font-family);
+    line-height: 1.35;
+    font-weight: normal;
+    margin-bottom: 0
+}
+
+.question-summary {
+    overflow: hidden;
+    padding: 15px 0;
+    float: left;
+    width: 728px;
+    border-bottom: 1px solid var(--black-050)
+}
+
+body.theme-highcontrast .question-summary {
+    border-bottom-color: currentColor
+}
+
+.question-summary .question-summary-scroll {
+    border-bottom: none
+}
+
+.question-summary .question-hyperlink {
+    font-family: var(--theme-post-title-font-family)
+}
+
+.stats {
+    margin: 0;
+    width: 58px
+}
+
+.statscontainer {
+    width: 78px;
+    float: left;
+    margin-right: 8px;
+    margin-left: 8px;
+    color: var(--black-500);
+    font-size: 11px
+}
+
+.statscontainer .views {
+    width: 58px
+}
+
+.statscontainer .status {
+    padding: 7px 0 5px;
+    border-radius: 3px
+}
+
+.statscontainer .status strong {
+    font-size: 1.61538462rem;
+    font-weight: normal
+}
+
+.narrow .status {
+    display: inline-block;
+    margin: 0 3px 0 0;
+    min-width: 44px;
+    height: auto;
+    font-size: 11px;
+    padding: 6px;
+    border: 1px solid transparent;
+    border-radius: 3px
+}
+
+.narrow .started {
+    width: auto;
+    padding-top: 4px;
+    white-space: nowrap
+}
+
+.narrow .votes {
+    display: inline-block;
+    height: 38px;
+    min-width: 38px;
+    margin: 0 3px 0 0;
+    font-size: 11px;
+    color: var(--black-400);
+    padding: 6px
+}
+
+.narrow .stats {
+    background: none;
+    margin: 0 0 0 7px;
+    padding: 0;
+    width: auto;
+    height: 48px;
+    display: inline-block
+}
+
+.narrow .views {
+    display: inline-block;
+    height: 38px;
+    min-width: 40px;
+    margin: 0 7px 0 0;
+    font-size: 11px;
+    color: var(--black-400);
+    padding: 7px 6px
+}
+
+.narrow .summary {
+    width: 530px;
+    padding: 0;
+    float: left
+}
+
+.narrow .summary h3 {
+    margin-bottom: .35em;
+    line-height: 1.3
+}
+
+.narrow .cp {
+    vertical-align: top;
+    float: left;
+    margin-right: 10px
+}
+
+.narrow .mini-counts {
+    font-size: 1.30769231rem;
+    margin-bottom: 4px
+}
+
+.votes {
+    padding: 0;
+    margin-bottom: 8px;
+    text-align: center
+}
+
+.vote-count-post {
+    display: block;
+    font-size: 1.61538462rem
+}
+
+.vote-count-post strong {
+    font-weight: normal
+}
+
+.status {
+    padding: 0;
+    margin-bottom: 8px;
+    text-align: center
+}
+
+.status strong {
+    display: block
+}
+
+.vote-count-separator {
+    border-top: 1px solid var(--black-050);
+    width: 36px;
+    margin-top: 5px;
+    margin-bottom: 5px
+}
+
+.views {
+    padding-top: 4px;
+    text-align: center
+}
+
+.views strong {
+    display: block
+}
+
+#question-suggestions {
+    overflow: hidden;
+    padding-bottom: 2px;
+    font-size: 1.15384615rem
+}
+
+#question-suggestions .answer-hyperlink, #question-suggestions .question-hyperlink {
+    font-size: 13px
+}
+
+#question-suggestions .answer-votes {
+    font-size: 11px;
+    line-height: 1.3;
+    padding: 1px 0 2px;
+    font-weight: normal
+}
+
+#question-suggestions label {
+    margin: 10px 0
+}
+
+#question-suggestions .answer-summary {
+    overflow: auto;
+    display: flex
+}
+
+.question-originals-of-duplicate.question-status {
+    width: auto;
+    margin: 10px 0;
+    padding: 10px;
+    background-image: none
+}
+
+.question-originals-of-duplicate p {
+    margin: 0;
+    font-weight: bold
+}
+
+.question-originals-of-duplicate ul {
+    margin: 0
+}
+
+.question-originals-of-duplicate ul li {
+    list-style-type: none;
+    margin: 0
+}
+
+.question-originals-of-duplicate .question-originals-answer-count {
+    font-style: italic;
+    padding-left: 5px
+}
+
+.question-originals-of-duplicate #edit-or-approve-duplicate {
+    margin: 15px 0 5px
+}
+
+.question-originals-of-duplicate #edit-or-approve-duplicate #got-my-answer {
+    margin: 0
+}
+
+.question-originals-of-duplicate #edit-or-approve-duplicate>div {
+    line-height: 33px
+}
+
+.question-status {
+    margin-top: 15px;
+    margin-bottom: 10px;
+    padding: 15px 8px 1px 60px;
+    background-color: var(--black-050);
+    border: var(--black-075);
+    clear: both
+}
+
+.question-status h2 {
+    font-size: 1.15384615rem;
+    line-height: 18px;
+    margin-bottom: 10px
+}
+
+.question-status p {
+    font-size: 13px;
+    word-wrap: break-word
+}
+
+.question-status .site-specific-close-reason-status-list {
+    margin-bottom: 0
+}
+
+.question-status .close-status-suffix {
+    display: block;
+    margin-top: 10px
+}
+
+.question-status .voter-history .badge1 {
+    vertical-align: middle
+}
+
+#answers {
+    padding-top: 10px
+}
+
+#answers-header {
+    margin-top: 10px;
+    width: 728px
+}
+
+.question {
+    clear: both
+}
+
+.question .postcell {
+    vertical-align: top
+}
+
+.question-page #answers .answer {
+    border-bottom: 1px solid var(--black-075)
+}
+
+hr {
+    border: 0;
+    color: var(--black-300);
+    background-color: var(--black-300);
+    height: 1px;
+    margin-bottom: 20px
+}
+
+.date {
+    text-align: right;
+    width: 70px;
+    white-space: nowrap;
+    color: var(--black-300);
+    height: 35px;
+    font-size: 1.46153846rem
+}
+
+.date_brick {
+    float: right;
+    width: 45px;
+    color: var(--black-350);
+    text-align: center;
+    line-height: 1.4;
+    font-size: 13px;
+    margin-left: 10px;
+    padding-top: 5px;
+    letter-spacing: 0;
+    overflow: hidden
+}
+
+.revcell1 {
+    width: 25px;
+    cursor: pointer;
+    text-align: right
+}
+
+.revcell2 {
+    width: 50px;
+    cursor: pointer;
+    font-size: 250%;
+    font-weight: bold;
+    color: var(--black-500);
+    text-align: left
+}
+
+.revcell3 {
+    vertical-align: middle;
+    width: 660px;
+    padding-top: 8px;
+    padding-bottom: 5px
+}
+
+.revcell4 {
+    padding: 5px;
+    width: 185px
+}
+
+.revcell5 {
+    margin-top: 10px;
+    margin-left: 10px
+}
+
+.unanswered .mini-counts span {
+    color: var(--black-800)
+}
+
+.votecell {
+    vertical-align: top;
+    padding-right: 15px
+}
+
+.votecell .vote-count-post {
+    margin: 8px 0
+}
+
+.votecell .vote {
+    min-width: 46px
+}
+
+body.theme-highcontrast .votecell button, body.theme-highcontrast .votecell a {
+    color: var(--black-300)
+}
+
+body.theme-highcontrast .votecell button:hover, body.theme-highcontrast .votecell a:hover, body.theme-highcontrast .votecell button:focus, body.theme-highcontrast .votecell a:focus {
+    color: var(--black-900)
+}
+
+#scroller {
+    margin-top: 5px
+}
+
+.answer {
+    padding-bottom: 16px;
+    padding-top: 16px
+}
+
+.post-signature {
+    text-align: left;
+    vertical-align: top;
+    width: 200px
+}
+
+.owner {
+    border-radius: 3px;
+    background-color: var(--theme-post-owner-background-color)
+}
+
+.new-contributor-indicator {
+    background-color: var(--theme-post-owner-new-background-color)
+}
+
+.affiliate-badge {
+    color: var(--orange-400)
+}
+
+.owner .affiliate-badge {
+    color: var(--black-700)
+}
+
+.downvoted-answer .comment-body, .downvoted-answer .post-signature, .downvoted-answer .s-prose, .downvoted-answer .vote>* {
+    opacity: .5;
+    transition: opacity .5s
+}
+
+.downvoted-answer .vote .message {
+    opacity: 1
+}
+
+.downvoted-answer:hover .comment-body, .downvoted-answer:hover .post-signature, .downvoted-answer:hover .s-prose, .downvoted-answer:hover .vote>* {
+    opacity: 1
+}
+
+.item-multiplier {
+    margin-right: 4px;
+    color: var(--black-400)
+}
+
+.reputation-score {
+    font-weight: bold;
+    font-size: 12px;
+    margin-right: 2px
+}
+
+.relativetime {
+    text-decoration: none
+}
+
+#notify-container {
+    font-size: 1.30769231rem;
+    text-align: center;
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 0;
+    z-index: 5051
+}
+
+#notify-container span.notify-close {
+    float: right;
+    margin-right: 20px;
+    text-decoration: none;
+    display: block;
+    cursor: pointer
+}
+
+#notify-container span.notify-close a {
+    text-decoration: none;
+    font-size: 1.30769231rem;
+    font-weight: bold;
+    color: hsl(0, 0%, 100%)
+}
+
+#notify-container div {
+    color: hsl(0, 0%, 100%);
+    padding: 9px 0;
+    background: #f90
+}
+
+.summarycount {
+    text-align: center;
+    font-size: 2.07692308rem;
+    line-height: 1
+}
+
+.summarycount+p {
+    margin-bottom: 0
+}
+
+.lsep {
+    margin: 0 2px;
+    color: hsl(210, 8%, 80%);
+    color: #1b4072;
+    font-size: 1px;
+    visibility: hidden
+}
+
+.post-taglist {
+    margin-bottom: 10px;
+    clear: both
+}
+
+.post-menu {
+    padding-top: 2px
+}
+
+.post-menu>a {
+    padding: 0 1px;
+    color: var(--black-400)
+}
+
+.post-menu>a:hover {
+    color: var(--black-700);
+    text-decoration: none
+}
+
+.post-menu .lsep {
+    margin: 0;
+    padding: 0
+}
+
+.post-menu>*:not(.s-popover) {
+    display: inline-block
+}
+
+.edit-tags-wrapper {
+    padding-right: 40px
+}
+
+.edit-tags-wrapper>a.post-tag {
+    margin-right: 6px
+}
+
+.inline-tag-edit-link {
+    padding: 0 3px 2px;
+    color: var(--black-400)
+}
+
+.inline-tag-edit-link:hover {
+    color: var(--black-700);
+    text-decoration: none
+}
+
+.deleted-post {
+    color: var(--red-400) !important;
+    font-weight: bold !important
+}
+
+.deleted-post:hover {
+    color: var(--white) !important;
+    background-color: var(--red-400) !important
+}
+
+.search-highlight {
+    color: var(--black-750);
+    background-color: var(--yellow-050);
+    font-weight: bold
+}
+
+.page-description {
+    margin: 10px 0
+}
+
+.page-description:not(.s-prose) {
+    font-size: 1.15384615rem;
+    line-height: 18px
+}
+
+.content-page {
+    padding: 20px 0
+}
+
+.content-page h2 {
+    margin-bottom: 10px;
+    font-size: 140%;
+    font-weight: bold
+}
+
+.content-page h3 {
+    margin-bottom: 10px;
+    font-size: 120%;
+    font-weight: bold
+}
+
+.user-info {
+    box-sizing: border-box;
+    padding: 5px 6px 7px 7px;
+    color: var(--black-500)
+}
+
+.user-info:before, .user-info:after {
+    content: "";
+    display: table
+}
+
+.user-info:after {
+    clear: both
+}
+
+.user-info .user-gravatar32 {
+    float: left;
+    width: 32px;
+    height: 32px;
+    border-radius: 1px
+}
+
+.user-info .user-gravatar32 img {
+    border-radius: 1px
+}
+
+.user-info .user-gravatar32+.user-details {
+    margin-left: 8px;
+    width: calc(100% - 40px)
+}
+
+.user-info .user-gravatar48+.user-details {
+    margin-left: 8px;
+    width: calc(100% - 48px)
+}
+
+.user-info .user-gravatar64+.user-details {
+    margin-left: 8px;
+    width: calc(100% - 64px)
+}
+
+.user-info .user-action-time {
+    margin-top: 1px;
+    margin-bottom: 4px;
+    font-size: 12px;
+    white-space: nowrap
+}
+
+.user-info .user-details {
+    float: left;
+    width: 100%
+}
+
+.user-info .-flair {
+    display: block
+}
+
+.user-info-td .user-info {
+    padding: 0
+}
+
+.user-details {
+    line-height: 17px;
+    word-wrap: break-word
+}
+
+.user-details .badgecount {
+    font-weight: 400;
+    font-size: 12px
+}
+
+.user-details td {
+    color: var(--black);
+    padding: 4px 0
+}
+
+.revision td {
+    background-color: var(--black-050)
+}
+
+.owner-revision td {
+    background-color: var(--powder-100)
+}
+
+.revision-comment {
+    color: var(--black-750);
+    padding: 0
+}
+
+.answer-votes {
+    color: var(--black-600);
+    text-align: center;
+    float: left;
+    padding: 3px;
+    min-width: 36px;
+    min-height: 15px;
+    text-decoration: none;
+    border-radius: 2px
+}
+
+#mainbar h2, .mainbar h2, #mainbar h3, .mainbar h3, #mainbar h4, .mainbar h4 {
+    font-weight: 400
+}
+
+.answer-link {
+    float: left;
+    width: 700px;
+    padding-left: 10px;
+    color: var(--black-600)
+}
+
+.answer-summary {
+    padding: 3px;
+    clear: both
+}
+
+.bounty-indicator {
+    float: left;
+    color: var(--white);
+    font-size: 11px;
+    padding: .2em .5em .25em;
+    line-height: 1.3;
+    background-color: var(--blue-600);
+    margin-right: 5px;
+    border-radius: 2px
+}
+
+.bounty-indicator-tab {
+    color: hsl(0, 0%, 100%);
+    display: inline;
+    background-color: var(--blue-600);
+    padding: .2em .5em .25em;
+    margin-right: 5px;
+    font-size: 11px;
+    line-height: 1.3;
+    border-radius: 2px
+}
+
+.bounty p {
+    margin-top: 10px
+}
+
+#bounty-submit {
+    box-shadow: var(--bs-sm);
+    background-color: var(--red-600);
+    border-color: var(--red-300) var(--red-900) var(--red-900) var(--red-300);
+    border-style: solid;
+    border-width: 1px 2px 2px 1px;
+    color: hsl(0, 0%, 100%);
+    font-size: 1.15384615rem;
+    font-weight: bold;
+    margin: 3px;
+    padding: 4px
+}
+
+.history-table {
+    line-height: 180%
+}
+
+.history-table .answer-hyperlink, .history-table .question-hyperlink {
+    font-size: 13px
+}
+
+.history-table span.revision-comment {
+    line-height: 180%
+}
+
+.history-table .comments {
+    border-top: none
+}
+
+.history-table p {
+    margin-bottom: 10px;
+    margin-top: 3px
+}
+
+#noscript-warning {
+    font-family: sans-serif;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 5050;
+    text-align: center;
+    font-weight: bold;
+    font-size: 120%;
+    color: hsl(0, 0%, 100%);
+    background-color: var(--red-600);
+    padding: 5px 0
+}
+
+#noscript-warning a {
+    color: hsl(0, 0%, 100%);
+    text-decoration: underline
+}
+
+.nav ul {
+    margin: 0
+}
+
+.nav ul li {
+    display: inline-block;
+    margin-left: 15px
+}
+
+.nav ul li a {
+    text-decoration: none;
+    display: block
+}
+
+.top-banner-message-container {
+    width: 1264px;
+    margin: 0 auto 14px;
+    padding: 0;
+    box-sizing: content-box;
+    position: relative
+}
+
+.top-banner-message-container .message {
+    width: 100%
+}
+
+#sidebar, .sidebar {
+    float: right;
+    width: 300px;
+    margin: 0 0 15px
+}
+
+#sidebar .badge, .sidebar .badge, #sidebar .badge-tag, .sidebar .badge-tag, #sidebar .moderator-tag, .sidebar .moderator-tag, #sidebar .post-tag, .sidebar .post-tag, #sidebar .required-tag, .sidebar .required-tag {
+    margin-bottom: .5em
+}
+
+#sidebar h4, .sidebar h4 {
+    margin-bottom: 1em
+}
+
+#sidebar.ask-sidebar {
+    width: 365px
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) #sidebar.ask-sidebar {
+        width: 300px
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav #sidebar.ask-sidebar {
+        width: 300px
+    }
+}
+
+@media print {
+    #sidebar.ask-sidebar {
+        width: 300px
+    }
+}
+
+#mainbar, .mainbar {
+    float: left;
+    width: 728px;
+    margin: 0;
+    padding: 0
+}
+
+#mainbar-full, .mainbar-full {
+    width: 100%;
+    padding: 0
+}
+
+#mainbar-full:before, .mainbar-full:before, #mainbar-full:after, .mainbar-full:after {
+    content: "";
+    display: table
+}
+
+#mainbar-full:after, .mainbar-full:after {
+    clear: both
+}
+
+div.form-error {
+    color: var(--red-700);
+    font-weight: bold;
+    font-size: 130%
+}
+
+.subheader {
+    clear: both;
+    margin-bottom: 10px;
+    height: 40px;
+    border-bottom: 1px solid var(--black-075)
+}
+
+body.theme-highcontrast .subheader {
+    border-color: currentColor
+}
+
+.subheader h1, .subheader h2 {
+    float: left;
+    margin-bottom: 0;
+    font-weight: normal
+}
+
+.subheader h1 {
+    color: var(--black-700);
+    font-size: 1.46153846rem;
+    line-height: 2.22
+}
+
+.subheader h2 {
+    color: var(--black-700);
+    font-size: 1.46153846rem
+}
+
+.subheader.tools-rev {
+    margin-bottom: 10px
+}
+
+.subheader a.link {
+    color: var(--theme-link-color)
+}
+
+body.home-page .subheader, body.questions-page .subheader {
+    margin-bottom: 0
+}
+
+.cool, .mini-counts.cool {
+    color: var(--black-350)
+}
+
+.coolbg {
+    background-color: var(--black-350);
+    color: hsl(0, 0%, 100%) !important
+}
+
+.mini-counts.warm, .warm {
+    color: var(--orange-800)
+}
+
+.hot, .mini-counts.hot {
+    color: var(--orange-600)
+}
+
+.hotbg {
+    background-color: var(--orange-600);
+    color: hsl(0, 0%, 100%) !important
+}
+
+.mini-counts.supernova, .supernova {
+    color: var(--orange-400)
+}
+
+.supernovabg {
+    background: var(--orange-400)
+}
+
+.answered, .answered .mini-counts, .answered strong {
+    color: var(--green-500)
+}
+
+.answered strong {
+    font-weight: normal;
+    font-size: 1.61538462rem
+}
+
+.answered-accepted {
+    background-color: var(--green-400)
+}
+
+.answered-accepted, .answered-accepted .mini-counts, .answered-accepted .minicounts span {
+    color: hsl(0, 0%, 100%)
+}
+
+body.theme-highcontrast .answered-accepted, body.theme-highcontrast .answered-accepted .mini-counts, body.theme-highcontrast .answered-accepted .minicounts span {
+    color: var(--white)
+}
+
+.summary {
+    float: left;
+    width: 630px
+}
+
+.summary h3 {
+    font-size: 1.15384615rem;
+    line-height: 1.4;
+    margin-bottom: .5em
+}
+
+.excerpt {
+    padding: 0;
+    padding-bottom: 5px;
+    margin: 0
+}
+
+.excerpt .started {
+    float: right;
+    width: 185px;
+    height: 55px;
+    margin-top: 5px
+}
+
+.excerpt p {
+    margin-bottom: 3px
+}
+
+.excerpt .tags {
+    width: 410px;
+    margin-top: 5px
+}
+
+.tags {
+    line-height: 18px;
+    float: left
+}
+
+.tags a:hover {
+    text-decoration: none
+}
+
+.started {
+    width: 200px;
+    float: right;
+    line-height: 18px
+}
+
+.started img {
+    vertical-align: baseline
+}
+
+.started .user-action-time {
+    margin-bottom: 2px
+}
+
+.started .reputation-score, .started .user-info {
+    color: var(--black-400)
+}
+
+.started .mod-flair, .started a:not(.started-link) {
+    font-size: 12px;
+    color: var(--theme-link-color)
+}
+
+.started .mod-flair:hover, .started a:not(.started-link):hover {
+    color: var(--theme-link-color-hover)
+}
+
+.started-link {
+    font-size: 12px;
+    color: var(--black-350)
+}
+
+.started-link:hover {
+    color: var(--theme-link-color)
+}
+
+.mod-flair {
+    color: var(--theme-link-color);
+    margin-left: 3px;
+    font-weight: bold;
+    font-size: 1.15384615rem;
+    line-height: 1
+}
+
+.module {
+    margin-bottom: 1.5em
+}
+
+.module:not(.s-sidebarwidget) .spacer {
+    margin-bottom: 8px
+}
+
+.module:not(.s-sidebarwidget) ul {
+    margin-left: 15px;
+    list-style-type: square;
+    margin-right: 30px;
+    line-height: 120%
+}
+
+.module:not(.s-sidebarwidget) li {
+    margin-bottom: 4px
+}
+
+.module:not(.s-sidebarwidget) h4 {
+    font-size: 1.15384615rem;
+    color: var(--black-700);
+    font-weight: normal
+}
+
+.newuser {
+    padding: 15px 15px 10px;
+    background-color: #FFF8DC;
+    border: 1px solid #E0DCBF;
+    font-size: 1.15384615rem
+}
+
+.vote {
+    text-align: center
+}
+
+.vote span {
+    display: block;
+    color: var(--black-500)
+}
+
+.s-prose .post-tag {
+    margin-bottom: 0 !important
+}
+
+@media screen {
+    .diffs .spoiler>*, .body-diffs .spoiler>* {
+        opacity: .3
+    }
+
+    .diffs .spoiler>*:hover, .body-diffs .spoiler>*:hover {
+        opacity: 1
+    }
+}
+
+.form-item {
+    padding: 10px 0 15px
+}
+
+.form-item label:not(.s-label) {
+    display: block;
+    font-weight: bold;
+    padding-bottom: 3px
+}
+
+span.feed-icon {
+    display: inline-block;
+    text-decoration: none;
+    vertical-align: middle;
+    background-position: -79px -320px;
+    width: 24px;
+    height: 16px
+}
+
+span.form-error {
+    color: #990000;
+    font-weight: bold;
+    margin-left: 5px;
+    font-size: 90%
+}
+
+.post-editor {
+    margin-top: 10px;
+    width: 660px;
+    box-sizing: border-box
+}
+
+.edit-block {
+    display: none
+}
+
+.page-sizer, .pager {
+    margin: 20px 0
+}
+
+.page-sizer a, .pager a, .page-sizer a:hover, .pager a:hover {
+    text-decoration: none
+}
+
+.leftcol {
+    width: 390px;
+    padding-top: 20px
+}
+
+.rightcol {
+    padding-top: 20px
+}
+
+.system-alert {
+    padding: 10px;
+    font-weight: bold;
+    margin-bottom: 10px;
+    margin-top: 5px;
+    border: 1px dotted #AE0000
+}
+
+#popup-flag-post textarea {
+    width: 590px;
+    max-width: 100%
+}
+
+#start-bounty-popup {
+    width: 500px
+}
+
+#start-bounty-popup textarea {
+    width: 550px;
+    max-width: 100%
+}
+
+.edit-tags {
+    padding: 5px 0 0 15px
+}
+
+.close-reasons input {
+    border: none;
+    cursor: pointer
+}
+
+.close-reasons li {
+    list-style-type: none
+}
+
+.close-reasons li td.close-desc {
+    color: hsl(210, 8%, 45%);
+    padding-top: 2px;
+    padding-bottom: 8px;
+    line-height: 130%
+}
+
+.close-reasons tr td:last-child {
+    cursor: pointer;
+    padding-left: .5em
+}
+
+.close-reasons span.close-reason {
+    font-weight: bold
+}
+
+.item-multiplier-count {
+    font-size: 11px;
+    color: var(--black-500)
+}
+
+span.diff-delete {
+    text-decoration: line-through;
+    color: var(--red-700);
+    background-color: var(--red-200)
+}
+
+img.diff-delete {
+    border: 2px solid var(--red-500);
+    opacity: .5
+}
+
+span.diff-add {
+    background: var(--green-100);
+    color: var(--green-800)
+}
+
+img.diff-add {
+    border: 2px solid var(--green-500)
+}
+
+img.sponsor-tag-img {
+    border: none;
+    opacity: 1;
+    width: 18px;
+    height: 16px;
+    vertical-align: top;
+    padding-right: 4px;
+    margin-top: -2px;
+    box-sizing: content-box !important
+}
+
+.tagged-ignored {
+    opacity: .35;
+    background: transparent
+}
+
+.tagged-ignored-hidden {
+    display: none !important
+}
+
+.tagged-interesting {
+    background-color: var(--yellow-050)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .tagged-interesting {
+        background-color: var(--black-025)
+    }
+}
+
+body.theme-dark .tagged-interesting, .theme-dark__forced .tagged-interesting {
+    background-color: var(--black-025)
+}
+
+.s-post-summary__watched {
+    background-color: var(--yellow-050)
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .s-post-summary__watched {
+        background-color: var(--black-025)
+    }
+}
+
+body.theme-dark .s-post-summary__watched, .theme-dark__forced .s-post-summary__watched {
+    background-color: var(--black-025)
+}
+
+#interestingTag {
+    font-size: 12px;
+    margin-right: 5px
+}
+
+#ignoredTag {
+    font-size: 12px;
+    margin-right: 5px
+}
+
+.everyoneloves__top-leaderboard, .everyoneloves__mid-leaderboard, .everyoneloves__mid-second-leaderboard, .everyoneloves__bot-mid-leaderboard, .everyoneloves__tag-sponsorship {
+    width: 728px
+}
+
+.everyoneloves__inline-sidebar {
+    display: none
+}
+
+.zone-container-responsive {
+    display: none
+}
+
+.welovestackoverflow {
+    padding: 10px;
+    line-height: 1.3;
+    overflow: hidden;
+    margin-bottom: 8px;
+    border: 2px solid var(--black-075)
+}
+
+.welovestackoverflow a {
+    color: var(--theme-link-color)
+}
+
+.tagged {
+    margin-top: 5px
+}
+
+.related {
+    line-height: 1.3;
+    font-size: 12px
+}
+
+.related a {
+    font-size: 12px;
+    font-weight: normal
+}
+
+.linked {
+    line-height: 1.3;
+    font-size: 12px
+}
+
+.linked a {
+    font-size: 12px;
+    font-weight: normal
+}
+
+.cbt {
+    clear: both
+}
+
+.space {
+    padding-top: 20px
+}
+
+.label-key {
+    color: var(--black-350);
+    font-size: 1.15384615rem
+}
+
+.label-key b, .label-key strong {
+    color: var(--black-700);
+    font-weight: normal
+}
+
+.bottom-notice {
+    margin-top: 15px;
+    padding-top: 10px;
+    font-weight: normal;
+    padding: 0 10px 0 0;
+    line-height: 1.4;
+    font-size: 1.30769231rem
+}
+
+#question-mini-list {
+    overflow: auto;
+    margin-bottom: 30px
+}
+
+.tag-col {
+    width: 184px
+}
+
+.accept-reminder {
+    clear: both;
+    text-align: center;
+    margin: 0 0 8px;
+    color: maroon
+}
+
+.pager-answers {
+    padding-top: 10px;
+    overflow: hidden;
+    clear: both
+}
+
+.ac_results {
+    padding: 0;
+    border: 1px solid var(--black-500);
+    background-color: var(--white);
+    overflow: hidden;
+    z-index: 10000;
+    text-align: left
+}
+
+.ac_results ul {
+    width: 100%;
+    list-style-position: outside;
+    list-style: none;
+    padding: 0;
+    margin: 0
+}
+
+.ac_results li {
+    margin: 0;
+    padding: 2px 5px;
+    cursor: default;
+    display: block;
+    line-height: 16px;
+    overflow: hidden
+}
+
+.ac_highlight {
+    font-weight: bold;
+    text-decoration: underline
+}
+
+.ac_loading {
+    background: hsl(0, 0%, 100%) url('https://cdn.sstatic.net/Img/progress-dots.gif?v=679ddd617b7d') right center no-repeat
+}
+
+.ac_over {
+    color: hsl(0, 0%, 100%);
+    background-color: var(--theme-primary-color)
+}
+
+@media print {
+    * {
+        position: relative
+    }
+
+    .site-footer, #header, #hlinks, #nav, #sidebar, #tabs, #feed-link, .bounty-link, .comments-link, .notify, .post-comments, .post-menu, .s-topbar, .tabs, div.vote, form, h2.bottom-notice, td.votecell {
+        display: none
+    }
+
+    .container, body {
+        font-size: 10pt !important;
+        overflow: visible !important;
+        overflow-y: visible !important;
+        height: auto
+    }
+
+    .container {
+        width: 710px
+    }
+
+    #answers, #content, #mainbar, #question-header, .container, .s-prose, .question {
+        float: none !important;
+        width: 100%;
+        overflow: visible !important
+    }
+
+    pre {
+        max-height: none;
+        display: block;
+        width: 600px;
+        height: auto;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        clear: both
+    }
+
+    code, pre {
+        font-size: 9pt !important
+    }
+
+    #answers-header {
+        clear: both;
+        page-break-after: avoid
+    }
+
+    .comments {
+        font-size: 9pt;
+        width: 650px
+    }
+
+    #mainbar {
+        margin: 0
+    }
+
+    .s-prose {
+        width: 90%
+    }
+
+    #content {
+        width: auto;
+        height: 100%;
+        overflow: auto;
+        overflow-x: auto;
+        overflow-y: auto;
+        border: none
+    }
+
+    .answer {
+        width: 700px;
+        overflow-y: auto
+    }
+}
+
+.comment-up-off, .comment-flag-off {
+    color: var(--black-300);
+    opacity: .4;
+    cursor: pointer
+}
+
+.comment-up-off:hover, .comment-up-on {
+    color: var(--theme-primary-color);
+    cursor: pointer;
+    opacity: 1
+}
+
+.comment-flag-on, .comment-flag:hover, .flag-on {
+    color: var(--red-500)
+}
+
+.delete-tag {
+    width: 14px;
+    height: 14px;
+    vertical-align: middle;
+    display: inline-block;
+    background-position: -40px -319px;
+    cursor: pointer;
+    margin-left: 3px;
+    margin-top: -2px;
+    margin-bottom: -1px
+}
+
+.delete-tag-active, .delete-tag:hover {
+    background-position: -40px -340px
+}
+
+.badge-earned-check {
+    width: 20px;
+    display: inline-block;
+    background-position: -20px -322px;
+    height: 10px;
+    position: relative;
+    top: 1px
+}
+
+.vote-accepted-bounty, .vote-accepted-off, .vote-accepted-on {
+    display: block;
+    margin: 0 auto
+}
+
+.expander-arrow-hide {
+    display: inline-block;
+    width: 20px;
+    height: 15px;
+    background-position: 0 -380px
+}
+
+.expander-arrow-show {
+    display: inline-block;
+    width: 20px;
+    height: 15px;
+    background-position: -20px -380px
+}
+
+.expander-arrow-small-hide {
+    display: inline-block;
+    width: 8px;
+    height: 13px;
+    background-position: 0 -380px
+}
+
+.expander-arrow-small-show {
+    display: inline-block;
+    width: 13px;
+    height: 8px;
+    background-position: -20px -383px
+}
+
+.anonymous-gravatar {
+    display: inline-block;
+    width: 32px;
+    height: 32px;
+    background-position: 0 -400px
+}
+
+.vcard {
+    margin-top: 10px
+}
+
+.mod-flag-indicator {
+    color: hsl(0, 0%, 100%);
+    display: inline;
+    padding: .2em .5em .25em !important;
+    margin-right: 5px;
+    font-size: 11px;
+    line-height: 1;
+    border-radius: 2px
+}
+
+.tag-popup {
+    width: 390px;
+    padding: 12px
+}
+
+.tag-popup .-container {
+    position: relative;
+    background-color: var(--white);
+    border: 1px solid var(--black-200);
+    border-radius: 5px;
+    padding: 16px;
+    font-size: 13px;
+    box-shadow: var(--bs-md)
+}
+
+.tag-popup .-arrow {
+    position: absolute;
+    display: none;
+    left: 50%
+}
+
+.tag-popup .-arrow:before {
+    position: absolute;
+    content: '';
+    background: var(--white);
+    border: 1px solid var(--black-200);
+    border-bottom: none;
+    border-right: none;
+    top: -6px;
+    left: -6px;
+    width: 12px;
+    height: 12px
+}
+
+.tag-popup .-arrow.-top {
+    display: block;
+    transform: rotate(45deg);
+    top: -1px
+}
+
+.tag-popup .-arrow.-bottom {
+    display: block;
+    transform: rotate(225deg);
+    bottom: -1px
+}
+
+body.theme-dark .tag-popup .-container {
+    background-color: var(--black-075);
+    border-color: transparent;
+    box-shadow: var(--bs-lg)
+}
+
+body.theme-dark .tag-popup .-arrow:before {
+    background: var(--black-075);
+    border-color: transparent
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .tag-popup .-container {
+        background-color: var(--black-075);
+        border-color: transparent;
+        box-shadow: var(--bs-lg)
+    }
+
+    body.theme-system .tag-popup .-arrow:before {
+        background: var(--black-075);
+        border-color: transparent
+    }
+}
+
+#user-menu {
+    border-radius: 2px;
+    border: 1px solid var(--black-800);
+    background-color: var(--black-600);
+    color: var(--black-075);
+    text-align: left;
+    padding: 10px;
+    box-shadow: var(--bs-sm);
+    font-family: var(--ff-sans);
+    z-index: 320;
+    position: relative;
+    width: 300px;
+    font-size: 11px;
+    line-height: 1.2
+}
+
+#user-menu .um-gravatar {
+    float: left;
+    margin-right: .8em;
+    margin-bottom: .75em
+}
+
+#user-menu .um-header-info .mod-flair, #user-menu .um-header-info .um-user-link {
+    font-size: 1.46153846rem;
+    color: var(--black-075) !important
+}
+
+#user-menu .um-header-info .um-flair .badgecount, #user-menu .um-header-info .um-flair .reputation-score {
+    color: var(--black-075)
+}
+
+#user-menu .um-about-me {
+    clear: both;
+    font-size: 11px;
+    margin: 5px 0;
+    overflow: hidden
+}
+
+#user-menu .um-links a {
+    margin-right: 8px;
+    font-size: 11px
+}
+
+#user-menu a, #user-menu a:visited {
+    color: var(--powder-300);
+    text-decoration: none
+}
+
+#user-menu a:hover {
+    color: var(--powder-100)
+}
+
+.ask-mainbar, #mainbar.ask-mainbar {
+    width: 665px
+}
+
+.ask-mainbar #excerpt, #mainbar.ask-mainbar #excerpt {
+    box-sizing: border-box
+}
+
+td.answercell {
+    vertical-align: top
+}
+
+.nowrap {
+    white-space: nowrap
+}
+
+code {
+    white-space: pre-wrap;
+    padding: 1px 5px
+}
+
+pre code {
+    white-space: inherit;
+    padding: 0
+}
+
+.user-timeline-deleted-action {
+    display: block;
+    color: hsl(210, 8%, 45%);
+    font-size: 11px
+}
+
+.expandable-question-summary {
+    float: none
+}
+
+.expandable-question-summary:not(.is-expanded) {
+    position: relative
+}
+
+.expandable-question-summary:not(.is-expanded) .expandable-question-summary__body {
+    height: 100px;
+    overflow: hidden;
+    position: relative
+}
+
+.expandable-question-summary:not(.is-expanded) .expandable-question-summary__body:after {
+    content: "";
+    display: block;
+    position: absolute;
+    height: 50%;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+    background: -webkit-linear-gradient(hsla(0, 0%, 100%, 0), hsl(0, 0%, 100%)) left repeat;
+    background: linear-gradient(hsla(0, 0%, 100%, 0), hsl(0, 0%, 100%)) left repeat
+}
+
+.tag-sponsorship {
+    height: 135px;
+    overflow: hidden;
+    width: 100%;
+    padding-bottom: 5px
+}
+
+.disabled-link {
+    color: hsl(210, 8%, 55%);
+    opacity: .6;
+    padding: 0 3px 2px
+}
+
+.disabled-button {
+    opacity: .6;
+    cursor: default !important
+}
+
+.show-votes .sidebar-linked .spacer, .show-votes .sidebar-related .spacer {
+    margin-bottom: 12px;
+    display: flex
+}
+
+.show-votes .sidebar-linked .spacer>a:first-child, .show-votes .sidebar-related .spacer>a:first-child {
+    padding-right: 10px
+}
+
+.show-votes .sidebar-linked .spacer>a:first-child .answer-votes, .show-votes .sidebar-related .spacer>a:first-child .answer-votes {
+    padding: 3px 0;
+    white-space: nowrap;
+    width: 38px;
+    text-align: center;
+    box-sizing: border-box;
+    height: auto;
+    float: none;
+    border-radius: 2px;
+    font-size: 90%;
+    background-color: var(--black-050);
+    color: var(--black-700);
+    transform: translateY(-1px)
+}
+
+.show-votes .sidebar-linked .spacer>a:first-child .answer-votes.answered-accepted, .show-votes .sidebar-related .spacer>a:first-child .answer-votes.answered-accepted {
+    color: hsl(0, 0%, 100%);
+    background-color: var(--green-400)
+}
+
+body.theme-highcontrast .show-votes .sidebar-linked .spacer>a:first-child .answer-votes.answered-accepted, body.theme-highcontrast .show-votes .sidebar-related .spacer>a:first-child .answer-votes.answered-accepted {
+    color: var(--white)
+}
+
+.show-votes .sidebar-linked .spacer>a:first-child .answer-votes.extra-large, .show-votes .sidebar-related .spacer>a:first-child .answer-votes.extra-large, .show-votes .sidebar-linked .spacer>a:first-child .answer-votes.large, .show-votes .sidebar-related .spacer>a:first-child .answer-votes.large {
+    padding: 3px 0;
+    min-width: 16px
+}
+
+.show-votes .sidebar-linked .spacer>a.question-hyperlink, .show-votes .sidebar-related .spacer>a.question-hyperlink {
+    display: inline-block;
+    padding-top: 2px;
+    width: calc(100% - 48px);
+    margin-bottom: 0
+}
+
+.comments .deleted-comment, .comments .deleted-comment:hover {
+    background-color: var(--red-050)
+}
+
+.comments .deleted-comment .deleted-comment-info {
+    color: #B65454;
+    display: block;
+    text-align: right
+}
+
+.comments .deleted-comment .deleted-comment-info a {
+    text-decoration: none;
+    border-bottom: 0
+}
+
+.highlighted-post {
+    animation: highlighted-post-fade 3s;
+    animation-timing-function: ease-out
+}
+
+@keyframes highlighted-post-fade {
+    0% {
+        background-color: var(--yellow-100)
+    }
+
+    100% {
+        background-color: rgba(0, 0, 0, 0)
+    }
+}
+
+.deleted-answer {
+    margin-left: -24px;
+    padding-left: 24px;
+    margin-top: -1px;
+    width: auto !important;
+    background-color: var(--red-050);
+    border-top: 1px solid var(--red-100)
+}
+
+.deleted-answer pre, .deleted-answer pre code {
+    background-color: inherit
+}
+
+.deleted-answer .hidden-deleted-answer a, .deleted-answer .hidden-deleted-question a {
+    font-weight: bold;
+    text-decoration: underline
+}
+
+.deleted-answer .comments .comment:hover {
+    background-color: var(--red-050)
+}
+
+.deleted-answer .comments .deleted-comment, .deleted-answer .comments .deleted-comment:hover {
+    background-color: var(--red-050)
+}
+
+.deleted-answer .comments .deleted-comment .undelete-comment, .deleted-answer .comments .deleted-comment:hover .undelete-comment {
+    display: none
+}
+
+.deleted-answer-info {
+    color: #B65454;
+    margin-top: 10px;
+    margin-left: 3px
+}
+
+.comment-date, .comment-date>a, .comment-date>a:hover {
+    border-bottom: none;
+    color: var(--black-350)
+}
+
+.existing-flag-count:before {
+    content: '('
+}
+
+.existing-flag-count:after {
+    content: ')'
+}
+
+.popup-submit {
+    float: right
+}
+
+.popup-cancel {
+    float: left
+}
+
+.popup-close {
+    float: right
+}
+
+.popup-close a {
+    padding: 3px 6px 2px;
+    font-size: 1.30769231rem;
+    font-weight: normal;
+    color: hsl(0, 0%, 100%) !important;
+    background-color: hsl(210, 8%, 5%);
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: 1
+}
+
+.popup-close a:hover {
+    text-decoration: none
+}
+
+#popup-close-question {
+    width: 800px
+}
+
+#popup-close-question #close-question-form {
+    overflow: hidden
+}
+
+#popup-close-question #close-question-form.close-question-voted label span {
+    cursor: default !important
+}
+
+#popup-close-question #close-question-form.close-question-voted input[type=submit] {
+    visibility: hidden
+}
+
+#popup-close-question .action-list>li {
+    width: auto
+}
+
+#popup-close-question .popup-pane, #popup-close-question .popup-subpane {
+    min-height: 430px
+}
+
+#popup-close-question .bounty-indicator-tab {
+    margin-left: 3px
+}
+
+#popup-close-question .popup-actions {
+    text-align: right;
+    margin-bottom: 2px
+}
+
+#popup-close-question .popup-actions .last-flag-details {
+    display: inline-block;
+    line-height: 17px;
+    text-align: left
+}
+
+#popup-close-question .popup-actions .popup-submit {
+    float: none
+}
+
+.close-as-duplicate-pane .search-prompt {
+    font-weight: bold
+}
+
+.close-as-duplicate-pane .search-errors {
+    color: var(--red-800);
+    text-align: left;
+    font-weight: bold;
+    font-size: 13px;
+    height: 13px;
+    margin: 4px 0
+}
+
+.close-as-duplicate-pane .original-display {
+    margin: 13px 0
+}
+
+.close-as-duplicate-pane .original-display .navi-container {
+    font-weight: bold;
+    color: var(--black-750);
+    margin-bottom: 7px
+}
+
+.close-as-duplicate-pane .original-display .navi-container .navi {
+    display: inline-block;
+    margin-right: 5px
+}
+
+.close-as-duplicate-pane .original-display .preview {
+    height: 310px;
+    overflow-y: auto;
+    border: 1px solid var(--black-300);
+    padding: 7px 0
+}
+
+.close-as-duplicate-pane .original-display .preview .show-original .show-title {
+    font-size: 1.30769231rem;
+    margin: 3px 0 10px
+}
+
+.close-as-duplicate-pane .original-display .preview .show-original .answer-count {
+    font-size: 1.15384615rem;
+    font-weight: bold;
+    border-bottom: 1px solid var(--black-300);
+    padding: 5px;
+    margin: 0 3px 0 5px
+}
+
+.close-as-duplicate-pane .original-display .preview .show-original .answer {
+    border-bottom-color: var(--black-150)
+}
+
+.close-as-duplicate-pane .original-display .list-originals {
+    height: 310px;
+    overflow-y: auto;
+    border: 1px solid var(--black-300);
+    padding: 7px 0
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list {
+    padding: 0 8px
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item {
+    float: left;
+    padding: 9px 5px 9px 0;
+    border-bottom: 1px solid var(--black-100);
+    cursor: pointer
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item:last-child {
+    border-bottom: 0
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item .stats {
+    float: left;
+    margin: 0 10px 0 0;
+    padding: 4px 7px 6px;
+    width: 58px
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item .summary {
+    width: 605px;
+    float: left
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item .post-link {
+    font-weight: bold;
+    font-size: 1.15384615rem;
+    margin-bottom: 5px
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item .post-link a:hover {
+    text-decoration: none !important;
+    border-bottom: 0
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item .bounty-indicator-tab {
+    margin-left: 3px
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item .post-type-abbr {
+    font-weight: bold
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item .votes-and-usages {
+    color: var(--black-350)
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item .body-summary {
+    line-height: 15px;
+    color: var(--black-750)
+}
+
+.close-as-duplicate-pane .original-display .list-originals .list .item.hover {
+    background-color: var(--black-075)
+}
+
+.migration-pane .migration-targets td {
+    vertical-align: middle
+}
+
+.migration-pane .migration-targets .target-icon {
+    min-width: 58px;
+    min-height: 58px
+}
+
+.migration-pane .migration-targets .target-icon img {
+    width: 58px;
+    height: 58px
+}
+
+.popup-tab-content {
+    clear: both
+}
+
+.action-list:not(.popup-condensed) {
+    margin-left: 5px !important;
+    margin-right: 5px;
+    margin-bottom: 10px !important
+}
+
+.action-list:not(.popup-condensed)>li {
+    width: 650px;
+    max-width: 100%
+}
+
+.action-list:not(.popup-condensed) li {
+    list-style-type: none;
+    padding: 6px
+}
+
+.action-list:not(.popup-condensed) li>label {
+    display: block;
+    margin: 5px 0
+}
+
+.popup._hidden-descriptions .action-list:not(.popup-condensed) li>label {
+    margin: 0
+}
+
+.action-list:not(.popup-condensed) input[type=radio] {
+    margin-right: 1px;
+    margin-top: 1px
+}
+
+.action-list:not(.popup-condensed) .action-desc, .action-list:not(.popup-condensed) .action-name {
+    cursor: pointer;
+    margin-left: 5px
+}
+
+.action-list:not(.popup-condensed) .action-disabled-reason-muted {
+    color: var(--black-500);
+    margin-left: 18px
+}
+
+.action-list:not(.popup-condensed) .action-name {
+    font-weight: bold;
+    font-size: 105%;
+    vertical-align: top
+}
+
+.action-list:not(.popup-condensed) .action-desc {
+    display: block;
+    color: var(--black-500);
+    line-height: 115%;
+    padding: 0 0 0 18px;
+    margin-top: -17px
+}
+
+.action-list:not(.popup-condensed) .action-desc p:last-child {
+    margin-bottom: 0
+}
+
+.action-list:not(.popup-condensed) .action-subform p:last-child {
+    margin-bottom: 1em
+}
+
+.action-list:not(.popup-condensed) .action-name~.action-desc {
+    padding-top: 23px
+}
+
+.action-list:not(.popup-condensed) .action-disabled span {
+    color: var(--black-350);
+    font-weight: normal;
+    cursor: default !important
+}
+
+.action-list:not(.popup-condensed) .action-selected {
+    background-color: var(--black-075)
+}
+
+.action-list:not(.popup-condensed) .action-subform {
+    display: none;
+    margin: 15px auto;
+    width: 535px;
+    max-width: 100%
+}
+
+.action-list:not(.popup-condensed) .action-subform .wide {
+    width: 400px
+}
+
+.action-list:not(.popup-condensed) h4 {
+    margin-bottom: 5px
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .responsively-horizontally-centered-legacy-popup {
+        width: 800px;
+        max-width: 90vw !important;
+        left: 0 !important;
+        right: 0 !important;
+        margin: 0 auto
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .responsively-horizontally-centered-legacy-popup {
+        width: 800px;
+        max-width: 90vw !important;
+        left: 0 !important;
+        right: 0 !important;
+        margin: 0 auto
+    }
+}
+
+@media print {
+    .responsively-horizontally-centered-legacy-popup {
+        width: 800px;
+        max-width: 90vw !important;
+        left: 0 !important;
+        right: 0 !important;
+        margin: 0 auto
+    }
+}
+
+#tags-table .answer-votes {
+    margin-right: 5px;
+    width: 25px;
+    margin-top: 2px;
+    display: inline-block;
+    float: none
+}
+
+#tags-browser {
+    width: 100%
+}
+
+#overlay-header {
+    opacity: 0;
+    display: none;
+    background: var(--black-050);
+    font-size: 1.30769231rem;
+    font-weight: normal;
+    text-align: center;
+    left: 0;
+    padding: .5em 10%;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 5052;
+    box-shadow: var(--bs-sm)
+}
+
+#overlay-header .close-overlay {
+    color: var(--black-350);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: normal
+}
+
+.mod-post-actions {
+    padding: 2px;
+    line-height: 20px
+}
+
+.bounty-indicator-tab.flagbg {
+    background-color: red !important
+}
+
+.answer-votes {
+    cursor: pointer
+}
+
+.answer-votes.large {
+    font-size: 90%;
+    padding-top: 4px;
+    padding-bottom: 2px
+}
+
+.answer-votes.extra-large {
+    font-size: 90%;
+    padding-top: 4px;
+    padding-bottom: 2px;
+    min-width: 32px
+}
+
+.quality-score {
+    font-size: 80%;
+    margin-right: 10px
+}
+
+.revision-comment.blur {
+    color: hsl(210, 8%, 60%)
+}
+
+.revision-comment {
+    line-height: 20px
+}
+
+.full-diff {
+    table-layout: fixed;
+    width: 100%
+}
+
+.full-diff .content {
+    font-family: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Liberation Mono", Menlo, Monaco, Consolas, monospace;
+    font-size: 12px
+}
+
+.full-diff td {
+    vertical-align: top;
+    margin-right: 5px;
+    border-left: 4px solid var(--white);
+    border-right: 4px solid var(--white)
+}
+
+.full-diff td.content {
+    width: 50%;
+    max-width: 50%;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    color: var(--black-350)
+}
+
+.full-diff .deleted>div {
+    background-color: var(--red-050)
+}
+
+.full-diff .inserted>div {
+    background-color: var(--green-025)
+}
+
+.full-diff td.content.deleted, .full-diff td.content.inserted {
+    background-color: transparent;
+    color: inherit
+}
+
+.full-diff .skip {
+    text-align: center;
+    padding: 10px;
+    background-color: var(--black-050);
+    color: var(--black-300);
+    border-top: 4px solid var(--white);
+    border-bottom: 4px solid var(--white)
+}
+
+.suggested-edit {
+    width: 960px
+}
+
+.suggested-edit .summary {
+    width: 910px
+}
+
+.suggested-edit .score {
+    display: block;
+    background: hsl(210, 8%, 95%);
+    padding: 8px 8px 6px;
+    color: hsl(210, 8%, 35%);
+    font-size: 120%;
+    font-weight: bold;
+    margin-bottom: 30px;
+    text-decoration: none;
+    text-align: center;
+    width: 15px
+}
+
+.suggested-edit .revision {
+    display: block;
+    margin-bottom: 8px
+}
+
+.suggested-edit .revision-comment {
+    padding-right: 8px
+}
+
+.suggested-edit .body-diffs {
+    margin-top: 18px
+}
+
+.suggested-edit .body-diffs td {
+    vertical-align: top
+}
+
+.suggested-edit .body-diffs table {
+    table-layout: fixed;
+    width: 900px
+}
+
+.suggested-edit .body-diffs .full-diff {
+    width: 900px
+}
+
+.suggested-edit .body-diffs .full-diff td.content {
+    width: 435px;
+    max-width: 435px
+}
+
+.suggested-edit .body-diffs .full-html-diff .s-prose {
+    width: 435px;
+    max-width: 435px
+}
+
+.suggested-edit .body-diffs .full-html-diff .s-prose img {
+    max-width: 430px
+}
+
+.suggested-edit .body-diffs .full-html-diff .gutter {
+    width: 30px;
+    max-width: 30px
+}
+
+.suggested-edit .body-diffs .full-html-diff th {
+    color: var(--black-350);
+    padding: 6px 0 4px
+}
+
+.suggested-edit .user-info-actions {
+    width: 900px
+}
+
+.suggested-edit .user-info-actions .started {
+    float: none !important
+}
+
+.suggested-edit .user-info-actions .current-owner {
+    width: 445px
+}
+
+.suggested-edit .user-info-actions .gutter {
+    width: 7px
+}
+
+.suggested-edit .user-info-actions .actions {
+    text-align: right
+}
+
+.suggested-edit .user-info-actions .form-error {
+    padding: 15px 0 5px;
+    display: none
+}
+
+.lightbox {
+    display: none;
+    background: hsl(210, 8%, 5%);
+    opacity: .7;
+    filter: alpha(opacity=70);
+    position: absolute;
+    top: 0;
+    left: 0;
+    min-width: 100%;
+    z-index: 8950
+}
+
+.lightbox-panel {
+    display: none;
+    z-index: 1001;
+    border: 0 !important
+}
+
+.comment-help code {
+    background-color: var(--powder-300) !important
+}
+
+div.form-field-error.form-error {
+    font-size: 12px;
+    display: block;
+    margin-top: -15px
+}
+
+#hot-network-questions h4 a {
+    font-weight: inherit;
+    font-size: inherit;
+    width: inherit
+}
+
+#hot-network-questions ul {
+    margin: 0
+}
+
+#hot-network-questions li {
+    list-style-type: none;
+    white-space: nowrap;
+    margin-bottom: 10px;
+    margin-left: 0
+}
+
+#hot-network-questions .favicon, #hot-network-questions a, #hot-network-questions img {
+    display: inline-block;
+    vertical-align: top
+}
+
+#hot-network-questions .favicon, #hot-network-questions img {
+    margin: 2px 6px 0 0
+}
+
+#hot-network-questions a {
+    font-weight: normal;
+    font-size: 12px;
+    white-space: normal;
+    width: 90%
+}
+
+#hot-network-questions .show-more {
+    margin-left: 22px
+}
+
+.questions-page .show-more, .tagged-questions-page .show-more, .tags-page .show-more {
+    display: block;
+    margin: 5px 0
+}
+
+.more-arrow {
+    display: block;
+    margin-top: 5px
+}
+
+.tag-editor {
+    cursor: text;
+    background-color: var(--white);
+    position: relative;
+    overflow: hidden;
+    white-space: normal;
+    height: auto !important;
+    min-height: 37px !important;
+    padding-top: 2px !important;
+    padding-bottom: 2px !important
+}
+
+.tag-editor .rendered-element {
+    margin: 2px;
+    font-size: 12px
+}
+
+.tag-editor input {
+    border: none !important;
+    box-shadow: none !important;
+    outline: 0 !important;
+    padding: 0 !important;
+    margin: 0 3px;
+    background-color: transparent !important;
+    height: 25px
+}
+
+.tag-editor input[type="text"] {
+    margin: 0;
+    height: 29px;
+    box-sizing: content-box
+}
+
+.tag-editor input[type="text"]:not([placeholder=""]) {
+    min-width: 100%
+}
+
+.tag-editor:not(.s-input) {
+    border: 1px solid var(--black-150)
+}
+
+.tag-editor:not(.s-input) span:not(:empty)+input {
+    padding-left: 4px !important
+}
+
+.tag-editor:not(.s-input) input[type="text"]:not([placeholder=""]) {
+    font-size: 13px
+}
+
+.tag-editor.s-input {
+    padding-left: 2px !important
+}
+
+.tag-editor.s-input input {
+    padding-left: calc(.7em - 2px) !important
+}
+
+.tag-editor.s-input span:not(:empty)+input {
+    padding-left: 4px !important
+}
+
+#tagnames {
+    width: 100%
+}
+
+.tag-suggestions {
+    background-color: var(--white);
+    border: 1px solid var(--black-150);
+    padding: 4px;
+    z-index: 300;
+    border-radius: 5px;
+    box-shadow: var(--bs-md);
+    display: flex;
+    flex-wrap: wrap
+}
+
+.tag-suggestions>div {
+    padding: 8px;
+    width: 200px;
+    overflow: hidden;
+    position: relative;
+    border-radius: 3px;
+    cursor: pointer
+}
+
+.tag-suggestions>div:focus {
+    background-color: var(--black-075)
+}
+
+.tag-suggestions>div:focus .more-info {
+    background-color: var(--black-075)
+}
+
+.tag-suggestions>div:hover {
+    background-color: var(--black-050)
+}
+
+.tag-suggestions>div:hover .more-info {
+    background-color: var(--black-050)
+}
+
+.tag-suggestions>div p {
+    font-size: 11px;
+    line-height: 1.15384615
+}
+
+.tag-suggestions>div p.more-info {
+    visibility: hidden;
+    position: absolute;
+    margin-bottom: 0;
+    right: 5px;
+    top: 7px;
+    padding: 3px
+}
+
+.tag-suggestions>div p.more-info a {
+    text-indent: -9999em;
+    width: 16px;
+    height: 16px;
+    border: 1px solid hsl(210, 8%, 55%);
+    box-sizing: border-box;
+    border-radius: 50%;
+    display: inline-block;
+    position: relative;
+    transition: none
+}
+
+.tag-suggestions>div p.more-info a:after, .tag-suggestions>div p.more-info a:before {
+    content: '';
+    width: 2px;
+    height: 2px;
+    position: absolute;
+    left: 6px;
+    top: 3px;
+    display: inline-block;
+    background-color: hsl(210, 8%, 55%)
+}
+
+.tag-suggestions>div p.more-info a:after {
+    top: 6px;
+    height: 5px
+}
+
+.tag-suggestions>div p.more-info a:hover {
+    border-color: var(--theme-link-color)
+}
+
+.tag-suggestions>div p.more-info a:hover:after, .tag-suggestions>div p.more-info a:hover:before {
+    background-color: var(--theme-link-color)
+}
+
+.tag-suggestions>div:focus p.more-info, .tag-suggestions>div:hover p.more-info {
+    visibility: visible
+}
+
+.tag-suggestions .match {
+    font-weight: bold;
+    text-decoration: underline
+}
+
+.search-prompt {
+    padding-right: 3px
+}
+
+.tools-rev-dim-link {
+    color: hsl(210, 8%, 65%) !important
+}
+
+.tools-rev h1 .lsep {
+    color: hsl(210, 8%, 85%);
+    visibility: visible;
+    font-size: 100%;
+    margin-left: 5px;
+    margin-right: 5px
+}
+
+.diff-skipped>div {
+    border-bottom: 2px dotted #d0d0d0
+}
+
+.diff-skipped {
+    padding: 4px 0 8px;
+    cursor: pointer
+}
+
+a.bounty-link {
+    padding: 0 3px 2px
+}
+
+.comment-form form {
+    position: relative
+}
+
+#tabcomplete {
+    position: absolute;
+    top: -17px;
+    margin-left: 5px
+}
+
+#tabcomplete li {
+    display: inline;
+    background-color: hsl(0, 0%, 100%);
+    color: hsl(210, 8%, 5%);
+    padding: 2px;
+    margin-right: 5px;
+    border: 1px solid hsl(210, 8%, 55%);
+    cursor: pointer
+}
+
+#tabcomplete li.chosen {
+    font-weight: bold
+}
+
+.comments {
+    -webkit-tap-highlight-color: hsla(0, 0%, 100%, 0)
+}
+
+span.highlight {
+    background-color: #FFFF77
+}
+
+textarea {
+    resize: none
+}
+
+.new-post-activity, .new-answer-activity {
+    background-color: var(--black-050)
+}
+
+.post-section-title {
+    font-weight: bold;
+    font-size: 120%
+}
+
+.similar-questions {
+    height: 200px
+}
+
+.title-search-float {
+    border: 1px solid hsl(210, 8%, 5%);
+    z-index: 99;
+    background: hsl(0, 0%, 100%)
+}
+
+.title-search-container {
+    max-height: 150px;
+    overflow-y: scroll;
+    overflow-x: hidden
+}
+
+.title-float-selected {
+    background-color: #00FFFF;
+    height: 24px
+}
+
+.title-loading {
+    background-image: url("https://cdn.sstatic.net/Img/progress-dots.gif?v=679ddd617b7d");
+    background-repeat: no-repeat;
+    background-position: center right
+}
+
+#show-editor-button {
+    margin-bottom: 8px
+}
+
+.ask-page .privacy-policy-agreement, .question-page .privacy-policy-agreement {
+    margin-top: 15px
+}
+
+.newsletter-popup .privacy-policy-agreement {
+    margin-top: 15px;
+    font-size: 90%
+}
+
+.privacy-policy-agreement {
+    font-style: italic
+}
+
+body.read-only .login-link {
+    opacity: .3
+}
+
+body.read-only #question-header .btn, body.read-only #questions-count .btn, body.read-only .askquestion {
+    opacity: .3
+}
+
+body.read-only .bookmark-off, body.read-only .vote-down-off, body.read-only .vote-up-off {
+    opacity: .3;
+    cursor: not-allowed
+}
+
+.review-post-author-guidance {
+    background: var(--black-050);
+    border: var(--black-075);
+    padding: 10px
+}
+
+.review-post-author-guidance p:last-child {
+    margin-bottom: 0
+}
+
+.facebook-login, .facebook-login:hover {
+    color: hsl(0, 0%, 100%);
+    background-color: #395697
+}
+
+.auth-shadow {
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.05), 0 20px 48px rgba(0, 0, 0, 0.05), 0 1px 4px rgba(0, 0, 0, 0.1)
+}
+
+.module {
+    word-wrap: break-word
+}
+
+.module p.took-ms {
+    font-size: .9em
+}
+
+.module p.side-desc {
+    margin-bottom: .1em
+}
+
+#tag-suggestions {
+    min-height: 30px;
+    margin-bottom: 10px
+}
+
+#tag-suggestions .post-tag {
+    margin-right: 6px
+}
+
+#tag-suggestions span.post-tag {
+    opacity: .5
+}
+
+.general-error {
+    color: #c04848;
+    font-weight: bold;
+    margin-bottom: 10px
+}
+
+.general-success {
+    color: #44B449;
+    font-weight: bold;
+    margin-bottom: 10px
+}
+
+.validation-error {
+    border-color: #C04848 !important
+}
+
+.val-message {
+    margin: 24px auto;
+    padding: 32px;
+    width: 100%;
+    max-width: 640px;
+    border: 1px solid transparent;
+    color: hsl(210, 8%, 15%);
+    text-align: center
+}
+
+.val-message p {
+    margin-bottom: .5em;
+    padding-left: 12px;
+    padding-right: 12px;
+    font-size: 1.15384615rem;
+    line-height: 1.30769231
+}
+
+.val-message p:last-of-type {
+    margin-bottom: 0
+}
+
+.val-message .val--title {
+    margin-bottom: .57em;
+    font-size: 1.46153846rem;
+    line-height: 1.30769231
+}
+
+.val-message .val--icon {
+    width: 36px;
+    height: 36px;
+    color: var(--green-500)
+}
+
+.val-textemphasis {
+    font-weight: 700;
+    margin-top: 12px
+}
+
+.val-success {
+    background-color: hsl(140, 42%, 95%);
+    border-color: hsl(140, 40%, 65%)
+}
+
+.val-success .val--title {
+    color: var(--green-500)
+}
+
+.val-error {
+    background-color: hsl(358, 75%, 97%);
+    border-color: hsl(358, 68%, 59%)
+}
+
+.val-info {
+    background-color: hsl(47, 87%, 94%);
+    border-color: hsl(47, 73%, 50%)
+}
+
+.message.message-error {
+    z-index: 3000;
+    display: none;
+    color: var(--red-050);
+    background-color: var(--red-600);
+    text-align: left;
+    width: auto;
+    font-family: var(--theme-body-font-family);
+    font-size: 13px;
+    line-height: 1.30769231
+}
+
+.message.message-error.message-dismissable {
+    cursor: pointer
+}
+
+.message.message-error a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn) {
+    color: var(--white);
+    text-decoration: underline
+}
+
+.message.message-error ul {
+    margin: 0 0 0 15px;
+    padding: 0
+}
+
+.message.message-error ul li {
+    margin: 0 0 5px;
+    padding: 0
+}
+
+.message.message-error ul li:last-child {
+    margin-bottom: 0
+}
+
+.message.message-error code {
+    background: transparent
+}
+
+.message.message-error .message-inner {
+    position: relative
+}
+
+.message.message-error .message-tip:before {
+    content: "";
+    position: absolute;
+    border-width: 9px;
+    border-style: solid;
+    border-color: transparent
+}
+
+.message.message-error .message-tip-top-center:before {
+    top: -9px;
+    left: 50%;
+    border-top-width: 0;
+    border-bottom-color: var(--red-600)
+}
+
+.message.message-error .message-tip-left-top:before {
+    top: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--red-600)
+}
+
+.message.message-error .message-tip-top-left:before {
+    top: -9px;
+    left: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--red-600)
+}
+
+.message.message-error .message-tip-left-bottom:before {
+    bottom: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--red-600)
+}
+
+.message.message-error .message-tip-bottom-left:before {
+    top: 100%;
+    left: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--red-600)
+}
+
+.message.message-error .message-tip-right-top:before {
+    top: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--red-600)
+}
+
+.message.message-error .message-tip-top-right:before {
+    top: -9px;
+    right: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--red-600)
+}
+
+.message.message-error .message-tip-right-bottom:before {
+    bottom: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--red-600)
+}
+
+.message.message-error .message-tip-bottom-right:before {
+    top: 100%;
+    right: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--red-600)
+}
+
+.message.message-error .message-tip-bottom-center:before {
+    top: 100%;
+    left: 50%;
+    border-bottom-width: 0;
+    border-top-color: var(--red-600)
+}
+
+.message.message-error .message-text {
+    padding: 12px
+}
+
+.message.message-error .message-close {
+    box-sizing: border-box;
+    float: right;
+    margin-top: 8px;
+    margin-right: 8px;
+    width: 24px;
+    height: 24px;
+    background-color: transparent;
+    text-align: center;
+    font-family: var(--ff-sans);
+    font-size: 1.30769231rem;
+    line-height: 24px;
+    font-weight: 700;
+    color: var(--white) !important;
+    transition: all 600ms cubic-bezier(.165, .84, .44, 1)
+}
+
+.message.message-error .message-close:hover {
+    background-color: var(--white);
+    border-color: var(--white);
+    color: var(--red-600) !important
+}
+
+.message.message-error .popup-title-award {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: block
+}
+
+.message.message-info {
+    z-index: 3000;
+    display: none;
+    color: var(--blue-050);
+    background-color: var(--blue-600);
+    text-align: left;
+    width: auto;
+    font-family: var(--theme-body-font-family);
+    font-size: 13px;
+    line-height: 1.30769231
+}
+
+.message.message-info.message-dismissable {
+    cursor: pointer
+}
+
+.message.message-info a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn) {
+    color: var(--white);
+    text-decoration: underline
+}
+
+.message.message-info ul {
+    margin: 0 0 0 15px;
+    padding: 0
+}
+
+.message.message-info ul li {
+    margin: 0 0 5px;
+    padding: 0
+}
+
+.message.message-info ul li:last-child {
+    margin-bottom: 0
+}
+
+.message.message-info code {
+    background: transparent
+}
+
+.message.message-info .message-inner {
+    position: relative
+}
+
+.message.message-info .message-tip:before {
+    content: "";
+    position: absolute;
+    border-width: 9px;
+    border-style: solid;
+    border-color: transparent
+}
+
+.message.message-info .message-tip-top-center:before {
+    top: -9px;
+    left: 50%;
+    border-top-width: 0;
+    border-bottom-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-left-top:before {
+    top: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-top-left:before {
+    top: -9px;
+    left: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-left-bottom:before {
+    bottom: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-bottom-left:before {
+    top: 100%;
+    left: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-right-top:before {
+    top: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-top-right:before {
+    top: -9px;
+    right: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-right-bottom:before {
+    bottom: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-bottom-right:before {
+    top: 100%;
+    right: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--blue-600)
+}
+
+.message.message-info .message-tip-bottom-center:before {
+    top: 100%;
+    left: 50%;
+    border-bottom-width: 0;
+    border-top-color: var(--blue-600)
+}
+
+.message.message-info .message-text {
+    padding: 12px
+}
+
+.message.message-info .message-close {
+    box-sizing: border-box;
+    float: right;
+    margin-top: 8px;
+    margin-right: 8px;
+    width: 24px;
+    height: 24px;
+    background-color: transparent;
+    text-align: center;
+    font-family: var(--ff-sans);
+    font-size: 1.30769231rem;
+    line-height: 24px;
+    font-weight: 700;
+    color: var(--white) !important;
+    transition: all 600ms cubic-bezier(.165, .84, .44, 1)
+}
+
+.message.message-info .message-close:hover {
+    background-color: var(--white);
+    border-color: var(--white);
+    color: var(--blue-600) !important
+}
+
+.message.message-info .popup-title-award {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: block
+}
+
+.message.message-warning {
+    z-index: 3000;
+    display: none;
+    color: var(--yellow-900);
+    background-color: var(--yellow-300);
+    text-align: left;
+    width: auto;
+    font-family: var(--theme-body-font-family);
+    font-size: 13px;
+    line-height: 1.30769231
+}
+
+.message.message-warning.message-dismissable {
+    cursor: pointer
+}
+
+.message.message-warning a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn) {
+    color: var(--blue-600);
+    text-decoration: underline
+}
+
+.message.message-warning ul {
+    margin: 0 0 0 15px;
+    padding: 0
+}
+
+.message.message-warning ul li {
+    margin: 0 0 5px;
+    padding: 0
+}
+
+.message.message-warning ul li:last-child {
+    margin-bottom: 0
+}
+
+.message.message-warning code {
+    background: transparent
+}
+
+.message.message-warning .message-inner {
+    position: relative
+}
+
+.message.message-warning .message-tip:before {
+    content: "";
+    position: absolute;
+    border-width: 9px;
+    border-style: solid;
+    border-color: transparent
+}
+
+.message.message-warning .message-tip-top-center:before {
+    top: -9px;
+    left: 50%;
+    border-top-width: 0;
+    border-bottom-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-left-top:before {
+    top: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-top-left:before {
+    top: -9px;
+    left: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-left-bottom:before {
+    bottom: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-bottom-left:before {
+    top: 100%;
+    left: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-right-top:before {
+    top: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-top-right:before {
+    top: -9px;
+    right: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-right-bottom:before {
+    bottom: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-bottom-right:before {
+    top: 100%;
+    right: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--yellow-300)
+}
+
+.message.message-warning .message-tip-bottom-center:before {
+    top: 100%;
+    left: 50%;
+    border-bottom-width: 0;
+    border-top-color: var(--yellow-300)
+}
+
+.message.message-warning .message-text {
+    padding: 12px
+}
+
+.message.message-warning .message-close {
+    box-sizing: border-box;
+    float: right;
+    margin-top: 8px;
+    margin-right: 8px;
+    width: 24px;
+    height: 24px;
+    background-color: transparent;
+    text-align: center;
+    font-family: var(--ff-sans);
+    font-size: 1.30769231rem;
+    line-height: 24px;
+    font-weight: 700;
+    color: var(--blue-600) !important;
+    transition: all 600ms cubic-bezier(.165, .84, .44, 1)
+}
+
+.message.message-warning .message-close:hover {
+    background-color: var(--blue-600);
+    border-color: var(--blue-600);
+    color: var(--yellow-300) !important
+}
+
+.message.message-warning .popup-title-award {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: block
+}
+
+.message.message-config, .message.message-info.contributor-dropdown {
+    z-index: 3000;
+    display: none;
+    color: var(--black-600);
+    background-color: var(--white);
+    text-align: left;
+    width: auto;
+    font-family: var(--theme-body-font-family);
+    font-size: 13px;
+    line-height: 1.30769231
+}
+
+.message.message-config.message-dismissable, .message.message-info.contributor-dropdown.message-dismissable {
+    cursor: pointer
+}
+
+.message.message-config a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn), .message.message-info.contributor-dropdown a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn) {
+    color: var(--black-800);
+    text-decoration: underline
+}
+
+.message.message-config ul, .message.message-info.contributor-dropdown ul {
+    margin: 0 0 0 15px;
+    padding: 0
+}
+
+.message.message-config ul li, .message.message-info.contributor-dropdown ul li {
+    margin: 0 0 5px;
+    padding: 0
+}
+
+.message.message-config ul li:last-child, .message.message-info.contributor-dropdown ul li:last-child {
+    margin-bottom: 0
+}
+
+.message.message-config code, .message.message-info.contributor-dropdown code {
+    background: transparent
+}
+
+.message.message-config .message-inner, .message.message-info.contributor-dropdown .message-inner {
+    position: relative
+}
+
+.message.message-config .message-tip:before, .message.message-info.contributor-dropdown .message-tip:before {
+    content: "";
+    position: absolute;
+    border-width: 9px;
+    border-style: solid;
+    border-color: transparent
+}
+
+.message.message-config .message-tip-top-center:before, .message.message-info.contributor-dropdown .message-tip-top-center:before {
+    top: -9px;
+    left: 50%;
+    border-top-width: 0;
+    border-bottom-color: var(--white)
+}
+
+.message.message-config .message-tip-left-top:before, .message.message-info.contributor-dropdown .message-tip-left-top:before {
+    top: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--white)
+}
+
+.message.message-config .message-tip-top-left:before, .message.message-info.contributor-dropdown .message-tip-top-left:before {
+    top: -9px;
+    left: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--white)
+}
+
+.message.message-config .message-tip-left-bottom:before, .message.message-info.contributor-dropdown .message-tip-left-bottom:before {
+    bottom: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--white)
+}
+
+.message.message-config .message-tip-bottom-left:before, .message.message-info.contributor-dropdown .message-tip-bottom-left:before {
+    top: 100%;
+    left: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--white)
+}
+
+.message.message-config .message-tip-right-top:before, .message.message-info.contributor-dropdown .message-tip-right-top:before {
+    top: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--white)
+}
+
+.message.message-config .message-tip-top-right:before, .message.message-info.contributor-dropdown .message-tip-top-right:before {
+    top: -9px;
+    right: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--white)
+}
+
+.message.message-config .message-tip-right-bottom:before, .message.message-info.contributor-dropdown .message-tip-right-bottom:before {
+    bottom: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--white)
+}
+
+.message.message-config .message-tip-bottom-right:before, .message.message-info.contributor-dropdown .message-tip-bottom-right:before {
+    top: 100%;
+    right: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--white)
+}
+
+.message.message-config .message-tip-bottom-center:before, .message.message-info.contributor-dropdown .message-tip-bottom-center:before {
+    top: 100%;
+    left: 50%;
+    border-bottom-width: 0;
+    border-top-color: var(--white)
+}
+
+.message.message-config .message-text, .message.message-info.contributor-dropdown .message-text {
+    padding: 12px
+}
+
+.message.message-config .message-close, .message.message-info.contributor-dropdown .message-close {
+    box-sizing: border-box;
+    float: right;
+    margin-top: 8px;
+    margin-right: 8px;
+    width: 24px;
+    height: 24px;
+    background-color: transparent;
+    text-align: center;
+    font-family: var(--ff-sans);
+    font-size: 1.30769231rem;
+    line-height: 24px;
+    font-weight: 700;
+    color: var(--black-800) !important;
+    transition: all 600ms cubic-bezier(.165, .84, .44, 1)
+}
+
+.message.message-config .message-close:hover, .message.message-info.contributor-dropdown .message-close:hover {
+    background-color: var(--black-800);
+    border-color: var(--black-800);
+    color: var(--white) !important
+}
+
+.message.message-config .popup-title-award, .message.message-info.contributor-dropdown .popup-title-award {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: block
+}
+
+.message.message-config .message-close, .message.message-info.contributor-dropdown .message-close {
+    margin-top: 2px;
+    margin-right: 2px
+}
+
+.message.message-success {
+    z-index: 3000;
+    display: none;
+    color: var(--green-025);
+    background-color: var(--green-500);
+    text-align: left;
+    width: auto;
+    font-family: var(--theme-body-font-family);
+    font-size: 13px;
+    line-height: 1.30769231
+}
+
+.message.message-success.message-dismissable {
+    cursor: pointer
+}
+
+.message.message-success a:not(.badge-tag):not(.button):not(.btn):not(.post-tag):not(.s-btn) {
+    color: var(--white);
+    text-decoration: underline
+}
+
+.message.message-success ul {
+    margin: 0 0 0 15px;
+    padding: 0
+}
+
+.message.message-success ul li {
+    margin: 0 0 5px;
+    padding: 0
+}
+
+.message.message-success ul li:last-child {
+    margin-bottom: 0
+}
+
+.message.message-success code {
+    background: transparent
+}
+
+.message.message-success .message-inner {
+    position: relative
+}
+
+.message.message-success .message-tip:before {
+    content: "";
+    position: absolute;
+    border-width: 9px;
+    border-style: solid;
+    border-color: transparent
+}
+
+.message.message-success .message-tip-top-center:before {
+    top: -9px;
+    left: 50%;
+    border-top-width: 0;
+    border-bottom-color: var(--green-500)
+}
+
+.message.message-success .message-tip-left-top:before {
+    top: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--green-500)
+}
+
+.message.message-success .message-tip-top-left:before {
+    top: -9px;
+    left: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--green-500)
+}
+
+.message.message-success .message-tip-left-bottom:before {
+    bottom: 0;
+    left: -9px;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--green-500)
+}
+
+.message.message-success .message-tip-bottom-left:before {
+    top: 100%;
+    left: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--green-500)
+}
+
+.message.message-success .message-tip-right-top:before {
+    top: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-top-color: var(--green-500)
+}
+
+.message.message-success .message-tip-top-right:before {
+    top: -9px;
+    right: 0;
+    border-bottom-width: 0;
+    border-left-width: 0;
+    border-right-color: var(--green-500)
+}
+
+.message.message-success .message-tip-right-bottom:before {
+    bottom: 0;
+    left: 100%;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-left-color: var(--green-500)
+}
+
+.message.message-success .message-tip-bottom-right:before {
+    top: 100%;
+    right: 0;
+    border-bottom-width: 0;
+    border-right-width: 0;
+    border-top-color: var(--green-500)
+}
+
+.message.message-success .message-tip-bottom-center:before {
+    top: 100%;
+    left: 50%;
+    border-bottom-width: 0;
+    border-top-color: var(--green-500)
+}
+
+.message.message-success .message-text {
+    padding: 12px
+}
+
+.message.message-success .message-close {
+    box-sizing: border-box;
+    float: right;
+    margin-top: 8px;
+    margin-right: 8px;
+    width: 24px;
+    height: 24px;
+    background-color: transparent;
+    text-align: center;
+    font-family: var(--ff-sans);
+    font-size: 1.30769231rem;
+    line-height: 24px;
+    font-weight: 700;
+    color: var(--white) !important;
+    transition: all 600ms cubic-bezier(.165, .84, .44, 1)
+}
+
+.message.message-success .message-close:hover {
+    background-color: var(--white);
+    border-color: var(--white);
+    color: var(--green-500) !important
+}
+
+.message.message-success .popup-title-award {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: block
+}
+
+.message.toast {
+    position: fixed;
+    top: 20px;
+    right: 30px;
+    z-index: 5051
+}
+
+#newsletter-ad ul {
+    margin: 1em 0 1em 1.5em
+}
+
+#newsletter-ad ul li {
+    margin-bottom: 5px
+}
+
+#newsletter-email-input {
+    width: 200px
+}
+
+#custom-header {
+    display: none
+}
+
+.privilege-icon {
+    display: inline-block;
+    width: 20px;
+    height: 16px;
+    background-image: url('https://cdn.sstatic.net/Img/share-sprite-new.png?v=e1b8bd67bc12');
+    background-image: url('https://cdn.sstatic.net/Img/share-sprite-new.svg?v=0e11bfd41fbc'), none;
+    background-repeat: no-repeat;
+    background-color: transparent;
+    overflow: hidden;
+    text-indent: -999em;
+    outline: none;
+    background-position-x: 50px;
+    margin-bottom: -3px;
+    margin-right: 6px
+}
+
+.privilege-icon.icon-milestone {
+    background-position: -60px 0
+}
+
+.privilege-icon.icon-moderation {
+    background-position: -80px 0
+}
+
+.privilege-icon.icon-communication {
+    background-position: -100px 0
+}
+
+.privilege-icon.icon-creation {
+    background-position: -120px 0
+}
+
+.privilege-icon.icon-documentation {
+    background-position: -140px 0
+}
+
+.tools-index-subtabs {
+    width: 600px
+}
+
+.migrated.to {
+    width: 48px;
+    height: 48px;
+    background-image: url('https://cdn.sstatic.net/Img/fatarrows.png?v=ae7d0b13a3f3');
+    display: inline-block;
+    background-repeat: no-repeat;
+    overflow: hidden;
+    background-position: -48px 0
+}
+
+#mainbar-full h2.title {
+    margin: 20px 0
+}
+
+#rep-page-container #master-graph rect {
+    stroke: none
+}
+
+sub sub sub sub, sup sup sup sup {
+    font-size: 101%;
+    position: initial
+}
+
+.quality-warning {
+    font-weight: bold;
+    padding-top: 15px
+}
+
+.tm-links .review-indicator span {
+    float: left;
+    color: var(--white);
+    font-size: 11px;
+    padding: .2em .5em .25em;
+    line-height: 1.3;
+    background-color: var(--blue-600);
+    margin-right: 5px;
+    border-radius: 2px;
+    float: right;
+    background-color: #cf7721;
+    margin-right: 0
+}
+
+.review-indicator span {
+    color: hsl(0, 0%, 100%);
+    display: inline;
+    background-color: var(--blue-600);
+    padding: .2em .5em .25em;
+    margin-right: 5px;
+    font-size: 11px;
+    line-height: 1.3;
+    border-radius: 2px;
+    background-color: #cf7721;
+    margin: 0
+}
+
+.migrated.from {
+    background-position: 0 -464px !important
+}
+
+.migrated.to {
+    background-position: -34px -464px !important
+}
+
+.migrated.from, .migrated.to {
+    width: 30px !important;
+    height: 28px !important;
+    margin-right: 15px
+}
+
+.mod-page #tabs-interval {
+    width: 400px
+}
+
+h4#h-linked {
+    margin-top: 15px
+}
+
+.flagged-post .answer-link {
+    width: 650px
+}
+
+#additional-notices {
+    clear: both
+}
+
+#large-user-info:after {
+    content: '';
+    display: table;
+    clear: both
+}
+
+.tools.close-stats h1 {
+    padding-top: 15px
+}
+
+.tools.close-stats .header {
+    font-weight: bold
+}
+
+.tools.close-stats .row {
+    padding: 3px 0
+}
+
+.tools.close-stats .row .col-4 {
+    width: 30%;
+    padding-right: 10px
+}
+
+.tools.close-stats .close-reasons .inactive, .tools.close-stats .close-reasons .inactive a {
+    opacity: .5
+}
+
+.tools.close-stats .closure-stats .row:nth-child(odd), .tools.close-stats .custom-reasons .row:nth-child(odd) {
+    background-color: var(--black-025)
+}
+
+.container.edit-tag-wiki .input-section {
+    margin-bottom: 15px
+}
+
+.container.edit-tag-wiki .input-section h3 {
+    margin-bottom: 8px
+}
+
+.container.edit-tag-wiki .input-section .text-counter {
+    display: block;
+    height: 15px;
+    margin-top: 5px
+}
+
+.convert-image-to-link {
+    width: 250px
+}
+
+.home-page #qlist-wrapper {
+    clear: both
+}
+
+.dupe-hammer-message-hover {
+    margin-left: 4px;
+    cursor: pointer
+}
+
+.dupe-hammer-message-hover .badge-tag {
+    vertical-align: middle
+}
+
+.dupe-hammer-message {
+    display: block;
+    max-width: 430px;
+    line-height: 22px
+}
+
+.realtime-post-deleted-notification {
+    z-index: 100;
+    text-align: center
+}
+
+.realtime-post-deleted-notification p {
+    margin-top: 30px;
+    padding: 15px;
+    font-size: 1.15384615rem;
+    background-color: var(--red-050)
+}
+
+.upload-image-warning {
+    text-align: center;
+    background-color: #fcf8e3;
+    padding: 10px 10px 5px;
+    border: 1px solid #fbeed5;
+    margin-bottom: 15px;
+    border-radius: 3px;
+    color: #c09853;
+    font-size: 13px;
+    line-height: 1.3
+}
+
+.oauth-authorizebody {
+    background: #EFF0F1
+}
+
+.oauth-authorize.app-has-icon .app-icon-container {
+    margin-top: 18px
+}
+
+.oauth-authorize.app-has-icon .icons-container {
+    margin-bottom: 4px !important
+}
+
+.oauth-authorize .root {
+    text-align: center;
+    padding: 40px
+}
+
+.oauth-authorize .root .app-authorization {
+    display: inline-block;
+    margin: auto;
+    text-align: left;
+    padding: 40px;
+    border: 1px solid #D6D8DB;
+    border-radius: 2px;
+    background: #fff
+}
+
+.oauth-authorize .root .app-authorization .icons-container {
+    margin-bottom: 25px;
+    position: relative
+}
+
+.oauth-authorize .root .app-authorization .icons-container .enterprise-sub-icon {
+    position: absolute;
+    bottom: -7px;
+    left: 29px
+}
+
+.oauth-authorize .root .app-authorization .icons-container .app-icon-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start
+}
+
+.oauth-authorize .root .app-authorization .icons-container .app-icon-container .app-icon-large {
+    height: 50px;
+    vertical-align: top
+}
+
+.oauth-authorize .root .app-authorization .icons-container .app-icon-container .no-icon {
+    visibility: hidden
+}
+
+.oauth-authorize .root .app-authorization .authorize-text {
+    font-size: 1.30769231rem;
+    margin-bottom: .5em
+}
+
+.oauth-authorize .root .app-authorization .authorize-text .app-name {
+    font-weight: bold
+}
+
+.oauth-authorize .root .app-authorization .authorizing-scopes {
+    margin-bottom: 0;
+    font-size: 1.15384615rem
+}
+
+.oauth-authorize .root .app-authorization .authorizing-scopes li {
+    margin: 12px 0
+}
+
+.oauth-authorize .root .app-authorization .authorizing-scopes li .channel-name {
+    text-decoration: underline
+}
+
+.oauth-authorize .root .app-authorization .auth-buttons {
+    margin-top: 20px
+}
+
+.dropdown-questions-filters {
+    top: 42px;
+    right: 6px
+}
+
+.MathJax_SVG_Display, .MathJax_Display {
+    overflow: auto hidden
+}
+
+.post-notice blockquote {
+    position: relative;
+    padding: 6px 12px 6px 16px;
+    background-color: inherit;
+    margin-bottom: 0;
+    border-left: none;
+    margin-top: 4px
+}
+
+.post-notice blockquote:before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 4px;
+    border-radius: 8px;
+    background: var(--powder-400)
+}
+
+.post-notice blockquote div {
+    margin-bottom: 8px
+}
+
+.post-notice blockquote *:last-child {
+    margin-bottom: 0
+}
+
+.blink {
+    animation-name: blinking;
+    animation-duration: 3.5s
+}
+
+@keyframes blinking {
+    from {
+        background: #f4a83d
+    }
+
+    to {
+        background: rgba(244, 168, 61, 0)
+    }
+}
+
+.community-wiki-link a {
+    display: flex;
+    gap: 4px
+}
+
+.community-wiki-link br {
+    content: '';
+    white-space: pre;
+    margin-left: -4px
+}
+
+body .mp-results {
+    top: var(--top-bar-allocated-space)
+}
+
+.af-bar {
+    display: none
+}
+
+.af-bar__shown {
+    display: block
+}
+
+.af-bar__shown.af-bar--smol {
+    display: flex
+}
+
+.af-theme-button {
+    --af-btn-outline-color: transparent;
+    --af-btn-focus-outline-color: var(--theme-primary-color);
+    --af-btn-selected-outline-color: var(--white);
+    background-color: var(--black-700);
+    display: inline-flex;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    align-items: center;
+    justify-content: center;
+    outline: solid 3px var(--af-btn-outline-color);
+    overflow: hidden
+}
+
+.af-theme-button:hover, input[type="radio"]:focus+.af-theme-button {
+    outline-color: var(--af-btn-focus-outline-color)
+}
+
+.af-theme-button img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover
+}
+
+input[type="radio"]:checked+.af-theme-button {
+    width: 44px;
+    height: 44px;
+    outline-color: var(--af-btn-selected-outline-color)
+}
+
+@keyframes wipe {
+    0% {
+        clip-path: polygon(-50% -1%, 0% -1%, -50% 101%, -100% 101%)
+    }
+
+    20%, 100% {
+        clip-path: polygon(150% -1%, 200% -1%, 150% 101%, 100% 101%)
+    }
+}
+
+.af-theme-image, .af-theme-image-base {
+    filter: none !important
+}
+
+.af-theme-image {
+    animation-name: wipe;
+    animation-duration: 6s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%
+}
+
+#af-theme-1 {
+    animation-delay: -2000ms
+}
+
+#af-theme-2 {
+    animation-delay: -4000ms
+}
+
+#af-theme-3 {
+    animation-delay: -6000ms
+}
+
+@media screen and (prefers-reduced-motion) {
+    .af-theme-image {
+        animation-play-state: paused
+    }
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .af-logo-img {
+        filter: invert(1)
+    }
+}
+
+body.theme-dark .af-logo-img, .theme-dark__forced .af-logo-img {
+    filter: invert(1)
+}
+
+body.theme-custom {
+    --theme-question-title-color: var(--theme-body-color);
+    --theme-question-title-font-family: var(--theme-body-font-family);
+    --theme-question-body-font-family: var(--theme-body-font-family);
+    --theme-question-title-color: var(--theme-link-color);
+    --theme-question-title-color-hover: var(--theme-link-color-hover);
+    --theme-question-title-color-visited: var(--theme-link-color-visited)
+}
+
+body.theme-custom .s-btn__muted {
+    color: var(--fc-light)
+}
+
+body.theme-custom .s-btn__muted:hover, body.theme-custom .s-btn__muted:focus, body.theme-custom .s-btn__muted:active {
+    color: var(--fc-medium);
+    background-color: var(--black-025)
+}
+
+body.theme-custom .s-btn__muted:active {
+    background: var(--black-025)
+}
+
+body.theme-custom .s-btn__muted.is-selected {
+    color: var(--fc-medium);
+    background-color: var(--black-075)
+}
+
+body.theme-custom .s-btn__muted.s-btn__outlined {
+    border-color: var(--black-300)
+}
+
+body.theme-custom .s-btn__muted.s-btn__outlined.is-selected {
+    border-color: var(--black-400)
+}
+
+body.theme-custom .s-btn__muted.s-btn__filled {
+    color: var(--fc-medium);
+    background-color: var(--black-100)
+}
+
+body.theme-custom .s-btn__muted.s-btn__filled:hover, body.theme-custom .s-btn__muted.s-btn__filled:focus, body.theme-custom .s-btn__muted.s-btn__filled:active {
+    color: var(--fc-medium);
+    background-color: var(--black-150)
+}
+
+body.theme-custom .s-btn__muted.s-btn__filled:active {
+    background-color: var(--black-200)
+}
+
+body.theme-custom .s-btn__muted.s-btn__filled.is-selected {
+    color: var(--fc-dark);
+    background-color: var(--black-350)
+}
+
+body.theme-custom .s-sidebarwidget {
+    --sidebarwidget-outer-border-color: var(--bc-medium);
+    --sidebarwidget-content-separator-color: var(--bc-light);
+    --sidebarwidget-header-background-color: var(--black-025);
+    --sidebarwidget-background-color: var(--white);
+    border: 1px solid var(--sidebarwidget-outer-border-color);
+    background-color: var(--sidebarwidget-background-color)
+}
+
+body.theme-custom .s-sidebarwidget:not(.s-anchors) a:not(.button):not(.s-btn):not(.post-tag):not(.s-sidebarwidget--action):not(.s-user-card--link), body.theme-custom .s-sidebarwidget:not(.s-anchors) a:not(.button):not(.s-btn):not(.post-tag):not(.s-sidebarwidget--action):not(.s-user-card--link):visited {
+    color: var(--fc-light)
+}
+
+body.theme-custom .s-sidebarwidget:after {
+    border-top: 1px solid var(--sidebarwidget-outer-border-color)
+}
+
+@supports ((-webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)) or (clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%))) or (-webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)) {
+    body.theme-custom .s-sidebarwidget:after {
+        border: 1px solid var(--sidebarwidget-outer-border-color)
+    }
+}
+
+body.theme-custom .s-sidebarwidget .s-sidebarwidget--header, body.theme-custom .s-sidebarwidget .s-sidebarwidget--content {
+    border-top: 1px solid var(--sidebarwidget-content-separator-color)
+}
+
+body.theme-custom .s-sidebarwidget .s-sidebarwidget--header {
+    background: var(--sidebarwidget-header-background-color);
+    color: var(--fc-medium)
+}
+
+body.theme-custom .s-sidebarwidget .s-sidebarwidget--action {
+    color: var(--theme-link-color)
+}
+
+body.theme-custom .s-sidebarwidget .s-sidebarwidget--item, body.theme-custom .s-sidebarwidget .s-sidebarwidget--item>:first-child {
+    color: var(--fc-dark)
+}
+
+body.theme-custom .s-sidebarwidget .s-sidebarwidget--subnav[aria-current="true"], body.theme-custom .s-sidebarwidget .s-sidebarwidget--subnav[aria-current="page"] {
+    color: var(--fc-dark)
+}
+
+body.theme-custom .s-sidebarwidget__yellow, body.theme-custom .s-sidebarwidget__blue, body.theme-custom .s-sidebarwidget__green {
+    border-color: var(--sidebarwidget-outer-border-color);
+    background-color: var(--sidebarwidget-background-color)
+}
+
+body.theme-custom .s-sidebarwidget__yellow .s-sidebarwidget--header, body.theme-custom .s-sidebarwidget__blue .s-sidebarwidget--header, body.theme-custom .s-sidebarwidget__green .s-sidebarwidget--header {
+    background-color: var(--sidebarwidget-background-color);
+    color: var(--fc-medium)
+}
+
+body.theme-custom .s-sidebarwidget__yellow .s-sidebarwidget--header, body.theme-custom .s-sidebarwidget__blue .s-sidebarwidget--header, body.theme-custom .s-sidebarwidget__green .s-sidebarwidget--header, body.theme-custom .s-sidebarwidget__yellow .s-sidebarwidget--content, body.theme-custom .s-sidebarwidget__blue .s-sidebarwidget--content, body.theme-custom .s-sidebarwidget__green .s-sidebarwidget--content {
+    border-color: var(--sidebarwidget-outer-border-color)
+}
+
+body.theme-custom .s-sidebarwidget__yellow:after, body.theme-custom .s-sidebarwidget__blue:after, body.theme-custom .s-sidebarwidget__green:after {
+    border-color: var(--sidebarwidget-outer-border-color)
+}
+
+body.theme-custom .s-breadcrumbs {
+    color: var(--fc-light)
+}
+
+body.theme-custom .s-breadcrumbs .s-breadcrumbs--link {
+    color: var(--fc-light)
+}
+
+body.theme-custom .s-breadcrumbs .s-breadcrumbs--link:hover {
+    color: var(--fc-medium)
+}
+
+body.theme-custom #question-header .question-hyperlink {
+    color: var(--theme-body-font-color)
+}
+
+body.theme-custom .s-topbar--item:hover .-badges * {
+    color: inherit !important
+}
+
+body.theme-custom .js-zone-container, body.theme-custom #hireme, body.theme-custom .mixed-site-content, body.theme-custom .js-consent-banner, body.theme-custom #onetrust-banner-sdk, body.theme-custom .js-zone-container *, body.theme-custom #hireme *, body.theme-custom .mixed-site-content *, body.theme-custom .js-consent-banner *, body.theme-custom #onetrust-banner-sdk * {
+    filter: none !important
+}
+
+body.theme-custom.theme-win31 {
+    --theme-base-primary-color-h: 243;
+    --theme-base-primary-color-s: 93.2%;
+    --theme-base-primary-color-l: 34.7%;
+    --theme-base-primary-color-r: 15;
+    --theme-base-primary-color-g: 6;
+    --theme-base-primary-color-b: 171;
+    --theme-base-secondary-color-h: 243;
+    --theme-base-secondary-color-s: 93.2%;
+    --theme-base-secondary-color-l: 34.7%;
+    --theme-base-secondary-color-r: 15;
+    --theme-base-secondary-color-g: 6;
+    --theme-base-secondary-color-b: 171;
+    --theme-background-color: #c0c4c8;
+    --theme-button-active-background-color: #f1f2f3;
+    --theme-button-color: #000000;
+    --theme-button-hover-background-color: #fafafb;
+    --theme-button-hover-color: #000000;
+    --theme-button-selected-background-color: #e9eaec;
+    --theme-button-selected-color: #000000;
+    --theme-button-filled-active-background-color: #e9eaec;
+    --theme-button-filled-active-border-color: #c0c4c8;
+    --theme-button-filled-background-color: #fafafb;
+    --theme-button-filled-border-color: #2a2a2a;
+    --theme-button-filled-color: #000000;
+    --theme-button-filled-hover-background-color: #f1f2f3;
+    --theme-button-filled-hover-color: #000000;
+    --theme-button-filled-selected-background-color: #d6d9db;
+    --theme-button-filled-selected-border-color: #b2b7bc;
+    --theme-button-filled-selected-color: #000000;
+    --theme-button-outlined-border-color: #d6d9db;
+    --theme-button-outlined-selected-border-color: #2a2a2a;
+    --theme-button-primary-active-background-color: #c0c4c8;
+    --theme-button-primary-background-color: #c0c4c8;
+    --theme-button-primary-color: #000000;
+    --theme-button-primary-hover-background-color: #b2b7bc;
+    --theme-button-primary-hover-color: #000000;
+    --theme-button-primary-number-color: #79828a;
+    --theme-button-primary-selected-background-color: #959ba2;
+    --theme-content-border-color: #2a2a2a;
+    --theme-link-color: #0e06ab;
+    --theme-link-color-hover: #3f38bc;
+    --theme-link-color-visited: #0c0592;
+    --theme-header-background-color: #0e06ab;
+    --theme-header-link-color: #0e06ab;
+    --theme-post-owner-background-color: #f6f6f7;
+    --theme-tag-background-color: #f6f6f7;
+    --theme-tag-color: #878f96;
+    --theme-tag-hover-background-color: #f1f2f3;
+    --theme-tag-hover-color: #79828a;
+    --theme-body-font-family: Arial, sans;
+    --theme-footer-background-color: transparent;
+    --shadow-inactive: inset -1px -1px #84888c, inset 1px 1px #F0F0F0, inset -2px -2px #85898d, inset 2px 2px #dfdfdf !important;
+    --element-bg: #c0c0c0;
+    --theme-topbar-background-color: transparent;
+    --theme-topbar-accent-border: none;
+    --theme-topbar-select-background: #ffffff;
+    --theme-topbar-item-color: #ffffff;
+    --theme-topbar-item-color-hover: #000000
+}
+
+body.theme-custom.theme-win31 * {
+    -webkit-font-smoothing: none;
+    image-rendering: pixelated
+}
+
+body.theme-custom.theme-win31 a:not(.s-btn), body.theme-custom.theme-win31 a:not(.s-btn):hover, body.theme-custom.theme-win31 .s-link, body.theme-custom.theme-win31 .s-link:hover {
+    text-decoration: underline;
+    text-decoration-skip-ink: none
+}
+
+body.theme-custom.theme-win31 .s-topbar .s-user-card .-badges, body.theme-custom.theme-win31 .s-topbar--item .-badges * {
+    color: inherit !important
+}
+
+body.theme-custom.theme-win31 * {
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    scrollbar-color: var(--element-bg) !important
+}
+
+body.theme-custom.theme-win31 .s-topbar--container {
+    background-color: var(--theme-primary-color);
+    color: var(--white);
+    border: 4px solid var(--theme-primary-color);
+    border-bottom-width: 0
+}
+
+body.theme-custom.theme-win31 .s-topbar--logo .-img._glyph {
+    filter: invert(.5) brightness(2)
+}
+
+body.theme-custom.theme-win31 .s-topbar--logo:hover .-img._glyph {
+    filter: invert(.5) brightness(0)
+}
+
+body.theme-custom.theme-win31 .s-topbar .s-select {
+    margin-right: 4px
+}
+
+body.theme-custom.theme-win31 a:focus, body.theme-custom.theme-win31 .s-link:focus, body.theme-custom.theme-win31 .s-btn.s-btn__link:focus {
+    outline: 1px dotted #000000;
+    outline-offset: 0
+}
+
+body.theme-custom.theme-win31 .s-btn:not(.s-btn__icon) {
+    border-radius: 1px !important;
+    color: var(--theme-button-primary-color);
+    font-weight: bold
+}
+
+body.theme-custom.theme-win31 .s-btn:focus:not(:active) {
+    outline: 1px dotted #000000;
+    outline-offset: -0.8em
+}
+
+body.theme-custom.theme-win31 .s-btn__primary {
+    border: 1px solid var(--theme-button-outlined-border-color);
+    box-shadow: inset -1px -1px #84888c, inset 1px 1px #F0F0F0, inset -2px -2px #85898d, inset 2px 2px #dfdfdf !important
+}
+
+body.theme-custom.theme-win31 .s-btn__primary:active, body.theme-custom.theme-win31 .s-btn__filled:active, body.theme-custom.theme-win31 .s-input, body.theme-custom.theme-win31 .s-textarea, body.theme-custom.theme-win31 .s-select select {
+    box-shadow: inset -1px -1px #f0f0f0, inset 1px 1px #151515, inset -2px -2px #dfdfdf, inset 2px 2px #85898d !important
+}
+
+body.theme-custom.theme-win31 .s-btn__primary::first-letter {
+    text-decoration: underline;
+    text-decoration-thickness: .15em;
+    text-decoration-skip-ink: none
+}
+
+body.theme-custom.theme-win31 .container {
+    border: 4px solid var(--theme-primary-color);
+    border-top-width: 0;
+    border-bottom-width: 0
+}
+
+body.theme-custom.theme-win31 .site-footer--container, body.theme-custom.theme-win31 .site-footer--extra {
+    background-color: var(--theme-content-background-color);
+    border: 4px solid var(--theme-primary-color)
+}
+
+body.theme-custom.theme-win31 #left-sidebar {
+    background-color: var(--theme-content-background-color)
+}
+
+body.theme-custom.theme-win31 .nav-links .youarehere .nav-links--link, body.theme-custom.theme-win31 .nav-links .youarehere .nav-links--link .svg-icon {
+    background-color: var(--theme-primary-color);
+    color: var(--white) !important
+}
+
+body.theme-custom.theme-win31 .s-checkbox, body.theme-custom.theme-win31 .s-radio {
+    border-color: black;
+    background: white;
+    box-shadow: inset -1px -1px #c0c4c8, inset 1px 1px #151515, inset -1px -1px #dfdfdf, inset 1px 1px #85898d !important
+}
+
+body.theme-custom.theme-win31 .s-radio {
+    border-radius: 50% !important
+}
+
+body.theme-custom.theme-win31 .s-radio:checked, body.theme-custom.theme-win31 .s-checkbox:checked {
+    border: 0;
+    background: var(--white);
+    position: relative
+}
+
+body.theme-custom.theme-win31 .s-radio:checked::after {
+    content: "";
+    width: 50%;
+    height: 50%;
+    background-color: black;
+    position: absolute;
+    top: 25%;
+    left: 25%;
+    border-radius: 50% !important
+}
+
+body.theme-custom.theme-win31 .s-checkbox:checked::before, body.theme-custom.theme-win31 .s-checkbox:checked::after {
+    content: "";
+    width: 2px;
+    height: 11px;
+    background-color: black;
+    position: absolute;
+    left: .5px;
+    top: 1px;
+    transform: translateX(5px) rotate(45deg);
+    border-radius: 1px
+}
+
+body.theme-custom.theme-win31 .s-checkbox:checked::after {
+    transform: translateX(5px) rotate(-45deg)
+}
+
+body.theme-custom.theme-win31 input:focus, body.theme-custom.theme-win31 select:focus, body.theme-custom.theme-win31 textarea:focus, body.theme-custom.theme-win31 input.has-focus, body.theme-custom.theme-win31 select.has-focus, body.theme-custom.theme-win31 textarea.has-focus {
+    outline: 2px solid black !important;
+    border-color: transparent
+}
+
+body.theme-custom.theme-win31 .s-select::before {
+    display: none
+}
+
+body.theme-custom.theme-win31 .s-select::after {
+    border: 0;
+    background-image: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/arrowdrop.png?v=e5987784d591");
+    content: "";
+    width: 20px;
+    height: 20px;
+    background-size: 50% auto;
+    background-repeat: no-repeat;
+    background-position: center;
+    top: 50%;
+    right: 4px;
+    transform: translateY(-50%)
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar, body.theme-custom.theme-win31 *::-webkit-scrollbar {
+    width: 20px !important;
+    height: 20px !important;
+    background-color: transparent !important;
+    border: 1px solid black !important
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar-track, body.theme-custom.theme-win31 *::-webkit-scrollbar-track {
+    border-radius: 0 !important;
+    background-color: var(--element-bg) !important;
+    border: 1px solid black !important
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar-thumb, body.theme-custom.theme-win31 *::-webkit-scrollbar-thumb {
+    border-radius: 0 !important;
+    background-color: var(--element-bg) !important;
+    border: 1px solid black !important;
+    box-shadow: var(--shadow-inactive)
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar-corner, body.theme-custom.theme-win31 *::-webkit-scrollbar-corner {
+    background-color: var(--element-bg) !important;
+    border: 1px solid black !important
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar-button, body.theme-custom.theme-win31 *::-webkit-scrollbar-button {
+    background-color: var(--element-bg) !important;
+    border: 1px solid black !important;
+    box-shadow: var(--shadow-inactive);
+    height: 20px;
+    width: 20px;
+    display: block;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 50%;
+    background-image: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/arrowup.png?v=4329a69b4efb")
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar-button:vertical:increment, body.theme-custom.theme-win31 *::-webkit-scrollbar-button:vertical:increment {
+    background-image: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/arrowdown.png?v=21fb3f6ec3e7")
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar-button:horizontal:decrement, body.theme-custom.theme-win31 *::-webkit-scrollbar-button:horizontal:decrement {
+    background-image: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/arrowleft.png?v=5794723486b1")
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar-button:horizontal:increment, body.theme-custom.theme-win31 *::-webkit-scrollbar-button:horizontal:increment {
+    background-image: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/arrowright.png?v=79d712516e17")
+}
+
+body.theme-custom.theme-win31::-webkit-scrollbar-button:vertical:start:increment, body.theme-custom.theme-win31 *::-webkit-scrollbar-button:vertical:start:increment, body.theme-custom.theme-win31::-webkit-scrollbar-button:vertical:end:decrement, body.theme-custom.theme-win31 *::-webkit-scrollbar-button:vertical:end:decrement, body.theme-custom.theme-win31::-webkit-scrollbar-button:horizontal:start:increment, body.theme-custom.theme-win31 *::-webkit-scrollbar-button:horizontal:start:increment, body.theme-custom.theme-win31::-webkit-scrollbar-button:horizontal:end:decrement, body.theme-custom.theme-win31 *::-webkit-scrollbar-button:horizontal:end:decrement {
+    display: none
+}
+
+body.theme-custom.theme-win31.theme-hotdog {
+    --theme-base-primary-color-h: 0;
+    --theme-base-primary-color-s: 100%;
+    --theme-base-primary-color-l: 47.5%;
+    --theme-base-primary-color-r: 242;
+    --theme-base-primary-color-g: 0;
+    --theme-base-primary-color-b: 0;
+    --theme-base-secondary-color-h: 0;
+    --theme-base-secondary-color-s: 100%;
+    --theme-base-secondary-color-l: 47.5%;
+    --theme-base-secondary-color-r: 242;
+    --theme-base-secondary-color-g: 0;
+    --theme-base-secondary-color-b: 0;
+    --theme-background-color: #fbfb00;
+    --theme-button-active-background-color: #f1f2f3;
+    --theme-button-color: #000000;
+    --theme-button-hover-background-color: #fafafb;
+    --theme-button-hover-color: #000000;
+    --theme-button-selected-background-color: #e9eaec;
+    --theme-button-selected-color: #000000;
+    --theme-button-filled-active-background-color: #e9eaec;
+    --theme-button-filled-active-border-color: #c0c4c8;
+    --theme-button-filled-background-color: #fafafb;
+    --theme-button-filled-border-color: #2a2a2a;
+    --theme-button-filled-color: #000000;
+    --theme-button-filled-hover-background-color: #f1f2f3;
+    --theme-button-filled-hover-color: #000000;
+    --theme-button-filled-selected-background-color: #d6d9db;
+    --theme-button-filled-selected-border-color: #b2b7bc;
+    --theme-button-filled-selected-color: #000000;
+    --theme-button-outlined-border-color: #d6d9db;
+    --theme-button-outlined-selected-border-color: #2a2a2a;
+    --theme-button-primary-active-background-color: #c0c4c8;
+    --theme-button-primary-background-color: #c0c4c8;
+    --theme-button-primary-color: #000000;
+    --theme-button-primary-hover-background-color: #b2b7bc;
+    --theme-button-primary-hover-color: #000000;
+    --theme-button-primary-number-color: #79828a;
+    --theme-button-primary-selected-background-color: #959ba2;
+    --theme-content-background-color: #fbfb00;
+    --theme-content-border-color: #2a2a2a;
+    --theme-footer-background-color: #000000;
+    --theme-link-color: #0e06ab;
+    --theme-link-color-hover: #3f38bc;
+    --theme-link-color-visited: #0c0592;
+    --theme-header-background-color: #0e06ab;
+    --theme-header-link-color: #0e06ab;
+    --theme-post-owner-background-color: #f6f6f7;
+    --theme-tag-background-color: #f6f6f7;
+    --theme-tag-color: #878f96;
+    --theme-tag-hover-background-color: #f1f2f3;
+    --theme-tag-hover-color: #79828a
+}
+
+body.theme-custom.theme-dark.theme-terminal {
+    --theme-base-primary-color-h: 120;
+    --theme-base-primary-color-s: 100%;
+    --theme-base-primary-color-l: 50%;
+    --theme-base-primary-color-r: 0;
+    --theme-base-primary-color-g: 255;
+    --theme-base-primary-color-b: 0;
+    --theme-base-secondary-color-h: 120;
+    --theme-base-secondary-color-s: 100%;
+    --theme-base-secondary-color-l: 50%;
+    --theme-base-secondary-color-r: 0;
+    --theme-base-secondary-color-g: 255;
+    --theme-base-secondary-color-b: 0;
+    --theme-background-color: #000111;
+    --theme-body-font-color: var(--theme-primary-color);
+    --theme-button-primary-color: #000000;
+    --theme-button-primary-hover-color: #000000;
+    --theme-button-primary-selected-color: #000000;
+    --theme-content-background-color: #000111;
+    --theme-content-border-color: var(--theme-primary-color);
+    --theme-link-color-hover: #ffffff;
+    --theme-link-color-visited: var(--fc-dark);
+    --theme-body-font-family: VT323, monospace;
+    --theme-topbar-background-color: var(--theme-content-background-color);
+    --theme-topbar-item-background-hover: var(--theme-secondary-color);
+    --theme-topbar-item-border-current: var(--theme-secondary-color);
+    --theme-topbar-item-color: var(--theme-secondary-color);
+    --theme-topbar-item-color-hover: var(--theme-content-background-color);
+    --theme-topbar-search-border-focus: var(--theme-secondary-color);
+    --fc-dark: var(--theme-secondary-300);
+    --fc-medium: var(--theme-secondary-500);
+    --fc-light: var(--theme-secondary-600);
+    --bc-lightest: var(--fc-light);
+    --bc-lighter: var(--fc-light);
+    --bc-light: var(--fc-medium);
+    --bc-medium: var(--fc-medium);
+    --bc-dark: var(--fc-dark);
+    --bc-darker: var(--fc-dark);
+    font-size-adjust: .5
+}
+
+body.theme-custom.theme-dark.theme-terminal * {
+    -webkit-font-smoothing: none;
+    image-rendering: pixelated
+}
+
+body.theme-custom.theme-dark.theme-terminal a:not(.s-btn), body.theme-custom.theme-dark.theme-terminal a:not(.s-btn):hover, body.theme-custom.theme-dark.theme-terminal .s-link, body.theme-custom.theme-dark.theme-terminal .s-link:hover {
+    text-decoration: underline;
+    text-decoration-skip-ink: none
+}
+
+body.theme-custom.theme-dark.theme-terminal .s-topbar .s-user-card .-badges, body.theme-custom.theme-dark.theme-terminal .s-topbar--item .-badges * {
+    color: inherit !important
+}
+
+body.theme-custom.theme-dark.theme-terminal * {
+    border-radius: 0 !important
+}
+
+body.theme-custom.theme-dark.theme-terminal .s-topbar--logo .-img._glyph {
+    filter: invert(.5) brightness(2) sepia(1) brightness(1) contrast(1) saturate(100) hue-rotate(45deg)
+}
+
+body.theme-custom.theme-dark.theme-terminal [class*="gravatar-wrapper-"], body.theme-custom.theme-dark.theme-terminal .s-avatar, body.theme-custom.theme-dark.theme-terminal .js-usermini-avatar-container {
+    background: var(--theme-primary-color)
+}
+
+body.theme-custom.theme-dark.theme-terminal [class*="gravatar-wrapper-"] img, body.theme-custom.theme-dark.theme-terminal .s-avatar img, body.theme-custom.theme-dark.theme-terminal .js-usermini-avatar-container img {
+    filter: grayscale(1) contrast(200%);
+    mix-blend-mode: multiply
+}
+
+body.theme-custom.theme-dark.theme-terminal [class*="user-gravatar"] {
+    background: var(--theme-primary-color)
+}
+
+body.theme-custom.theme-dark.theme-terminal [class*="user-gravatar"] span {
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+    filter: grayscale(1);
+    mix-blend-mode: multiply
+}
+
+body.theme-custom.theme-dark.theme-terminal .s-btn__primary {
+    color: var(--theme-button-primary-color) !important
+}
+
+body.theme-custom.theme-dark.theme-terminal #question-header .question-hyperlink {
+    color: var(--theme-body-font-color)
+}
+
+body.theme-custom.theme-dark.theme-terminal .flush-left {
+    border-top-color: var(--bc-medium)
+}
+
+body.theme-custom.theme-dark.theme-terminal .af-bar {
+    background-color: var(--theme-background-color) !important;
+    color: var(--theme-body-font-color) !important
+}
+
+body.theme-custom.theme-dark.theme-terminal .af-bar .af-logo-img {
+    filter: invert(.5) brightness(2) sepia(1) brightness(1) contrast(1) saturate(100) hue-rotate(45deg)
+}
+
+body.theme-custom.theme-dark.theme-terminal .af-bar .af-theme-button {
+    --af-btn-outline-color: var(--theme-primary-color);
+    --af-btn-focus-outline-color: var(--red-500);
+    --af-btn-selected-outline-color: #ffffff;
+    background: var(--theme-background-color);
+    border-radius: 50% !important
+}
+
+body.theme-custom.theme-topsecret {
+    --theme-body-font-family: Courier, serif;
+    --ff-mono: var(--theme-body-font-family);
+    --theme-question-body-font-family: #232629;
+    --theme-question-title-font-family: var(--theme-body-font-family);
+    --theme-body-font-color: #000000;
+    --theme-content-border-color: var(--bc-darker);
+    --theme-topbar-background-color: white;
+    --theme-topbar-select-background: white;
+    --theme-button-active-background-color: #ffffff;
+    --theme-button-background-color: #ffffff;
+    --theme-button-color: var(--fc-medium);
+    --theme-button-hover-background-color: #ffffff;
+    --theme-button-hover-color: var(--fc-dark);
+    --theme-button-selected-background-color: #ffffff;
+    --theme-button-selected-color: var(--fc-dark);
+    --theme-button-filled-active-background-color: #ffffff;
+    --theme-button-filled-active-border-color: var(--fc-dark);
+    --theme-button-filled-background-color: #ffffff;
+    --theme-button-filled-border-color: var(--fc-medium);
+    --theme-button-filled-color: var(--fc-medium);
+    --theme-button-filled-hover-background-color: #ffffff;
+    --theme-button-filled-hover-color: var(--fc-dark);
+    --theme-button-filled-selected-background-color: #ffffff;
+    --theme-button-filled-selected-border-color: var(--fc-dark);
+    --theme-button-filled-selected-color: var(--fc-dark);
+    --theme-button-outlined-border-color: var(--fc-medium);
+    --theme-button-outlined-selected-border-color: var(--fc-dark);
+    --topsecret-image: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/confidential.svg?v=eb675da66cdd");
+    --fc-dark: #0c0d0e;
+    --fc-medium: #3b4045;
+    --fc-light: #6a737c;
+    --bc-lightest: var(--fc-light);
+    --bc-lighter: var(--fc-light);
+    --bc-light: var(--fc-medium);
+    --bc-medium: var(--fc-medium);
+    --bc-dark: var(--fc-dark);
+    --bc-darker: var(--fc-dark);
+    --bs-sm: var(--bs-lg);
+    --bs-md: var(--bs-lg);
+    --bs-xl: var(--bs-lg)
+}
+
+body.theme-custom.theme-topsecret a:not(.s-btn), body.theme-custom.theme-topsecret a:not(.s-btn):hover, body.theme-custom.theme-topsecret .s-link, body.theme-custom.theme-topsecret .s-link:hover {
+    text-decoration: underline;
+    text-decoration-skip-ink: none
+}
+
+body.theme-custom.theme-topsecret .s-topbar .s-user-card .-badges, body.theme-custom.theme-topsecret .s-topbar--item .-badges * {
+    color: inherit !important
+}
+
+body.theme-custom.theme-topsecret .s-topbar--logo .-img {
+    filter: invert(.5) brightness(0)
+}
+
+body.theme-custom.theme-topsecret #content::before {
+    content: "";
+    background: var(--topsecret-image) no-repeat center;
+    background-size: contain;
+    transform: rotate(-18deg);
+    width: 150px;
+    height: 150px;
+    pointer-events: none;
+    position: absolute;
+    top: 0px;
+    left: 150px;
+    z-index: 5000
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive body.theme-custom.theme-topsecret #content::before {
+        width: 100px;
+        height: 100px;
+        left: 0
+    }
+}
+
+@media print {
+    body.theme-custom.theme-topsecret #content::before {
+        width: 100px;
+        height: 100px;
+        left: 0
+    }
+}
+
+body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n), body.theme-custom.theme-topsecret #questions>:nth-child(2n), body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n) {
+    font-family: 'Flow Block', serif !important
+}
+
+body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n), body.theme-custom.theme-topsecret #questions>:nth-child(2n), body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n), body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n) *, body.theme-custom.theme-topsecret #questions>:nth-child(2n) *, body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n) * {
+    text-decoration: none !important
+}
+
+body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n):hover, body.theme-custom.theme-topsecret #questions>:nth-child(2n):hover, body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n):hover, body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n):focus, body.theme-custom.theme-topsecret #questions>:nth-child(2n):focus, body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n):focus, body.theme-custom.theme-topsecret #question-mini-list>:nth-child(2n):active, body.theme-custom.theme-topsecret #questions>:nth-child(2n):active, body.theme-custom.theme-topsecret .js-search-results>*>:nth-child(2n):active {
+    font-family: revert !important
+}
+
+body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n), body.theme-custom.theme-topsecret .post-layout :nth-child(5n) {
+    font-family: 'Flow Block', serif !important
+}
+
+body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n), body.theme-custom.theme-topsecret .post-layout :nth-child(5n), body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n) *, body.theme-custom.theme-topsecret .post-layout :nth-child(5n) * {
+    text-decoration: none !important
+}
+
+body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n):hover, body.theme-custom.theme-topsecret .post-layout :nth-child(5n):hover, body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n):focus, body.theme-custom.theme-topsecret .post-layout :nth-child(5n):focus, body.theme-custom.theme-topsecret .s-prose :nth-of-type(2n):active, body.theme-custom.theme-topsecret .post-layout :nth-child(5n):active {
+    font-family: revert !important
+}
+
+body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a {
+    font-family: 'Flow Block', serif !important
+}
+
+body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a, body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a * {
+    text-decoration: none !important
+}
+
+body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a:hover, body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a:focus, body.theme-custom.theme-topsecret .s-post-summary:nth-of-type(6n) .s-post-summary--content-title a:active {
+    font-family: revert !important
+}
+
+body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n) {
+    font-family: 'Flow Block', serif !important
+}
+
+body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n), body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n) * {
+    text-decoration: none !important
+}
+
+body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n):hover, body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n):focus, body.theme-custom.theme-topsecret #mainbar-full :nth-of-type(6n):active {
+    font-family: revert !important
+}
+
+body.theme-custom.theme-topsecret .js-zone-container, body.theme-custom.theme-topsecret #hireme, body.theme-custom.theme-topsecret .mixed-site-content, body.theme-custom.theme-topsecret .js-consent-banner, body.theme-custom.theme-topsecret #onetrust-banner-sdk, body.theme-custom.theme-topsecret .js-zone-container *, body.theme-custom.theme-topsecret #hireme *, body.theme-custom.theme-topsecret .mixed-site-content *, body.theme-custom.theme-topsecret .js-consent-banner *, body.theme-custom.theme-topsecret #onetrust-banner-sdk * {
+    font-family: var(--theme-body-font-family) !important
+}
+
+body.theme-custom.theme-topsecret .s-badge.s-badge__staff {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(244, 130, 37, 0) .9%, #f48225 2.4%, rgba(244, 130, 37, 0.5) 5.8%, rgba(244, 130, 37, 0.1) 93%, rgba(244, 130, 37, 0.7) 96%, rgba(244, 130, 37, 0) 98%), linear-gradient(183deg, rgba(244, 130, 37, 0) 0%, rgba(244, 130, 37, 0.3) 7.9%, rgba(244, 130, 37, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(244, 130, 37, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .s-badge.s-badge__moderator {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(217, 234, 247, 0) .9%, #d9eaf7 2.4%, rgba(217, 234, 247, 0.5) 5.8%, rgba(217, 234, 247, 0.1) 93%, rgba(217, 234, 247, 0.7) 96%, rgba(217, 234, 247, 0) 98%), linear-gradient(183deg, rgba(217, 234, 247, 0) 0%, rgba(217, 234, 247, 0.3) 7.9%, rgba(217, 234, 247, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(217, 234, 247, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .s-post-summary--stats-item.has-accepted-answer {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(72, 168, 104, 0) .9%, #48a868 2.4%, rgba(72, 168, 104, 0.5) 5.8%, rgba(72, 168, 104, 0.1) 93%, rgba(72, 168, 104, 0.7) 96%, rgba(72, 168, 104, 0) 98%), linear-gradient(183deg, rgba(72, 168, 104, 0) 0%, rgba(72, 168, 104, 0.3) 7.9%, rgba(72, 168, 104, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(72, 168, 104, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .s-post-summary.s-post-summary__watched {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(255, 255, 40, 0) .9%, #ffff28 2.4%, rgba(255, 255, 40, 0.5) 5.8%, rgba(255, 255, 40, 0.1) 93%, rgba(255, 255, 40, 0.7) 96%, rgba(255, 255, 40, 0) 98%), linear-gradient(183deg, rgba(255, 255, 40, 0) 0%, rgba(255, 255, 40, 0.3) 7.9%, rgba(255, 255, 40, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(255, 255, 40, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .s-post-summary.s-post-summary__deleted {
+    background-color: transparent
+}
+
+body.theme-custom.theme-topsecret .s-post-summary.s-post-summary__deleted .s-post-summary--stats-item.is-deleted {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(208, 57, 62, 0) .9%, #d0393e 2.4%, rgba(208, 57, 62, 0.5) 5.8%, rgba(208, 57, 62, 0.1) 93%, rgba(208, 57, 62, 0.7) 96%, rgba(208, 57, 62, 0) 98%), linear-gradient(183deg, rgba(208, 57, 62, 0) 0%, rgba(208, 57, 62, 0.3) 7.9%, rgba(208, 57, 62, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(208, 57, 62, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .nav-links .youarehere {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(255, 255, 40, 0) .9%, #ffff28 2.4%, rgba(255, 255, 40, 0.5) 5.8%, rgba(255, 255, 40, 0.1) 93%, rgba(255, 255, 40, 0.7) 96%, rgba(255, 255, 40, 0) 98%), linear-gradient(183deg, rgba(255, 255, 40, 0) 0%, rgba(255, 255, 40, 0.3) 7.9%, rgba(255, 255, 40, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(255, 255, 40, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .nav-links .youarehere .nav-links--link {
+    border: 0;
+    background: transparent
+}
+
+body.theme-custom.theme-topsecret .s-navigation--item.is-selected {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(244, 130, 37, 0) .9%, #f48225 2.4%, rgba(244, 130, 37, 0.5) 5.8%, rgba(244, 130, 37, 0.1) 93%, rgba(244, 130, 37, 0.7) 96%, rgba(244, 130, 37, 0) 98%), linear-gradient(183deg, rgba(244, 130, 37, 0) 0%, rgba(244, 130, 37, 0.3) 7.9%, rgba(244, 130, 37, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(244, 130, 37, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .s-btn-group .s-btn {
+    border-top: 0;
+    border-bottom: 0;
+    border-radius: 0
+}
+
+body.theme-custom.theme-topsecret .s-btn-group .is-selected {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(130, 255, 173, 0) .9%, #82ffad 2.4%, rgba(130, 255, 173, 0.5) 5.8%, rgba(130, 255, 173, 0.1) 93%, rgba(130, 255, 173, 0.7) 96%, rgba(130, 255, 173, 0) 98%), linear-gradient(183deg, rgba(130, 255, 173, 0) 0%, rgba(130, 255, 173, 0.3) 7.9%, rgba(130, 255, 173, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(130, 255, 173, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .subtabs a, body.theme-custom.theme-topsecret .filter a {
+    border: 0
+}
+
+body.theme-custom.theme-topsecret .subtabs a.youarehere, body.theme-custom.theme-topsecret .filter a.youarehere, body.theme-custom.theme-topsecret .subtabs a.active, body.theme-custom.theme-topsecret .filter a.active {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(244, 130, 37, 0) .9%, #f48225 2.4%, rgba(244, 130, 37, 0.5) 5.8%, rgba(244, 130, 37, 0.1) 93%, rgba(244, 130, 37, 0.7) 96%, rgba(244, 130, 37, 0) 98%), linear-gradient(183deg, rgba(244, 130, 37, 0) 0%, rgba(244, 130, 37, 0.3) 7.9%, rgba(244, 130, 37, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(244, 130, 37, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret .s-pagination {
+    border: 0
+}
+
+body.theme-custom.theme-topsecret .s-pagination .is-selected {
+    font-weight: bolder;
+    background: linear-gradient(104deg, rgba(244, 130, 37, 0) .9%, #f48225 2.4%, rgba(244, 130, 37, 0.5) 5.8%, rgba(244, 130, 37, 0.1) 93%, rgba(244, 130, 37, 0.7) 96%, rgba(244, 130, 37, 0) 98%), linear-gradient(183deg, rgba(244, 130, 37, 0) 0%, rgba(244, 130, 37, 0.3) 7.9%, rgba(244, 130, 37, 0) 15%);
+    -webkit-box-decoration-break: clone;
+    margin: 0;
+    border-radius: 7.5px;
+    text-shadow: -12px 12px 9.8px rgba(244, 130, 37, 0.7), 21px -18.1px 7.3px #fff, -18.1px -27.3px 30px #fff;
+    border-color: transparent;
+    color: var(--fc-dark)
+}
+
+body.theme-custom.theme-topsecret img, body.theme-custom.theme-topsecret svg:not(.s-avatar--badge) {
+    filter: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeColorMatrix type='matrix' values='-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='colormatrix'/%3E%3CfeGaussianBlur stdDeviation='0' x='0%25' y='0%25' width='100%25' height='100%25' in='colormatrix' edgeMode='none' result='blur'/%3E%3CfeBlend mode='color-dodge' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' in2='blur' result='blend'/%3E%3CfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='blend' result='colormatrix1'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeConvolveMatrix order='3 3' kernelMatrix='-1 -1 -1 -1 5 -1 -1 -1 -1' divisor='1' bias='1' targetX='0' targetY='0' edgeMode='duplicate' preserveAlpha='true' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='convolveMatrix'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") invert(0)
+}
+
+body.theme-custom.theme-topsecret [class*="gravatar-wrapper-"] img, body.theme-custom.theme-topsecret .s-avatar img, body.theme-custom.theme-topsecret .js-usermini-avatar-container img {
+    filter: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeColorMatrix type='matrix' values='-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='colormatrix'/%3E%3CfeGaussianBlur stdDeviation='20' x='0%25' y='0%25' width='100%25' height='100%25' in='colormatrix' edgeMode='none' result='blur'/%3E%3CfeBlend mode='color-dodge' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' in2='blur' result='blend'/%3E%3CfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='blend' result='colormatrix1'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeConvolveMatrix order='3 3' kernelMatrix='-1 -1 -1 -1 8 -1 -1 -1 -1' divisor='1' bias='1' targetX='0' targetY='0' edgeMode='duplicate' preserveAlpha='true' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='convolveMatrix'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") invert(0)
+}
+
+body.theme-custom.theme-topsecret [class*="user-gravatar"] span {
+    display: inline-block;
+    filter: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeColorMatrix type='matrix' values='-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='colormatrix'/%3E%3CfeGaussianBlur stdDeviation='20' x='0%25' y='0%25' width='100%25' height='100%25' in='colormatrix' edgeMode='none' result='blur'/%3E%3CfeBlend mode='color-dodge' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' in2='blur' result='blend'/%3E%3CfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='blend' result='colormatrix1'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeConvolveMatrix order='3 3' kernelMatrix='-1 -1 -1 -1 8 -1 -1 -1 -1' divisor='1' bias='1' targetX='0' targetY='0' edgeMode='duplicate' preserveAlpha='true' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='convolveMatrix'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") invert(0)
+}
+
+body.theme-custom.theme-topsecret .s-sidebarwidget:first-child {
+    transform: rotate(.1deg)
+}
+
+body.theme-custom.theme-topsecret .s-sidebarwidget:nth-child(2) {
+    transform: rotate(-0.3deg)
+}
+
+body.theme-custom.theme-topsecret .af-bar {
+    background-color: white !important;
+    color: var(--fc-dark) !important;
+    box-shadow: var(--bs-lg);
+    border: 1px solid var(--bc-dark)
+}
+
+body.theme-custom.theme-topsecret .af-bar svg, body.theme-custom.theme-topsecret .af-bar img:not(.af-logo-img) {
+    filter: none !important
+}
+
+body.theme-custom.theme-topsecret .af-bar .af-logo-img {
+    filter: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeColorMatrix type='matrix' values='-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='colormatrix'/%3E%3CfeGaussianBlur stdDeviation='20' x='0%25' y='0%25' width='100%25' height='100%25' in='colormatrix' edgeMode='none' result='blur'/%3E%3CfeBlend mode='color-dodge' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' in2='blur' result='blend'/%3E%3CfeColorMatrix type='saturate' values='0' x='0%25' y='0%25' width='100%25' height='100%25' in='blend' result='colormatrix1'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cdefs%3E%3Cfilter id='filter' x='-20%25' y='-20%25' width='140%25' height='140%25' filterUnits='objectBoundingBox' primitiveUnits='userSpaceOnUse' color-interpolation-filters='sRGB'%3E%3CfeConvolveMatrix order='3 3' kernelMatrix='-1 -1 -1 -1 8 -1 -1 -1 -1' divisor='1' bias='1' targetX='0' targetY='0' edgeMode='duplicate' preserveAlpha='true' x='0%25' y='0%25' width='100%25' height='100%25' in='SourceGraphic' result='convolveMatrix'/%3E%3C/filter%3E%3C/defs%3E%3C/svg%3E#filter") invert(1)
+}
+
+body.theme-custom.theme-topsecret .af-bar .af-theme-button {
+    --af-btn-outline-color: var(--bc-dark);
+    --af-btn-selected-outline-color: var(--theme-primary-color);
+    background: white !important
+}
+
+body.theme-custom.theme-frisa {
+    --theme-base-primary-color-h: 25;
+    --theme-base-primary-color-s: 69.3%;
+    --theme-base-primary-color-l: 55.3%;
+    --theme-base-primary-color-r: 220;
+    --theme-base-primary-color-g: 128;
+    --theme-base-primary-color-b: 62;
+    --theme-base-secondary-color-h: 339;
+    --theme-base-secondary-color-s: 63.2%;
+    --theme-base-secondary-color-l: 54.1%;
+    --theme-base-secondary-color-r: 212;
+    --theme-base-secondary-color-g: 64;
+    --theme-base-secondary-color-b: 115;
+    --theme-wintergreen: #4fad80;
+    --theme-light-purplish: #706fae;
+    --theme-dark-purplish: #454690;
+    --theme-button-active-background-color: var(--theme-button-filled-background-color);
+    --theme-button-color: var(--theme-button-filled-background-color);
+    --theme-button-hover-background-color: var(--theme-link-color);
+    --theme-button-hover-color: var(--theme-button-filled-color);
+    --theme-button-selected-background-color: var(--theme-button-filled-background-color);
+    --theme-button-selected-color: var(--theme-button-filled-selected-color);
+    --theme-button-filled-active-background-color: var(--theme-button-filled-background-color);
+    --theme-button-filled-active-border-color: var(--theme-button-filled-background-color);
+    --theme-button-filled-background-color: #88bf56;
+    --theme-button-filled-border-color: var(--theme-button-filled-background-color);
+    --theme-button-filled-color: var(--theme-button-filled-color);
+    --theme-button-filled-hover-background-color: var(--theme-link-color);
+    --theme-button-filled-hover-color: var(--theme-button-filled-color);
+    --theme-button-filled-selected-background-color: var(--theme-button-filled-background-color);
+    --theme-button-filled-selected-border-color: var(--theme-button-filled-background-color);
+    --theme-button-filled-selected-color: #50ab58;
+    --theme-button-outlined-border-color: var(--theme-button-filled-background-color);
+    --theme-button-outlined-selected-border-color: var(--theme-button-filled-background-color);
+    --theme-button-primary-active-background-color: var(--theme-secondary-color);
+    --theme-button-primary-background-color: var(--theme-secondary-color);
+    --theme-button-primary-hover-background-color: var(--theme-light-purplish);
+    --theme-button-primary-number-color: var(--theme-button-filled-color);
+    --theme-button-primary-selected-background-color: var(--theme-secondary-color);
+    --theme-content-background-color: #ffffff;
+    --theme-content-border-color: #ffffff;
+    --theme-footer-background-color: var(--theme-dark-purplish);
+    --theme-footer-divider-color: var(--theme-dark-purplish);
+    --theme-footer-link-caret-color: var(--theme-dark-purplish);
+    --theme-footer-link-color: #ffffff;
+    --theme-footer-link-color-hover: #e0ec77;
+    --theme-footer-text-color: #ababab;
+    --theme-footer-title-color: #be87bd;
+    --theme-link-color: #439ad5;
+    --theme-link-color-hover: #4fb1a8;
+    --theme-link-color-visited: #3969b6;
+    --theme-header-background-color: var(--theme-secondary-color);
+    --theme-header-link-color: #ffffff;
+    --theme-post-owner-background-color: var(--theme-footer-link-color-hover);
+    --theme-post-owner-new-background-color: var(--theme-footer-link-color-hover);
+    --theme-question-title-color: #e16b56;
+    --theme-question-title-color-hover: var(--theme-secondary-color);
+    --theme-question-title-color-visited: var(--theme-dark-purplish);
+    --theme-tag-background-color: var(--theme-light-purplish);
+    --theme-tag-border-color: var(--theme-light-purplish);
+    --theme-tag-color: #ffffff;
+    --theme-tag-hover-background-color: var(--theme-wintergreen);
+    --theme-tag-hover-border-color: var(--theme-wintergreen);
+    --theme-tag-hover-color: #ffffff;
+    --theme-background-color: var(--theme-link-color);
+    --theme-background-size: 50% auto, cover;
+    --theme-background-repeat: repeat, no-repeat;
+    --theme-background-attachment: fixed;
+    --theme-background-position: 0 0;
+    --theme-topbar-accent-border: none;
+    --theme-topbar-background-color: #ffffff;
+    --theme-topbar-item-background-hover: var(--theme-secondary-color);
+    --theme-topbar-item-border-current: var(--theme-secondary-color);
+    --theme-topbar-item-color: var(--theme-secondary-color);
+    --theme-topbar-item-color-current: #ffffff;
+    --theme-topbar-item-color-hover: #ffffff;
+    --theme-topbar-search-border-focus: var(--theme-secondary-color);
+    font-family: 'Nunito', sans-serif;
+    font-size: 15px;
+    background-image: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/frisa-bg.png?v=3d424b05383e"), linear-gradient(135deg, #f5e256 0%, #dc803e 33%, #d44073 66%, #454690 100%)
+}
+
+body.theme-custom.theme-frisa .s-topbar {
+    padding-top: 4px
+}
+
+body.theme-custom.theme-frisa .s-topbar::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background: linear-gradient(90deg, #f5e256 0%, #dc803e 33%, #d44073 66%, #454690 100%)
+}
+
+body.theme-custom.theme-frisa .s-topbar .s-topbar--logo:hover .-img._glyph {
+    filter: invert(.5) brightness(2)
+}
+
+body.theme-custom.theme-frisa .container {
+    max-width: 1312px
+}
+
+html.html__unpinned-leftnav body.theme-custom.theme-frisa .container {
+    max-width: 1148px
+}
+
+body.theme-custom.theme-frisa .s-topbar .s-topbar--container {
+    width: 1312px
+}
+
+body.theme-custom.theme-frisa #content {
+    margin: 24px;
+    border-radius: 16px
+}
+
+body.theme-custom.theme-frisa .nav-links .fc-black-500 {
+    color: #fff !important
+}
+
+body.theme-custom.theme-frisa .nav-links .nav-links--link, body.theme-custom.theme-frisa .nav-links .nav-links--link:visited {
+    border-radius: 20px;
+    margin: 8px 0;
+    color: #ffffff;
+    background: rgba(212, 64, 115, 0.4)
+}
+
+body.theme-custom.theme-frisa .nav-links .youarehere .nav-links--link {
+    background: #fff;
+    color: var(--theme-secondary-color);
+    border-right: none
+}
+
+body.theme-custom.theme-frisa .nav-links .nav-links--link.-link__with-icon .svg-icon, body.theme-custom.theme-frisa .nav-links .nav-links--link:hover .svg-icon {
+    color: #fff !important
+}
+
+body.theme-custom.theme-frisa .nav-links .nav-links--link:hover {
+    color: #fff;
+    background: var(--theme-secondary-color)
+}
+
+body.theme-custom.theme-frisa .nav-links .youarehere .nav-links--link .svg-icon {
+    color: currentColor !important
+}
+
+body.theme-custom.theme-frisa .nav-links .fs-fine {
+    color: #ffffff !important;
+    text-shadow: 1px 1px 1px var(--theme-dark-purplish);
+    font-weight: bold
+}
+
+body.theme-custom.theme-frisa .s-btn__filled:hover, body.theme-custom.theme-frisa .s-btn__filled:focus, body.theme-custom.theme-frisa .s-btn__filled:active {
+    border-color: #439AD5
+}
+
+body.theme-custom.theme-frisa .s-btn {
+    border-radius: 20px
+}
+
+body.theme-custom.theme-frisa .s-input, body.theme-custom.theme-frisa .s-textarea {
+    border-radius: 8px
+}
+
+body.theme-custom.theme-frisa .owner {
+    border-radius: 8px
+}
+
+body.theme-custom.theme-frisa .gravatar-wrapper-24 {
+    border-radius: 12px
+}
+
+body.theme-custom.theme-frisa .post-tag, body.theme-custom.theme-frisa .s-tag {
+    border-radius: 6px
+}
+
+body.theme-custom.theme-frisa .s-sidebarwidget {
+    border-radius: 12px;
+    box-shadow: none;
+    overflow: hidden
+}
+
+body.theme-custom.theme-frisa .s-sidebarwidget--header:first-child {
+    border-top: none
+}
+
+body.theme-custom.theme-frisa .s-post-summary {
+    padding: 24px 16px
+}
+
+body.theme-custom.theme-frisa .s-post-summary--content .s-post-summary--content-title, body.theme-custom.theme-frisa .s-post-summary--content .s-post-summary--content-title .s-link {
+    font-weight: bold
+}
+
+body.theme-custom.theme-frisa .s-post-summary--stats {
+    margin-right: 12px
+}
+
+body.theme-custom.theme-frisa .s-post-summary--stats .s-post-summary--stats-item.has-answers {
+    color: var(--theme-wintergreen);
+    border-color: var(--theme-wintergreen);
+    border-radius: 6px;
+    padding: 4px 8px
+}
+
+body.theme-custom.theme-frisa .s-post-summary--stats .s-post-summary--stats-item.has-answers.has-accepted-answer {
+    background-color: var(--theme-wintergreen);
+    color: #ffffff
+}
+
+body.theme-custom.theme-frisa .js-freemium-cta>div:last-child {
+    background-color: var(--white)
+}
+
+body.theme-custom.theme-frisa .af-bar__big {
+    background: var(--theme-footer-background-color) !important
+}
+
+body.theme-custom.theme-plumber {
+    --sky: #8b7fff;
+    --brick: #8c3300;
+    --brick-hit: #4e0d00;
+    --pipe: #2b8000;
+    --item-block: #c89d02;
+    --bar-height: 60px;
+    --theme-base-primary-color-h: 99.84375;
+    --theme-base-primary-color-s: 100%;
+    --theme-base-primary-color-l: 25.09803922%;
+    --theme-base-primary-color-r: 43;
+    --theme-base-primary-color-g: 128;
+    --theme-base-primary-color-b: 0;
+    --theme-base-secondary-color-h: 21.85714286;
+    --theme-base-secondary-color-s: 100%;
+    --theme-base-secondary-color-l: 27.45098039%;
+    --theme-base-secondary-color-r: 140;
+    --theme-base-secondary-color-g: 51;
+    --theme-base-secondary-color-b: 0;
+    --theme-background-color: var(--sky);
+    --theme-content-background-color: rgba(255, 255, 255, 0.9);
+    --theme-button-primary-background-color: var(--item-block);
+    --theme-button-primary-hover-background-color: var(--brick-hit);
+    --theme-topbar-background-color: var(--sky);
+    --theme-topbar-item-color: var(--white);
+    --theme-topbar-item-color-hover: var(--black);
+    background: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/cloud.svg?v=817468d1c875") -2% 110px/118px auto no-repeat, url("https://cdn.sstatic.net/Img/april-fools-2022/assets/cloud.svg?v=817468d1c875") 6% 260px/118px auto no-repeat, url("https://cdn.sstatic.net/Img/april-fools-2022/assets/cloud.svg?v=817468d1c875") 101% 220px/118px auto no-repeat, url("https://cdn.sstatic.net/Img/april-fools-2022/assets/cloud.svg?v=817468d1c875") 90% 110px/118px auto no-repeat, url("https://cdn.sstatic.net/Img/april-fools-2022/assets/blocks-left.svg?v=e515c1d7c7d9") 0 calc(100% - var(--bar-height))/15% auto no-repeat, url("https://cdn.sstatic.net/Img/april-fools-2022/assets/blocks-right.svg?v=ff2a999b5c52") 100% calc(100% - var(--bar-height))/15% auto no-repeat, var(--theme-background-color);
+    background-attachment: fixed
+}
+
+body.theme-custom.theme-plumber * {
+    -webkit-font-smoothing: none;
+    image-rendering: pixelated
+}
+
+body.theme-custom.theme-plumber .s-topbar .s-user-card .-badges, body.theme-custom.theme-plumber .s-topbar--item .-badges * {
+    color: inherit !important
+}
+
+body.theme-custom.theme-plumber .s-topbar--logo .-img._glyph {
+    filter: invert(.5) brightness(2)
+}
+
+body.theme-custom.theme-plumber .s-topbar--logo:hover .-img._glyph {
+    filter: invert(.5) brightness(0)
+}
+
+body.theme-custom.theme-plumber .s-btn__primary::before, body.theme-custom.theme-plumber .s-btn__filled::before {
+    content: "";
+    width: 48px;
+    height: 48px;
+    border-radius: 100%;
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    background: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/coin.png?v=ca0d5083f7c7") no-repeat;
+    background-size: contain;
+    image-rendering: pixelated
+}
+
+body.theme-custom.theme-plumber .s-btn__primary:hover::before, body.theme-custom.theme-plumber .s-btn__filled:hover::before {
+    bottom: calc(100% + 4px);
+    top: auto;
+    display: block
+}
+
+body.theme-custom.theme-plumber #left-sidebar {
+    background: var(--theme-content-background-color)
+}
+
+body.theme-custom.theme-plumber .nav-links .nav-links--link, body.theme-custom.theme-plumber .nav-links .nav-links--link:visited {
+    color: var(--fc-medium)
+}
+
+body.theme-custom.theme-plumber .af-bar__big {
+    background: url("https://cdn.sstatic.net/Img/april-fools-2022/assets/brick.png?v=fed5f69efacc") repeat !important;
+    border: 0 !important;
+    height: var(--bar-height)
+}
+
+body.theme-custom.theme-plumber .af-bar__big .af-author-container, body.theme-custom.theme-plumber .af-bar__big .af-logo-container, body.theme-custom.theme-plumber .af-bar__big .af-minimize-bar-container {
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 2px
+}
+
+body.theme-custom.theme-bookface {
+    --theme-base-primary-color-h: 221;
+    --theme-base-primary-color-s: 42.3%;
+    --theme-base-primary-color-l: 30.6%;
+    --theme-base-primary-color-r: 45;
+    --theme-base-primary-color-g: 66;
+    --theme-base-primary-color-b: 111;
+    --theme-background-color: #eaebef;
+    --theme-button-primary-background-color: #4e629d;
+    --theme-footer-background-color: var(--theme-primary-color);
+    --theme-footer-link-color: #cad6e2;
+    --theme-footer-link-color-hover: #ffffff;
+    --theme-footer-text-color: #cad6e2;
+    --theme-footer-title-color: #a4ccf4;
+    --theme-header-background-color: var(--theme-primary-color);
+    --theme-header-link-color: var(--theme-primary-color);
+    --theme-post-owner-background-color: #eeedf2;
+    --theme-topbar-background-color: #3b5999;
+    --theme-topbar-item-background-hover: var(--theme-primary-color);
+    --theme-topbar-item-color: #1c3163;
+    --theme-topbar-item-color-hover: #a8bcee;
+    --theme-tag-background-color: #eeedf2
+}
+
+body.theme-custom.theme-bookface .s-topbar .s-user-card, body.theme-custom.theme-bookface .s-topbar .s-navigation .s-navigation--item {
+    color: #fff
+}
+
+body.theme-custom.theme-bookface .s-topbar--logo .-img {
+    filter: invert(.5) brightness(2)
+}
+
+body.theme-custom.theme-bookface .user-details a {
+    color: #4a6cbd;
+    font-weight: bold
+}
+
+body.theme-custom.theme-bookface .js-voting-container {
+    color: #6b7179 !important
+}
+
+body.theme-custom.theme-bookface .af-bar {
+    background: var(--theme-footer-background-color) !important;
+    background-color: var(--black-800)
+}
+
+body.theme-custom.theme-bookface .af-theme-button {
+    --af-btn-focus-outline-color: var(--white)
+}
+
+body.theme-custom.theme-3d {
+    --theme-topbar-background-color: var(--theme-background-color);
+    --theme-topbar-accent-border: none;
+    --theme-topbar-item-color-hover: black
+}
+
+body.theme-custom.theme-3d img.s-avatar--image, body.theme-custom.theme-3d .gravatar-wrapper-24, body.theme-custom.theme-3d img {
+    filter: grayscale(80%) brightness(1.75) drop-shadow(4px 0 0 red) drop-shadow(-4px 0 0 cyan) !important;
+    opacity: .75
+}
+
+body.theme-custom.theme-3d svg, body.theme-custom.theme-3d .icon-bg, body.theme-custom.theme-3d .wmd-button, body.theme-custom.theme-3d input[type=radio], body.theme-custom.theme-3d input[type=checkbox] {
+    filter: grayscale(80%) saturate(.1) drop-shadow(-4px 0 0 cyan) drop-shadow(4px 0 0 red)
+}
+
+body.theme-custom.theme-3d h1, body.theme-custom.theme-3d h2, body.theme-custom.theme-3d h3, body.theme-custom.theme-3d h4, body.theme-custom.theme-3d h5, body.theme-custom.theme-3d h6, body.theme-custom.theme-3d p, body.theme-custom.theme-3d a, body.theme-custom.theme-3d li, body.theme-custom.theme-3d span, body.theme-custom.theme-3d label, body.theme-custom.theme-3d button, body.theme-custom.theme-3d div, body.theme-custom.theme-3d input, body.theme-custom.theme-3d select, body.theme-custom.theme-3d textarea, body.theme-custom.theme-3d ::before, body.theme-custom.theme-3d ::after {
+    text-overflow: clip;
+    letter-spacing: 3px;
+    text-shadow: -3px 0 1px cyan, 3px 0 1px red
+}
+
+body.theme-custom.theme-3d .s-topbar--logo .-img._glyph, body.theme-custom.theme-3d .site-footer--logo a {
+    filter: grayscale(80%) saturate(.1) drop-shadow(4px 0 0 red) drop-shadow(-4px 0 0 cyan);
+    opacity: .75
+}
+
+body.theme-custom.theme-3d .s-topbar--logo:hover {
+    background-color: transparent
+}
+
+body.theme-custom.theme-3d .s-topbar--logo:hover .-img._glyph {
+    opacity: 1
+}
+
+body.theme-custom.theme-3d .site-footer--logo svg {
+    filter: drop-shadow(-4px 0 0 cyan)
+}
+
+body.theme-custom.theme-3d .nav-links span, body.theme-custom.theme-3d .nav-links div, body.theme-custom.theme-3d .nav-links a, body.theme-custom.theme-3d .post-signature *, body.theme-custom.theme-3d .mdhelp-tabs * {
+    letter-spacing: 0 !important
+}
+
+body.theme-custom.theme-3d .af-bar * {
+    filter: none !important;
+    text-shadow: none !important;
+    letter-spacing: initial !important;
+    opacity: 1
+}
+
+body.theme-custom.theme-3d .js-zone-container, body.theme-custom.theme-3d #hireme, body.theme-custom.theme-3d .mixed-site-content, body.theme-custom.theme-3d .js-consent-banner, body.theme-custom.theme-3d #onetrust-banner-sdk, body.theme-custom.theme-3d .js-zone-container *, body.theme-custom.theme-3d #hireme *, body.theme-custom.theme-3d .mixed-site-content *, body.theme-custom.theme-3d .js-consent-banner *, body.theme-custom.theme-3d #onetrust-banner-sdk * {
+    filter: none !important;
+    text-shadow: none !important;
+    letter-spacing: initial !important;
+    opacity: 1
+}
+
+.vote-up-off, .vote-up-on, .vote-down-off, .vote-down-on {
+    height: 30px
+}
+
+.vote-down-off, .vote-down-on {
+    margin-bottom: 10px
+}
+
+.s-topbar .s-topbar--logo .-img {
+    background-image: url("https://cdn.sstatic.net/Img/unified/sprites.svg?v=fcc0ea44ba27")
+}
+
+#tabs a, .tabs a {
+    position: relative;
+    padding: 13px 10px;
+    background-color: var(--theme-content-background-color);
+    border: 1px solid transparent;
+    font-size: 12px
+}
+
+#tabs a:before, .tabs a:before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    height: 2px;
+    background-color: transparent
+}
+
+#tabs a:focus, .tabs a:focus {
+    background-color: var(--black-025);
+    border-bottom-color: transparent
+}
+
+#tabs a:hover:not(.youarehere), .tabs a:hover:not(.youarehere), #tabs a:focus:not(.youarehere), .tabs a:focus:not(.youarehere) {
+    border-color: var(--black-075);
+    border-bottom-color: transparent
+}
+
+#tabs a.youarehere, .tabs a.youarehere {
+    padding-bottom: 14px;
+    font-weight: 400;
+    border-color: var(--black-075);
+    border-bottom-color: transparent;
+    cursor: default
+}
+
+#tabs a.youarehere:before, .tabs a.youarehere:before {
+    background-color: var(--theme-primary-color)
+}
+
+#tabs a.external, .tabs a.external {
+    color: var(--theme-link-color)
+}
+
+#tabs a.external:hover, .tabs a.external:hover {
+    color: var(--theme-link-color-hover);
+    border-color: transparent;
+    border-bottom-color: var(--theme-primary-color);
+    background-color: hsl(180, 7%, 97%);
+    box-shadow: inset 0 -1px 0 0 hsl(0, 0%, 100%)
+}
+
+#tabs #tab-switch {
+    display: inline-block;
+    color: hsl(210, 8%, 45%);
+    border: 1px solid hsl(210, 8%, 85%);
+    font-size: 12px;
+    padding: 3px 6px;
+    border-radius: 2px;
+    margin: 7px auto 5px 5px;
+    background-color: transparent;
+    transition: all, .15s, ease
+}
+
+#tabs #tab-switch:hover {
+    border-color: #bdcdd7
+}
+
+#sidebar h4 {
+    color: var(--black-700);
+    font-size: 1.46153846rem;
+    font-weight: 400
+}
+
+#sidebar .related, #sidebar .linked {
+    font-size: 13px
+}
+
+#sidebar .related a, #sidebar .linked a {
+    font-size: 13px
+}
+
+#sidebar .aside-cta {
+    margin-bottom: 1em;
+    text-align: right
+}
+
+#sidebar #questions-count {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between
+}
+
+#sidebar #questions-count .-main-cta {
+    padding-left: 20px
+}
+
+#sidebar #questions-count .-main-cta .btn {
+    white-space: nowrap
+}
+
+.post-tag, .geo-tag, .container .chosen-choices .search-choice, .container .chosen-container-multi .chosen-choices li.search-choice {
+    font-size: 12px
+}
+
+.-flair>span:not(.reputation-score) {
+    margin-right: 3px;
+    margin-left: 2px
+}
+
+.badge {
+    transition: background .1s ease
+}
+
+.badge1, .badge2, .badge3 {
+    margin-right: 3px;
+    margin-left: 2px;
+    width: 6px
+}
+
+.badge1 {
+    background-position: -102px -398px
+}
+
+.badge2 {
+    background-position: -82px -398px
+}
+
+.badge3 {
+    background-position: -62px -398px
+}
+
+.badgecount {
+    padding-left: 0
+}
+
+body:not(.unified-theme) .narrow .mini-counts {
+    margin-bottom: 2px
+}
+
+body:not(.unified-theme) .narrow .votes, body:not(.unified-theme) .narrow .status, body:not(.unified-theme) .narrow .views {
+    padding: 8px 5px;
+    line-height: 1
+}
+
+.narrow .status {
+    color: var(--black-400)
+}
+
+.answered, .answered-accepted {
+    border: 1px solid transparent
+}
+
+.status.answered {
+    border-color: var(--green-400)
+}
+
+.status.answered, .status.answered .mini-counts, .status.answered strong {
+    color: var(--green-500)
+}
+
+.status.answered-accepted, .status.answered-accepted .mini-counts, .status.answered-accepted .minicounts span {
+    color: hsl(0, 0%, 100%)
+}
+
+.status.unanswered .mini-counts span {
+    color: inherit
+}
+
+body:not(.unified-theme) .question-summary {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--black-075)
+}
+
+#question-header {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between
+}
+
+#question-header .-main-cta {
+    padding-left: 20px
+}
+
+#question-header .-main-cta .btn {
+    white-space: nowrap
+}
+
+#question-header .question-hyperlink {
+    color: var(--black-700)
+}
+
+.comment-text, .flag-action-card-text {
+    font-size: 13px;
+    line-height: 1.4
+}
+
+input[type="text"]:not(.s-input):not(.s-textarea):focus, input[type="email"]:not(.s-input):not(.s-textarea):focus, input[type="password"]:not(.s-input):not(.s-textarea):focus, textarea:not(.s-input):not(.s-textarea):focus {
+    outline: 0;
+    border: 1px solid hsl(206, 90%, 69.5%)
+}
+
+input[type="text"]:not(.s-input), textarea:not(.wmd-input):not(.s-textarea), input[type="url"], input[type="datetime"], input[type="datetime-local"], input[type="date"], .tag-editor:not(.s-input) {
+    box-shadow: 0 1px 2px hsla(210, 8%, 5%, 0.1) inset
+}
+
+.error-page h1 {
+    margin-bottom: 24px
+}
+
+.error-page p {
+    font-size: 1.15384615rem
+}
+
+html, body {
+    min-width: 1264px
+}
+
+html.html__unpinned-leftnav, html.html__unpinned-leftnav body {
+    min-width: 1100px
+}
+
+html.html__responsive, html.html__responsive body {
+    min-width: auto
+}
+
+body {
+    padding-top: 50px
+}
+
+@media print {
+    body {
+        padding-top: 0px
+    }
+}
+
+body .s-topbar~.container, body .s-topbar~#announcement-banner {
+    margin-top: 0
+}
+
+body>.container {
+    max-width: 1264px;
+    width: 100%;
+    background: none;
+    display: flex;
+    justify-content: space-between;
+    margin: 0 auto
+}
+
+html.html__unpinned-leftnav body>.container {
+    max-width: 1100px
+}
+
+body>.container:after, body>.container:before {
+    display: none
+}
+
+body.floating-content>.container {
+    justify-content: center;
+    margin: 0;
+    background-color: var(--black-050)
+}
+
+body.floating-content>.container, html.html__unpinned-leftnav body.floating-content>.container {
+    max-width: 100%
+}
+
+body.floating-content>.container #left-sidebar {
+    display: none
+}
+
+#content {
+    max-width: 1100px;
+    width: calc(100% - 164px);
+    background-color: var(--theme-content-background-color);
+    border-radius: 0;
+    border: 1px solid var(--theme-content-border-color);
+    border-top-width: 0;
+    border-bottom-width: 0;
+    border-left-width: 1px;
+    border-right-width: 0;
+    padding: 24px;
+    box-sizing: border-box
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive #content {
+        border-left: 0;
+        border-right: 0
+    }
+}
+
+@media print {
+    #content {
+        border-left: 0;
+        border-right: 0
+    }
+}
+
+body.theme-highcontrast #content {
+    border-left: 1px solid currentColor
+}
+
+html.html__unpinned-leftnav #content {
+    width: 100%
+}
+
+html.html__unpinned-leftnav #content {
+    border-left-width: 0
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) #content {
+        padding-left: 16px;
+        padding-right: 16px
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav #content {
+        padding-left: 16px;
+        padding-right: 16px
+    }
+}
+
+@media print {
+    #content {
+        padding-left: 16px;
+        padding-right: 16px
+    }
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive #content {
+        padding-left: 12px;
+        padding-right: 12px;
+        width: 100%
+    }
+}
+
+@media print {
+    #content {
+        padding-left: 12px;
+        padding-right: 12px;
+        width: 100%
+    }
+}
+
+body.floating-content #content {
+    width: 100%;
+    max-width: 1264px;
+    margin: 0;
+    background-color: transparent;
+    border-left: 0;
+    border-right: 0
+}
+
+#sidebar, .sidebar {
+    margin-left: 24px
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) #sidebar, html.html__responsive:not(.html__unpinned-leftnav) .sidebar {
+        float: none;
+        clear: both;
+        margin: 0 auto;
+        width: 100%
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav #sidebar, html.html__responsive.html__unpinned-leftnav .sidebar {
+        float: none;
+        clear: both;
+        margin: 0 auto;
+        width: 100%
+    }
+}
+
+@media print {
+    #sidebar, .sidebar {
+        float: none;
+        clear: both;
+        margin: 0 auto;
+        width: 100%
+    }
+}
+
+.site-footer.site-footer--container, .site-footer.site-footer--extra {
+    max-width: 1264px
+}
+
+body>.container.container__full {
+    max-width: 100%
+}
+
+body>.container.container__full .left-sidebar {
+    display: none
+}
+
+body>.container.container__full #content {
+    padding: 0;
+    max-width: 100%
+}
+
+body>.container .container--inner {
+    max-width: 1264px;
+    padding: 0 24px;
+    margin: 0 auto
+}
+
+#mainbar, .mainbar {
+    width: calc(100% - 300px - 24px)
+}
+
+#mainbar.ask-mainbar, .mainbar.ask-mainbar {
+    width: calc(100% - 365px - 24px)
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) #mainbar, html.html__responsive:not(.html__unpinned-leftnav) .mainbar {
+        width: 100%;
+        float: none
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav #mainbar, html.html__responsive.html__unpinned-leftnav .mainbar {
+        width: 100%;
+        float: none
+    }
+}
+
+@media print {
+    #mainbar, .mainbar {
+        width: 100%;
+        float: none
+    }
+}
+
+#questions, #answers {
+    width: auto;
+    float: none
+}
+
+.answer, .post-editor, #answers-header {
+    width: 100%
+}
+
+.subheader {
+    box-sizing: content-box
+}
+
+.site-header {
+    box-sizing: border-box;
+    background-color: var(--theme-header-background-color);
+    background-image: none;
+    background-position: var(--theme-header-background-position);
+    background-repeat: var(--theme-header-background-repeat);
+    background-size: var(--theme-header-background-size);
+    border-bottom: var(--theme-header-background-border-bottom)
+}
+
+.site-header .site-header--container {
+    width: 100%;
+    min-height: 70px;
+    max-width: 1264px;
+    margin: 0 auto;
+    padding: 0 8px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: var(--theme-header-foreground-color);
+    background-image: none;
+    background-position: var(--theme-header-foreground-position);
+    background-repeat: var(--theme-header-foreground-repeat);
+    background-size: var(--theme-header-foreground-size)
+}
+
+html.html__unpinned-leftnav .site-header .site-header--container {
+    max-width: 1100px
+}
+
+body.floating-content .site-header .site-header--container, html.html__unpinned-leftnav body.floating-content .site-header .site-header--container {
+    max-width: 1264px
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .site-header .site-header--container {
+        background-image: none
+    }
+}
+
+@media print {
+    .site-header .site-header--container {
+        background-image: none
+    }
+}
+
+.site-header .site-header--link {
+    color: var(--theme-header-link-color)
+}
+
+.site-header .site-header--sponsored {
+    color: var(--theme-header-sponsored-color);
+    font-size: 10px
+}
+
+.s-banner button, .s-banner a {
+    text-decoration: underline
+}
+
+.s-banner button:hover, .s-banner a:hover {
+    text-decoration: underline
+}
+
+.s-banner__danger button, .s-banner__danger a {
+    color: white
+}
+
+.s-banner__danger button:hover, .s-banner__danger a:hover {
+    color: white
+}
+
+.left-sidebar {
+    width: 164px;
+    flex-shrink: 0;
+    z-index: 1000;
+    box-shadow: 0 0 0 hsla(210, 8%, 5%, 0.05);
+    transition: box-shadow ease-in-out .1s, transform ease-in-out .1s;
+    transform: translateZ(0)
+}
+
+.left-sidebar, .left-sidebar *, .left-sidebar *:after, .left-sidebar *:before {
+    box-sizing: border-box
+}
+
+.left-sidebar .nav {
+    position: sticky;
+    position: -webkit-sticky;
+    position: -moz-sticky;
+    top: 24px;
+    padding-bottom: 12px
+}
+
+.left-sidebar .-label {
+    font-weight: bold;
+    padding-left: 12px;
+    color: var(--black-400);
+    padding-bottom: 4px;
+    font-size: 12px
+}
+
+.left-sidebar--sticky-container {
+    position: fixed;
+    width: 164px;
+    padding-top: 24px
+}
+
+@supports (position: sticky) or (position: -webkit-sticky) {
+    .left-sidebar--sticky-container:not(.left-sidebar__fake-sticky) {
+        position: -webkit-sticky;
+        position: sticky;
+        width: auto;
+        top: 0;
+        margin-bottom: 8px;
+        max-height: calc(100vh);
+        overflow-y: auto;
+        scrollbar-color: var(--scrollbar) transparent;
+        top: var(--top-bar-allocated-space);
+        max-height: calc(100vh - var(--top-bar-allocated-space))
+    }
+
+    .left-sidebar--sticky-container:not(.left-sidebar__fake-sticky)::-webkit-scrollbar {
+        width: 10px;
+        height: 10px;
+        background-color: transparent
+    }
+
+    .left-sidebar--sticky-container:not(.left-sidebar__fake-sticky)::-webkit-scrollbar-track {
+        border-radius: 10px;
+        background-color: transparent
+    }
+
+    .left-sidebar--sticky-container:not(.left-sidebar__fake-sticky)::-webkit-scrollbar-thumb {
+        border-radius: 10px;
+        background-color: var(--scrollbar)
+    }
+
+    .left-sidebar--sticky-container:not(.left-sidebar__fake-sticky)::-webkit-scrollbar-corner {
+        background-color: transparent;
+        border-color: transparent
+    }
+
+    html.html__unpinned-leftnav .left-sidebar--sticky-container:not(.left-sidebar__fake-sticky) {
+        max-height: calc(100vh - 50px)
+    }
+}
+
+.leftnav-dialog .left-sidebar--sticky-container {
+    position: static;
+    width: auto
+}
+
+html.html__unpinned-leftnav .container .left-sidebar {
+    display: none
+}
+
+.activity-indicator {
+    width: 10px;
+    height: 10px
+}
+
+.nav-links {
+    padding: 0;
+    margin: 0 0 12px;
+    list-style: none
+}
+
+.nav-links .nav-links--link {
+    display: block;
+    padding: 4px;
+    padding-left: 30px;
+    line-height: 2;
+    font-size: 13px
+}
+
+.nav-links .nav-links--link, .nav-links .nav-links--link:visited {
+    color: var(--black-600)
+}
+
+.nav-links .nav-links--link:hover, .nav-links .nav-links--link:focus, .nav-links .nav-links--link:active {
+    color: var(--black-900)
+}
+
+.nav-links .nav-links--link.-link__with-icon {
+    display: flex;
+    padding: 8px 6px 8px 0
+}
+
+.nav-links .nav-links--link.-link__with-icon .svg-icon {
+    flex-shrink: 0;
+    margin-top: -1px;
+    margin-right: 4px;
+    color: var(--black-400)
+}
+
+.nav-links .nav-links--link.-link__with-icon:hover .svg-icon, .nav-links .nav-links--link.-link__with-icon:focus .svg-icon, .nav-links .nav-links--link.-link__with-icon:active .svg-icon {
+    color: var(--black-900)
+}
+
+.nav-links .nav-links--link .-link--channel-name {
+    line-height: 1.30769231
+}
+
+.nav-links .youarehere .nav-links--link {
+    font-weight: bold;
+    background: var(--black-050);
+    color: var(--black-900);
+    border-right: 3px solid var(--theme-primary-color)
+}
+
+.nav-links .youarehere .nav-links--link .svg-icon {
+    color: var(--black-900)
+}
+
+.left-sidebar-improvements .nav-links .nav-links--link {
+    padding-left: 30px
+}
+
+.left-sidebar-toggle {
+    display: none;
+    padding-top: 3px;
+    height: 100%;
+    width: 44px;
+    flex-shrink: 0
+}
+
+.left-sidebar-toggle span {
+    width: 18px;
+    height: 2px;
+    background-color: var(--black-400)
+}
+
+.left-sidebar-toggle span:before, .left-sidebar-toggle span:after {
+    position: absolute;
+    content: '';
+    width: 18px;
+    height: 2px;
+    left: 0;
+    background: var(--black-400);
+    top: -5px;
+    transition: all ease-in-out .1s
+}
+
+.left-sidebar-toggle span:after {
+    top: 5px
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .left-sidebar-toggle {
+        display: flex
+    }
+}
+
+@media print {
+    .left-sidebar-toggle {
+        display: flex
+    }
+}
+
+html.html__unpinned-leftnav .left-sidebar-toggle {
+    display: flex
+}
+
+.left-sidebar-toggle.topbar-icon-on span {
+    background-color: transparent
+}
+
+.left-sidebar-toggle.topbar-icon-on span:before, .left-sidebar-toggle.topbar-icon-on span:after {
+    top: 0;
+    transform: rotate(-45deg)
+}
+
+.left-sidebar-toggle.topbar-icon-on span:after {
+    transform: rotate(45deg)
+}
+
+.flush-left {
+    margin-left: -24px;
+    border-top: 1px solid var(--black-100)
+}
+
+body.theme-highcontrast .flush-left {
+    border-top-color: currentColor
+}
+
+.flush-left .question-summary {
+    width: 100%;
+    padding-left: 8px;
+    box-sizing: border-box
+}
+
+.flush-left .flush-left, .flush-left .mixed-question-list {
+    border-top: none
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .flush-left {
+        margin-left: -16px;
+        margin-right: -16px;
+        width: calc(100% + 2*16px)
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .flush-left {
+        margin-left: -16px;
+        margin-right: -16px;
+        width: calc(100% + 2*16px)
+    }
+}
+
+@media print {
+    .flush-left {
+        margin-left: -16px;
+        margin-right: -16px;
+        width: calc(100% + 2*16px)
+    }
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .flush-left {
+        margin-left: -12px;
+        margin-right: -12px;
+        width: calc(100% + 2*12px)
+    }
+}
+
+@media print {
+    .flush-left {
+        margin-left: -12px;
+        margin-right: -12px;
+        width: calc(100% + 2*12px)
+    }
+}
+
+.question-summary {
+    display: flex;
+    padding: 12px 8px;
+    float: none;
+    width: 100%
+}
+
+.question-summary .stats, .question-summary .stats+.views {
+    margin-left: 0
+}
+
+.question-summary h3, .question-summary .excerpt {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word
+}
+
+.statscontainer {
+    margin-right: 16px;
+    width: 58px;
+    float: none
+}
+
+.summary, .narrow .summary {
+    flex: 1 auto;
+    width: auto;
+    float: none;
+    margin: 0;
+    overflow: hidden
+}
+
+.cp, .narrow .cp {
+    float: none;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    margin-right: 0;
+    padding: 0 8px 0 0;
+    box-sizing: content-box;
+    flex-shrink: 0
+}
+
+.narrow .started {
+    white-space: normal
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) #tabs a, html.html__responsive:not(.html__unpinned-leftnav) .tabs a {
+        margin-right: 0;
+        padding-left: 8px;
+        padding-right: 8px
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav #tabs a, html.html__responsive.html__unpinned-leftnav .tabs a {
+        margin-right: 0;
+        padding-left: 8px;
+        padding-right: 8px
+    }
+}
+
+@media print {
+    #tabs a, .tabs a {
+        margin-right: 0;
+        padding-left: 8px;
+        padding-right: 8px
+    }
+}
+
+._with-left-nav~.container .col-sidebar {
+    margin-right: 32px
+}
+
+.user-page ._with-left-nav~.container .settings-page {
+    margin: 0 0 0 32px !important
+}
+
+#add-login-page, #login-page, #signup-page {
+    box-sizing: content-box
+}
+
+.fc-theme-body-font {
+    color: var(--theme-body-font-color) !important
+}
+
+.timeline-wrapper .timeline {
+    width: 798px
+}
+
+.timeline-wrapper .timeline-sidebar {
+    margin-left: 24px
+}
+
+.user-page .row {
+    max-width: 1100px
+}
+
+#profile-side {
+    margin-right: 24px
+}
+
+*[data-can-be] {
+    display: none
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive *[data-is-here-when]:not([data-is-here-when~="sm"]) {
+        display: none
+    }
+}
+
+@media print {
+    *[data-is-here-when]:not([data-is-here-when~="sm"]) {
+        display: none
+    }
+}
+
+@media screen and (max-width:980px) and (min-width:640.1px) {
+    html.html__responsive:not(.html__unpinned-leftnav) *[data-is-here-when]:not([data-is-here-when~="md"]) {
+        display: none
+    }
+}
+
+@media screen and (max-width:816px) and (min-width:640.1px) {
+    html.html__responsive.html__unpinned-leftnav *[data-is-here-when]:not([data-is-here-when~="md"]) {
+        display: none
+    }
+}
+
+@media screen and (min-width:980.1px) {
+    html.html__responsive:not(.html__unpinned-leftnav) *[data-is-here-when]:not([data-is-here-when~="lg"]) {
+        display: none
+    }
+}
+
+@media screen and (min-width:816.1px) {
+    html.html__responsive.html__unpinned-leftnav *[data-is-here-when]:not([data-is-here-when~="lg"]) {
+        display: none
+    }
+}
+
+@media screen and (max-width:640px) {
+    html.html__responsive .statscontainer {
+        margin-left: 0;
+        margin-right: 12px
+    }
+
+    html.html__responsive .question-summary {
+        padding-left: 12px !important;
+        padding-right: 12px !important
+    }
+
+    html.html__responsive .question-summary.narrow {
+        flex-direction: column
+    }
+
+    html.html__responsive .narrow .cp {
+        width: 100%;
+        float: none;
+        padding-bottom: 8px !important;
+        padding-left: 0 !important;
+        padding-right: 0 !important
+    }
+
+    html.html__responsive .narrow .votes, html.html__responsive .narrow .status, html.html__responsive .narrow .views {
+        padding: 4px 0;
+        line-height: 1;
+        box-sizing: border-box;
+        width: auto;
+        height: auto;
+        border-radius: 3px;
+        min-width: auto;
+        text-align: left;
+        margin: 0 4px 0 0
+    }
+
+    html.html__responsive .narrow .votes>div, html.html__responsive .narrow .status>div, html.html__responsive .narrow .views>div {
+        display: inline-block;
+        font-size: 12px;
+        margin-bottom: 0
+    }
+
+    html.html__responsive .narrow .votes>div.mini-counts, html.html__responsive .narrow .status>div.mini-counts, html.html__responsive .narrow .views>div.mini-counts {
+        font-weight: bold
+    }
+
+    html.html__responsive .narrow .status {
+        margin-top: -1px;
+        padding: 4px 8px
+    }
+
+    html.html__responsive .narrow .summary {
+        width: 100%;
+        float: none
+    }
+}
+
+@media print {
+    .statscontainer {
+        margin-left: 0;
+        margin-right: 12px
+    }
+
+    .question-summary {
+        padding-left: 12px !important;
+        padding-right: 12px !important
+    }
+
+    .question-summary.narrow {
+        flex-direction: column
+    }
+
+    .narrow .cp {
+        width: 100%;
+        float: none;
+        padding-bottom: 8px !important;
+        padding-left: 0 !important;
+        padding-right: 0 !important
+    }
+
+    .narrow .votes, .narrow .status, .narrow .views {
+        padding: 4px 0;
+        line-height: 1;
+        box-sizing: border-box;
+        width: auto;
+        height: auto;
+        border-radius: 3px;
+        min-width: auto;
+        text-align: left;
+        margin: 0 4px 0 0
+    }
+
+    .narrow .votes>div, .narrow .status>div, .narrow .views>div {
+        display: inline-block;
+        font-size: 12px;
+        margin-bottom: 0
+    }
+
+    .narrow .votes>div.mini-counts, .narrow .status>div.mini-counts, .narrow .views>div.mini-counts {
+        font-weight: bold
+    }
+
+    .narrow .status {
+        margin-top: -1px;
+        padding: 4px 8px
+    }
+
+    .narrow .summary {
+        width: 100%;
+        float: none
+    }
+}
+
+html.html__responsive .everyoneloves__top-leaderboard, html.html__responsive .everyoneloves__mid-leaderboard, html.html__responsive .everyoneloves__mid-second-leaderboard, html.html__responsive .everyoneloves__bot-mid-leaderboard, html.html__responsive .everyoneloves__tag-sponsorship {
+    margin-left: 0
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__inline-sidebar {
+        display: block;
+        width: 300px
+    }
+
+    html.html__responsive:not(.html__unpinned-leftnav) .zone-container-responsive {
+        display: block
+    }
+
+    html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__top-sidebar {
+        display: none
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .everyoneloves__inline-sidebar {
+        display: block;
+        width: 300px
+    }
+
+    html.html__responsive.html__unpinned-leftnav .zone-container-responsive {
+        display: block
+    }
+
+    html.html__responsive.html__unpinned-leftnav .everyoneloves__top-sidebar {
+        display: none
+    }
+}
+
+@media print {
+    .everyoneloves__inline-sidebar {
+        display: block;
+        width: 300px
+    }
+
+    .zone-container-responsive {
+        display: block
+    }
+
+    .everyoneloves__top-sidebar {
+        display: none
+    }
+}
+
+@media screen and (max-width:1280px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .zone-container-main, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__top-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__mid-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__mid-second-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__bot-mid-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__tag-sponsorship {
+        display: none
+    }
+}
+
+@media screen and (max-width:1116px) {
+    html.html__responsive.html__unpinned-leftnav .zone-container-main, html.html__responsive.html__unpinned-leftnav .everyoneloves__top-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__mid-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__mid-second-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__bot-mid-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__tag-sponsorship {
+        display: none
+    }
+}
+
+@media print {
+    .zone-container-main, .everyoneloves__top-leaderboard, .everyoneloves__mid-leaderboard, .everyoneloves__mid-second-leaderboard, .everyoneloves__bot-mid-leaderboard, .everyoneloves__tag-sponsorship {
+        display: none
+    }
+}
+
+@media screen and (max-width:980px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .zone-container-main, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__top-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__mid-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__sec-mid-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__bot-mid-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__tag-sponsorship {
+        display: block
+    }
+}
+
+@media screen and (max-width:816px) {
+    html.html__responsive.html__unpinned-leftnav .zone-container-main, html.html__responsive.html__unpinned-leftnav .everyoneloves__top-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__mid-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__sec-mid-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__bot-mid-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__tag-sponsorship {
+        display: block
+    }
+}
+
+@media print {
+    .zone-container-main, .everyoneloves__top-leaderboard, .everyoneloves__mid-leaderboard, .everyoneloves__sec-mid-leaderboard, .everyoneloves__bot-mid-leaderboard, .everyoneloves__tag-sponsorship {
+        display: block
+    }
+}
+
+@media screen and (max-width:940px) {
+    html.html__responsive:not(.html__unpinned-leftnav) .zone-container-main, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__top-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__mid-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__sec-mid-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__bot-mid-leaderboard, html.html__responsive:not(.html__unpinned-leftnav) .everyoneloves__tag-sponsorship {
+        display: none
+    }
+}
+
+@media screen and (max-width:776px) {
+    html.html__responsive.html__unpinned-leftnav .zone-container-main, html.html__responsive.html__unpinned-leftnav .everyoneloves__top-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__mid-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__sec-mid-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__bot-mid-leaderboard, html.html__responsive.html__unpinned-leftnav .everyoneloves__tag-sponsorship {
+        display: none
+    }
+}
+
+@media print {
+    .zone-container-main, .everyoneloves__top-leaderboard, .everyoneloves__mid-leaderboard, .everyoneloves__sec-mid-leaderboard, .everyoneloves__bot-mid-leaderboard, .everyoneloves__tag-sponsorship {
+        display: none
+    }
+}
+
+@media screen and (min-width:1050px) {
+    .wide\:bg-image-ask-v2 {
+        background-image: url('https://cdn.sstatic.net/Img/ask/background.svg?v=2e9a8205b368')
+    }
+
+    .wide\:h-ask-v2-background {
+        height: 130px
+    }
+}
+
+.subcommunity-selected-tab {
+    border-top-width: 1px !important;
+    border-top-color: transparent !important;
+    border-left-width: 1px !important;
+    border-left-color: transparent !important;
+    border-right-width: 1px !important;
+    border-right-color: transparent !important
+}
+
+.subcommunity-selected-tab:before {
+    content: " ";
+    width: 0;
+    height: 0;
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 8px solid var(--orange-400);
+    left: 50%;
+    margin-left: -4px;
+    position: absolute;
+    top: 100%
+}
+
+.themed.subcommunity-intel {
+    --theme-base-primary-color-h: 206.86567164;
+    --theme-base-primary-color-s: 100%;
+    --theme-base-primary-color-l: 26.2745098%;
+    --theme-base-primary-color-r: 0;
+    --theme-base-primary-color-g: 74;
+    --theme-base-primary-color-b: 134;
+    --theme-dark-primary-color-h: 192.80632411;
+    --theme-dark-primary-color-s: 100%;
+    --theme-dark-primary-color-l: 49.60784314%;
+    --theme-dark-primary-color-r: 0;
+    --theme-dark-primary-color-g: 199;
+    --theme-dark-primary-color-b: 253
+}
+
+.themed.subcommunity-audiobubble {
+    --theme-base-primary-color-h: 196.02094241;
+    --theme-base-primary-color-s: 80.5907173%;
+    --theme-base-primary-color-l: 53.52941176%;
+    --theme-base-primary-color-r: 41;
+    --theme-base-primary-color-g: 181;
+    --theme-base-primary-color-b: 232;
+    --theme-dark-primary-color-h: 16.02094241;
+    --theme-dark-primary-color-s: 80.5907173%;
+    --theme-dark-primary-color-l: 46.47058824%;
+    --theme-dark-primary-color-r: 214;
+    --theme-dark-primary-color-g: 74;
+    --theme-dark-primary-color-b: 23
+}
+
+.themed.subcommunity-google-cloud {
+    --theme-base-primary-color-h: 220.85889571;
+    --theme-base-primary-color-s: 66.53061224%;
+    --theme-base-primary-color-l: 51.96078431%;
+    --theme-base-primary-color-r: 51;
+    --theme-base-primary-color-g: 103;
+    --theme-base-primary-color-b: 214;
+    --theme-dark-primary-color-h: 0;
+    --theme-dark-primary-color-s: 0%;
+    --theme-dark-primary-color-l: 100%;
+    --theme-dark-primary-color-r: 255;
+    --theme-dark-primary-color-g: 255;
+    --theme-dark-primary-color-b: 255
+}
+
+.themed.subcommunity-go {
+    --theme-base-primary-color-h: 210;
+    --theme-base-primary-color-s: 28.84615385%;
+    --theme-base-primary-color-l: 20.39215686%;
+    --theme-base-primary-color-r: 37;
+    --theme-base-primary-color-g: 52;
+    --theme-base-primary-color-b: 67;
+    --theme-dark-primary-color-h: 191.27819549;
+    --theme-dark-primary-color-s: 69.63350785%;
+    --theme-dark-primary-color-l: 62.54901961%;
+    --theme-dark-primary-color-r: 93;
+    --theme-dark-primary-color-g: 201;
+    --theme-dark-primary-color-b: 226
+}
+
+.themed.subcommunity-gitlab {
+    --theme-base-primary-color-h: 264.80769231;
+    --theme-base-primary-color-s: 80%;
+    --theme-base-primary-color-l: 25.49019608%;
+    --theme-base-primary-color-r: 56;
+    --theme-base-primary-color-g: 13;
+    --theme-base-primary-color-b: 117;
+    --theme-dark-primary-color-h: 35.06849315;
+    --theme-dark-primary-color-s: 97.33333333%;
+    --theme-dark-primary-color-l: 55.88235294%;
+    --theme-dark-primary-color-r: 252;
+    --theme-dark-primary-color-g: 161;
+    --theme-dark-primary-color-b: 33
+}
+
+.themed.subcommunity-twilio {
+    --theme-base-primary-color-h: 352.92307692;
+    --theme-base-primary-color-s: 88.23529412%;
+    --theme-base-primary-color-l: 56.66666667%;
+    --theme-base-primary-color-r: 242;
+    --theme-base-primary-color-g: 47;
+    --theme-base-primary-color-b: 70;
+    --theme-dark-primary-color-h: 209.41176471;
+    --theme-dark-primary-color-s: 100%;
+    --theme-dark-primary-color-l: 80%;
+    --theme-dark-primary-color-r: 153;
+    --theme-dark-primary-color-g: 205;
+    --theme-dark-primary-color-b: 255
+}
+
+.subcommunity-avatar.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/generic.svg?v=d212b4bfb0de')
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .subcommunity-avatar.s-avatar {
+        background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/generic-dark.svg?v=afc23eaab8a5')
+    }
+}
+
+body.theme-dark .subcommunity-avatar.s-avatar, .theme-dark__forced .subcommunity-avatar.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/generic-dark.svg?v=afc23eaab8a5')
+}
+
+.subcommunity-background {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/default-header.png?v=2578f8c2036f')
+}
+
+.subcommunity-intel.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/intel.svg?v=0371bf2f3b96')
+}
+
+.subcommunity-intel.subcommunity-background {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/intel-header.jpg?v=5df15f21a51e')
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (min-device-pixel-ratio:1.5) {
+    .subcommunity-intel.subcommunity-background {
+        background: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/intel-header.jpg?v=5df15f21a51e') no-repeat top left;
+        background-size: 1056px 256px
+    }
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .subcommunity-intel.s-avatar {
+        background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/intel-dark.svg?v=72ff93f7d507')
+    }
+}
+
+body.theme-dark .subcommunity-intel.s-avatar, .theme-dark__forced .subcommunity-intel.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/intel-dark.svg?v=72ff93f7d507')
+}
+
+.subcommunity-audiobubble.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/audiobubble.svg?v=ae2f1f659f62')
+}
+
+.subcommunity-audiobubble.subcommunity-background {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/default-header.png?v=2578f8c2036f')
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (min-device-pixel-ratio:1.5) {
+    .subcommunity-audiobubble.subcommunity-background {
+        background: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/default-header@2x.png?v=c3407e66edc0') no-repeat top left;
+        background-size: 1056px 256px
+    }
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .subcommunity-audiobubble.s-avatar {
+        background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/audiobubble-dark.svg?v=879efc1e2c3b')
+    }
+}
+
+body.theme-dark .subcommunity-audiobubble.s-avatar, .theme-dark__forced .subcommunity-audiobubble.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/audiobubble-dark.svg?v=879efc1e2c3b')
+}
+
+.subcommunity-google-cloud.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/google-cloud.svg?v=5d10e4a96c5b')
+}
+
+.subcommunity-google-cloud.subcommunity-background {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/default-header.png?v=2578f8c2036f')
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (min-device-pixel-ratio:1.5) {
+    .subcommunity-google-cloud.subcommunity-background {
+        background: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/default-header@2x.png?v=c3407e66edc0') no-repeat top left;
+        background-size: 1056px 256px
+    }
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .subcommunity-google-cloud.s-avatar {
+        background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/google-cloud-dark.svg?v=5d10e4a96c5b')
+    }
+}
+
+body.theme-dark .subcommunity-google-cloud.s-avatar, .theme-dark__forced .subcommunity-google-cloud.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/google-cloud-dark.svg?v=5d10e4a96c5b')
+}
+
+.subcommunity-go.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/go.svg?v=4a0ccd527283')
+}
+
+.subcommunity-go.subcommunity-background {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/go-header.jpg?v=d1c1d1b3d6c3')
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (min-device-pixel-ratio:1.5) {
+    .subcommunity-go.subcommunity-background {
+        background: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/go-header.jpg?v=d1c1d1b3d6c3') no-repeat top left;
+        background-size: 1056px 256px
+    }
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .subcommunity-go.s-avatar {
+        background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/go-dark.svg?v=ee6a739f1c3a')
+    }
+}
+
+body.theme-dark .subcommunity-go.s-avatar, .theme-dark__forced .subcommunity-go.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/go-dark.svg?v=ee6a739f1c3a')
+}
+
+.subcommunity-gitlab.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/gitlab.svg?v=eec07a1769d1')
+}
+
+.subcommunity-gitlab.subcommunity-background {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/gitlab-header.png?v=a89ab0043f4e')
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (min-device-pixel-ratio:1.5) {
+    .subcommunity-gitlab.subcommunity-background {
+        background: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/gitlab-header.png?v=a89ab0043f4e') no-repeat top left;
+        background-size: 1056px 256px
+    }
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .subcommunity-gitlab.s-avatar {
+        background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/gitlab-dark.svg?v=eec07a1769d1')
+    }
+}
+
+body.theme-dark .subcommunity-gitlab.s-avatar, .theme-dark__forced .subcommunity-gitlab.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/gitlab-dark.svg?v=eec07a1769d1')
+}
+
+.subcommunity-twilio.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/twilio.svg?v=ab07490da974')
+}
+
+.subcommunity-twilio.subcommunity-background {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/twilio-header.png?v=07a8e45752d6')
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio:1.5), only screen and (min--moz-device-pixel-ratio:1.5), only screen and (min-device-pixel-ratio:1.5) {
+    .subcommunity-twilio.subcommunity-background {
+        background: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/twilio-header.png?v=07a8e45752d6') no-repeat top left;
+        background-size: 1056px 256px
+    }
+}
+
+@media (prefers-color-scheme:dark) {
+    body.theme-system .subcommunity-twilio.s-avatar {
+        background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/twilio-dark.svg?v=ecd751ea2049')
+    }
+}
+
+body.theme-dark .subcommunity-twilio.s-avatar, .theme-dark__forced .subcommunity-twilio.s-avatar {
+    background-image: url('https://cdn.sstatic.net/Sites/stackoverflow/Img/subcommunities/twilio-dark.svg?v=ecd751ea2049')
+}

--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@
   const linkEl = document.createElement('link')
   linkEl.rel = 'stylesheet'
   linkEl.type = 'text/css'
-  linkEl.href = 'https://cdn.jsdelivr.net/gh/donaldxdonald/filters_for_stackoverflow@master/primary.css'
+  linkEl.href = 'https://cdn.jsdelivr.net/gh/donaldxdonald/filters_for_stackoverflow@master/primary.min.css'
 
   // sticky element
   const stickyEl = document.createElement('div')


### PR DESCRIPTION
The CSS that you have uses relative paths such as `../../Img/april-fools-2022/assets/coin.png?v=ca0d5083f7c7`, so this PR fixes that so each URL uses the correct path from `https://cdn.sstatic.net/`. I also formatted the CSS, so it is easier to read and in the script I changed `primary.css` to `primary.min.css` so jsDelivr would minify it. If for some reason Stack Overflow removes the assets on the CDN, I have archived all the April Fools assets in my fork.